### PR TITLE
adjust linux install; add desktop file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -880,16 +880,21 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
     install(FILES ${${PROJECT_NAME}_INSTALL_QT_PLATFORMS_LIBS} DESTINATION          "${INSTALL_PATH}/platforms" OPTIONAL)
 
 elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        OUTPUT_NAME "${PROJECT_NAME_LOWER}"
+    )
     install(TARGETS ${PROJECT_NAME}
-        RUNTIME         DESTINATION         "${INSTALL_PATH}/bin"
-        BUNDLE          DESTINATION         "${INSTALL_PATH}/bin"
-        LIBRARY         DESTINATION         "${INSTALL_PATH}/bin")
+        RUNTIME         DESTINATION         "$bin"
+        BUNDLE          DESTINATION         "$bin"
+        LIBRARY         DESTINATION         "$bin")
     # install libs
-    install(FILES ${${PROJECT_NAME}_INSTALL_QT_LIBS}            DESTINATION "${INSTALL_PATH}/lib/${PROJECT_NAME}"                OPTIONAL)
-    install(FILES ${${PROJECT_NAME}_INSTALL_OS_LIBS}            DESTINATION "${INSTALL_PATH}/lib/${PROJECT_NAME}"                OPTIONAL)
-    install(FILES ${${PROJECT_NAME}_INSTALL_QT_PLATFORMS_LIBS}  DESTINATION "${INSTALL_PATH}/lib/${PROJECT_NAME}/platforms"      OPTIONAL)
-    install(DIRECTORY templates                                 DESTINATION "${INSTALL_PATH}/share/${PROJECT_NAME}/"             OPTIONAL)
-    install(FILES "icon.png"                                     DESTINATION "${INSTALL_PATH}/share/pixmaps/${PROJECT_NAME}.png"  OPTIONAL)
+    install(FILES ${${PROJECT_NAME}_INSTALL_QT_LIBS}            DESTINATION "lib/${PROJECT_NAME_LOWER}"                              OPTIONAL)
+    install(FILES ${${PROJECT_NAME}_INSTALL_OS_LIBS}            DESTINATION "lib/${PROJECT_NAME_LOWER}"                              OPTIONAL)
+    install(FILES ${${PROJECT_NAME}_INSTALL_QT_PLATFORMS_LIBS}  DESTINATION "lib/${PROJECT_NAME_LOWER}"                              OPTIONAL)
+    install(DIRECTORY templates                                 DESTINATION "share/${PROJECT_NAME_LOWER}"                            OPTIONAL)
+    install(FILES "icon.png"                                    DESTINATION "share/pixmaps"       RENAME "${PROJECT_NAME_LOWER}.png" OPTIONAL)
+    install(FILES "Commander_Wars.desktop"                      DESTINATION "share/applications"  RENAME "${PROJECT_NAME}.desktop"   OPTIONAL)
 else()
     install(TARGETS ${PROJECT_NAME}
         RUNTIME         DESTINATION         "${INSTALL_PATH}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,9 +885,9 @@ elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
         OUTPUT_NAME "${PROJECT_NAME_LOWER}"
     )
     install(TARGETS ${PROJECT_NAME}
-        RUNTIME         DESTINATION         "$bin"
-        BUNDLE          DESTINATION         "$bin"
-        LIBRARY         DESTINATION         "$bin")
+        RUNTIME         DESTINATION         "bin"
+        BUNDLE          DESTINATION         "bin"
+        LIBRARY         DESTINATION         "bin")
     # install libs
     install(FILES ${${PROJECT_NAME}_INSTALL_QT_LIBS}            DESTINATION "lib/${PROJECT_NAME_LOWER}"                              OPTIONAL)
     install(FILES ${${PROJECT_NAME}_INSTALL_OS_LIBS}            DESTINATION "lib/${PROJECT_NAME_LOWER}"                              OPTIONAL)

--- a/Commander_Wars.desktop
+++ b/Commander_Wars.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Commander Wars
+Exec=commander_wars
+Comment="Advance Wars Clone with a lot of additions customizations and modding support"
+Terminal=false
+Icon=commander_wars.png
+Type=Application
+Categories=Game;


### PR DESCRIPTION
before: (`usr` as `DCMAKE_INSTALL_PREFIX`)
```
usr
└── Commander_Wars_Release
    ├── bin
    │   └── Commander_Wars
    ├── lib
    │   └── Commander_Wars
    │       ├── addr2line
    │       └── platforms
    │           ├── libqeglfs.so
    │           ├── libqlinuxfb.so
    │           ├── libqminimalegl.so
    │           ├── libqminimal.so
    │           ├── libqoffscreen.so
    │           ├── libqvnc.so
    │           ├── libqwayland-egl.so
    │           ├── libqwayland-generic.so
    │           └── libqxcb.so
    └── share
        ├── Commander_Wars
        │   └── templates
        │       ├── gamescript.js
        │       └── init.js
        └── pixmaps
            └── Commander_Wars.png
                └── icon.png
```
after:  (`usr` as `DCMAKE_INSTALL_PREFIX`)
```
usr
├── bin
│   └── commander_wars
├── lib
│   └── commander_wars
│       ├── addr2line
│       ├── libqeglfs.so
│       ├── libqlinuxfb.so
│       ├── libqminimalegl.so
│       ├── libqminimal.so
│       ├── libqoffscreen.so
│       ├── libqvnc.so
│       ├── libqwayland-egl.so
│       ├── libqwayland-generic.so
│       └── libqxcb.so
└── share
    ├── applications
    │   └── Commander_Wars.desktop
    ├── commander_wars
    │   └── templates
    │       ├── gamescript.js
    │       └── init.js
    └── pixmaps
        └── commander_wars.png
```

* fix icon path
* add desktop file for starmenu entry and other desktop integration.
* move sub-sub-folder up at `lib` (never seen this before, no idea if the linker does check this folder)
* use lowercase for binary. Linux filesystem is case sensitive. (I think Mac and Unix also). Binaries should be lowercase by convention.
* remove `Commander_Wars_Release` prefix. Can still be used, by using cmake options: `-DCMAKE_INSTALL_PREFIX=Commander_Wars_Release`

I think `addr2line` should be removed, because it is not used on Linux, but I have no idea how I can do that.