### PR TITLE
fix missing `/` if USEAPPCONFIGPATH is used

### DIFF
--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -186,7 +186,7 @@ Settings::Settings()
         defaultCoCount = 1;
     }
 #ifdef USEAPPCONFIGPATH
-    defaultPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    defaultPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/";
 #endif
 
     auto devices = QInputDevice::devices();


### PR DESCRIPTION
the current path for savegames is `~/.local/share/Commander Warssavegames` instead `~/.local/share/Commander Wars/savegames`.
same issue for the other path.