### PR TITLE
fix compiler warning - using format string in log

### DIFF
--- a/coreengine/console.cpp
+++ b/coreengine/console.cpp
@@ -181,32 +181,32 @@ void Console::print(QString message, eLogLevels MsgLogLevel)
         {
             case eDEBUG:
             {
-                qDebug(msg.toStdString().c_str());
+                qDebug("%s", msg.toStdString().c_str());
                 prefix = "DEBUG: ";
                 break;
             }
             case eINFO:
             {
-                qInfo(msg.toStdString().c_str());
+                qInfo("%s", msg.toStdString().c_str());
                 prefix = "INFO: ";
                 break;
             }
             case eWARNING:
             {
-                qWarning(msg.toStdString().c_str());
+                qWarning("%s", msg.toStdString().c_str());
                 prefix = "WARNING: ";
                 break;
             }
             case eERROR:
             {
-                qCritical(msg.toStdString().c_str());
+                qCritical("%s", msg.toStdString().c_str());
                 prefix = "CRITICAL: ";
                 break;
             }
             case eFATAL:
             {
                 prefix = "FATAL: ";
-                qFatal(msg.toStdString().c_str());
+                qFatal("%s", msg.toStdString().c_str());
                 break;
             }
             default:


### PR DESCRIPTION
Fixes some compiler warnings i noticed when compiling with gcc9. 

Still working on getting it compiled properly so all sources are copied into the right place, haven't made much progress yet but we'll see what happens. 