### PR TITLE
Typo, Grammar, Clarification Edits

### DIFF
--- a/ingamescriptsupport/campaigneditor.cpp
+++ b/ingamescriptsupport/campaigneditor.cpp
@@ -312,7 +312,7 @@ void CampaignEditor::updateCampaignData()
 
         spCheckbox pBox = spCheckbox::create();
         pBox->setChecked(mapDatas[i].lastMap);
-        pBox->setTooltipText(tr("All maps marked as last map need to be won in order to finish the campaign"));
+        pBox->setTooltipText(tr("All maps marked as last map need to be won in order to finish the campaign."));
         pBox->setPosition(940, 10 + i * 40);
         m_Panel->addItem(pBox);
         connect(pBox.get(), &Checkbox::checkChanged, [this, i](bool value)
@@ -761,7 +761,7 @@ void CampaignEditor::showEditDisableMaps(qint32 index)
     pText->setPosition(10, 10);
     pPanel->addItem(pText);
     spSpinBox spinBox = spSpinBox::create(150, 1, mapDatas.size() - 1);
-    spinBox->setTooltipText(tr("Number of maps that disable this map again. They need to be won in order to make this map unplayable again. E.g. you won the selected map and you want to stop make it repeatedly playable."));
+    spinBox->setTooltipText(tr("Number of maps that disable this map again. When they are one this map is made unplayable. Can be used to make a map no longer playable after a Victory."));
     spinBox->setPosition(300, 10);
     spinBox->setCurrentValue(mapDatas[index].disableCount);
     connect(spinBox.get(), &SpinBox::sigValueChanged,
@@ -974,7 +974,7 @@ void CampaignEditor::showEditScriptVariables(qint32 index)
     pText->setPosition(30, y);
     pPanel->addItem(pText);
     checkBox = spCheckbox::create();
-    checkBox->setTooltipText(tr("If checked and if the disable variable fullfil the condition this map can't be played."));
+    checkBox->setTooltipText(tr("If checked and if the disable variable has been fullfiled this map can't be played."));
     checkBox->setPosition(width, y);
     checkBox->setChecked(mapDatas[index].scriptVariableDisableActive);
     connect(checkBox.get(), &Checkbox::checkChanged,

--- a/ingamescriptsupport/scripteditor.cpp
+++ b/ingamescriptsupport/scripteditor.cpp
@@ -60,7 +60,7 @@ ScriptEditor::ScriptEditor(GameMap* pMap)
                               tr(ScriptCondition::ConditionUnitReachedArea.toStdString().c_str()),
                               tr(ScriptCondition::ConditionCheckVariable.toStdString().c_str())};
     m_Conditions = spDropDownmenu::create(300, items);
-    m_Conditions->setTooltipText(tr("Condition type you wan't to create. If a condition is selected this condition and the selected one need to be fullfilled to activate the event."));
+    m_Conditions->setTooltipText(tr("Condition type you want to create. If another condition is selected both must be fulfilled to activate the event."));
     m_Conditions->setPosition(30, Settings::getHeight() / 2 - 45);
     pSpriteBox->addChild(m_Conditions);
     // condition button
@@ -132,7 +132,7 @@ ScriptEditor::ScriptEditor(GameMap* pMap)
     pText->setPosition(30, 30);
     pSpriteBox->addChild(pText);
     m_ImmediateStart = spCheckbox::create();
-    m_ImmediateStart->setTooltipText(tr("If checked the game starts without beeing able to change rules, players or co's."));
+    m_ImmediateStart->setTooltipText(tr("If checked the game starts without being able to change rules, players or CO's."));
     m_ImmediateStart->setPosition(280, 30);
     m_ImmediateStart->setChecked(false);
     pSpriteBox->addChild(m_ImmediateStart);

--- a/menue/achievementmenu.cpp
+++ b/menue/achievementmenu.cpp
@@ -69,7 +69,7 @@ Achievementmenu::Achievementmenu()
     pTextfield->setPosition(10, y);
     addChild(pTextfield);
     m_SearchString = spTextbox::create(Settings::getWidth() - 380);
-    m_SearchString->setTooltipText(tr("Text that will be searched for in the title of each wikipage."));
+    m_SearchString->setTooltipText(tr("Search for an Achievement by title or description."));
     m_SearchString->setPosition(150, y);
     connect(m_SearchString.get(), &Textbox::sigTextChanged, this, [this](QString)
     {

--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -859,7 +859,7 @@ void GameMenue::performAction(spGameAction pGameAction)
     if (m_multiplayerSyncData.m_waitingForSyncFinished)
     {
         m_multiplayerSyncData.m_postSyncAction = pGameAction;
-        spDialogConnecting pDialogConnecting = spDialogConnecting::create(tr("Waiting for Players/Observers to join"), 1000 * 60 * 5);
+        spDialogConnecting pDialogConnecting = spDialogConnecting::create(tr("Waiting for Players/Observers to join..."), 1000 * 60 * 5);
         addChild(pDialogConnecting);
         connect(pDialogConnecting.get(), &DialogConnecting::sigCancel, this, &GameMenue::exitGame, Qt::QueuedConnection);
         connect(this, &GameMenue::sigSyncFinished, pDialogConnecting.get(), &DialogConnecting::connected, Qt::QueuedConnection);

--- a/menue/mapselectionmapsmenue.cpp
+++ b/menue/mapselectionmapsmenue.cpp
@@ -512,7 +512,7 @@ void MapSelectionMapsMenue::saveRules(QString filename)
         spGameMap pMap = m_pMapSelectionView->getCurrentMap();
         pMap->getGameRules()->serializeObject(stream);
         file.close();
-        spDialogMessageBox pMessageBox = spDialogMessageBox::create(tr("Do you want to make the saved ruleset as default ruleset?"), true, tr("Yes"), tr("No"));
+        spDialogMessageBox pMessageBox = spDialogMessageBox::create(tr("Do you want to make the saved ruleset the default ruleset?"), true, tr("Yes"), tr("No"));
         addChild(pMessageBox);
         connect(pMessageBox.get(),  &DialogMessageBox::sigOk, this, [=]()
         {

--- a/menue/optionmenue.cpp
+++ b/menue/optionmenue.cpp
@@ -412,7 +412,7 @@ void OptionMenue::showSettings()
     spDropDownmenu pScreenResolution = spDropDownmenu::create(400, displaySizes);
     pScreenResolution->setPosition(sliderOffset - 130, y);
     pScreenResolution->setCurrentItem(currentDisplayMode);
-    pScreenResolution->setTooltipText(tr("Selects the screen resolution for the game"));
+    pScreenResolution->setTooltipText(tr("Selects the screen resolution for the game."));
     m_pOptions->addItem(pScreenResolution);
     auto* pPtrScreenResolution = pScreenResolution.get();
     connect(pScreenResolution.get(), &DropDownmenu::sigItemChanged, this, [this, pPtrScreenResolution](qint32)
@@ -434,7 +434,7 @@ void OptionMenue::showSettings()
     m_pOptions->addItem(pTextfield);
     QStringList items = {tr("Window"), tr("Bordered"), tr("Fullscreen")};
     spDropDownmenu pScreenModes = spDropDownmenu::create(400, items);
-    pScreenModes->setTooltipText(tr("Selects the screen mode for the game"));
+    pScreenModes->setTooltipText(tr("Selects the screen mode for the game."));
     pScreenModes->setPosition(sliderOffset - 130, y);
     pScreenModes->setCurrentItem(pApp->getScreenMode());
     pScreenModes->setEnabled(!Settings::getSmallScreenDevice());
@@ -448,7 +448,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSlider pSlider = spSlider::create(Settings::getWidth() - 20 - sliderOffset, -50, 50);
-    pSlider->setTooltipText(tr("Selects the brightness for the game"));
+    pSlider->setTooltipText(tr("Selects the brightness for the game."));
     pSlider->setPosition(sliderOffset - 130, y);
     pSlider->setCurrentValue(Settings::getBrightness());
     connect(pSlider.get(), &Slider::sliderValueChanged, this, [=](qint32 value)
@@ -465,7 +465,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pSlider = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 1, 160, "");
-    pSlider->setTooltipText(tr("Selects the gamma factor for the game"));
+    pSlider->setTooltipText(tr("Selects the gamma factor for the game."));
     pSlider->setPosition(sliderOffset - 130, y);
     pSlider->setCurrentValue(Settings::getGamma() * 30.0f);
     connect(pSlider.get(), &Slider::sliderValueChanged, this, [=](qint32 value)
@@ -482,7 +482,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spCheckbox pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If checked several ui elements are hidden and get shown with an additional button.\nWarning disabling this on a smaller screen may lead to unplayable game experience."));
+    pCheckbox->setTooltipText(tr("If checked several UI elements are hidden and accessible with an additional button.\nWarning: disabling this on a smaller screen may lead to unplayable game experience."));
     pCheckbox->setChecked(Settings::getSmallScreenDevice());
     pCheckbox->setPosition(sliderOffset - 130, y);
     connect(pCheckbox.get(), &Checkbox::checkChanged, Settings::getInstance(), &Settings::setSmallScreenDevice, Qt::QueuedConnection);
@@ -503,7 +503,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pSlider = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 30, 60, "");
-    pSlider->setTooltipText(tr("Selects the maximum FPS use it to reduce power consumption on smartphones."));
+    pSlider->setTooltipText(tr("Selects the maximum FPS, use it to reduce power consumption on smartphones."));
     pSlider->setPosition(sliderOffset - 130, y);
     pSlider->setCurrentValue(Settings::getFramesPerSecond());
     connect(pSlider.get(), &Slider::sliderValueChanged, Settings::getInstance(), &Settings::setFramesPerSecond, Qt::QueuedConnection);
@@ -529,7 +529,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSpinBox touchPointSensitivity = spSpinBox::create(200, 0, std::numeric_limits<quint16>::max());
-    touchPointSensitivity->setTooltipText(tr("Selects how long a touch is treated as the same point. Used for detecting long press events."));
+    touchPointSensitivity->setTooltipText(tr("Selects how long a touch is treated as the same point. Used for detecting long-press events."));
     touchPointSensitivity->setCurrentValue(Settings::getTouchPointSensitivity());
     touchPointSensitivity->setPosition(sliderOffset - 130, y);
     connect(touchPointSensitivity.get(), &SpinBox::sigValueChanged, Settings::getInstance(), &Settings::setTouchPointSensitivity);
@@ -544,7 +544,7 @@ void OptionMenue::showSettings()
         pTextfield->setPosition(10, y);
         m_pOptions->addItem(pTextfield);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("Enables Gamepad support for controllers. Note: This is experimental and won't 100% with all controllers and isn't supported for android, iOS, macOS and linux."));
+        pCheckbox->setTooltipText(tr("Enables Gamepad support for controllers. Note: This is an experimental feature and won't work 100% with all controllers. This feature isn't supported for Android, iOS, MacOS and Linux."));
         pCheckbox->setChecked(Settings::getGamepadEnabled());
         pCheckbox->setPosition(sliderOffset - 130, y);
         connect(pCheckbox.get(), &Checkbox::checkChanged, Settings::getInstance(), &Settings::setGamepadEnabled, Qt::QueuedConnection);
@@ -566,7 +566,7 @@ void OptionMenue::showSettings()
         pTextfield->setPosition(10, y);
         m_pOptions->addItem(pTextfield);
         spSpinBox gamepadSensitivity = spSpinBox::create(200, 0.1, 100);
-        gamepadSensitivity->setTooltipText(tr("Selects how often events are send by the gamepad. Smaller values create a faster cursor."));
+        gamepadSensitivity->setTooltipText(tr("Selects how often events are sent by a gamepad. Lowering this value will increase cursor speed."));
         gamepadSensitivity->setCurrentValue(Settings::getGamepadSensitivity());
         gamepadSensitivity->setPosition(sliderOffset - 130, y);
         connect(gamepadSensitivity.get(), &SpinBox::sigValueChanged, Settings::getInstance(), &Settings::setGamepadSensitivity);
@@ -628,7 +628,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spTimeSpinBox autoSavingCycleTime = spTimeSpinBox::create(200);
-    autoSavingCycleTime->setTooltipText(tr("Selects the auto saving cycle in hours:minutes:seconds"));
+    autoSavingCycleTime->setTooltipText(tr("Selects the time between auto saves in hours:minutes:seconds"));
     autoSavingCycleTime->setCurrentValue(std::chrono::duration_cast<std::chrono::milliseconds>(Settings::getAutoSavingCylceTime()).count());
     autoSavingCycleTime->setPosition(sliderOffset - 130, y);
     connect(autoSavingCycleTime.get(), &TimeSpinBox::sigValueChanged, [=](qint32 value)
@@ -644,7 +644,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSpinBox autoSavingCycle = spSpinBox::create(200, 0, std::numeric_limits<quint16>::max());
-    autoSavingCycle->setTooltipText(tr("Selects the amount of auto save games that get cycled through while auto saving. A value 0 disables this feature."));
+    autoSavingCycle->setTooltipText(tr("Selects the number of auto saves that are kept during games. A value of 0 disables this feature."));
     autoSavingCycle->setCurrentValue(Settings::getAutoSavingCycle());
     autoSavingCycle->setPosition(sliderOffset - 130, y);
     connect(autoSavingCycle.get(), &SpinBox::sigValueChanged, Settings::getInstance(), &Settings::setAutoSavingCycle);
@@ -658,7 +658,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If checked games will be recorded and you can rewatch them in the replay section."));
+    pCheckbox->setTooltipText(tr("If checked: games will be recorded and you can rewatch them in the replay section."));
     pCheckbox->setChecked(Settings::getRecord());
     pCheckbox->setPosition(sliderOffset - 130, y);
     connect(pCheckbox.get(), &Checkbox::checkChanged, Settings::getInstance(), &Settings::setRecord, Qt::QueuedConnection);
@@ -678,7 +678,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spTextbox pTextbox = spTextbox::create(Settings::getWidth() - 20 - sliderOffset);
-    pTextbox->setTooltipText(tr("Selects your username shown at various places of the game"));
+    pTextbox->setTooltipText(tr("Select your Username that is shown in-game and in multiplayer lobbies."));
     pTextbox->setCurrentText(Settings::getUsername());
     Textbox* pPtrTextbox = pTextbox.get();
     connect(pTextbox.get(), &Textbox::sigTextChanged, this, [this, pPtrTextbox](QString value)
@@ -707,7 +707,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pTextbox = spTextbox::create(Settings::getWidth() - 20 - sliderOffset);
-    pTextbox->setTooltipText(tr("Selects the dedicated game server you wan't to connect to when playing a multiplayer game."));
+    pTextbox->setTooltipText(tr("Provide the address to the multiplayer game server you want to connect to."));
     pTextbox->setCurrentText(Settings::getServerAdress());
     connect(pTextbox.get(), &Textbox::sigTextChanged, [=](QString value)
     {
@@ -723,7 +723,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSpinBox portBox = spSpinBox::create(200, 0, std::numeric_limits<quint16>::max());
-    portBox->setTooltipText(tr("Selects the dedicated servers chat port for used to chat in the lobby of the dedicated server"));
+    portBox->setTooltipText(tr("Selects the port dedicated server use for the lobby chat."));
     portBox->setCurrentValue(Settings::getServerPort());
     portBox->setPosition(sliderOffset - 130, y);
     connect(portBox.get(), &SpinBox::sigValueChanged, [=](float value)
@@ -757,7 +757,7 @@ void OptionMenue::showSettings()
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     portBox = spSpinBox::create(200, 0, std::numeric_limits<quint16>::max());
-    portBox->setTooltipText(tr("Selects the game port for used to play the game with the server either with a dedicated server or direct connection."));
+    portBox->setTooltipText(tr("Selects the game port used to play on a dedicated server or through a direct connection."));
     portBox->setCurrentValue(Settings::getGamePort());
     portBox->setPosition(sliderOffset - 130, y);
     connect(portBox.get(), &SpinBox::sigValueChanged, [=](float value)
@@ -793,7 +793,7 @@ void OptionMenue::showSoundOptions(spPanel pOwner, qint32 sliderOffset, qint32 &
     pTextfield->setPosition(10, y);
     pOwner->addItem(pTextfield);
     spCheckbox pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If checked mutes all sounds and music are muted."));
+    pCheckbox->setTooltipText(tr("If checked: mutes all sounds and music."));
     pCheckbox->setChecked(Settings::getMuted());
     pCheckbox->setPosition(sliderOffset - 130, y);
     connect(pCheckbox.get(), &Checkbox::checkChanged, Settings::getInstance(), [=](bool checked)
@@ -823,7 +823,7 @@ void OptionMenue::showSoundOptions(spPanel pOwner, qint32 sliderOffset, qint32 &
         }
     }
     spDropDownmenu pAudioDevice = spDropDownmenu::create(Settings::getWidth() - 20 - sliderOffset, items);
-    pAudioDevice->setTooltipText(tr("Selects the primary audio output device"));
+    pAudioDevice->setTooltipText(tr("Selects the primary audio output device."));
     pAudioDevice->setPosition(sliderOffset - 130, y);
     pAudioDevice->setCurrentItem(currentItem);
     pAudioDevice->setEnabled(!Settings::getSmallScreenDevice());
@@ -838,11 +838,11 @@ void OptionMenue::showSoundOptions(spPanel pOwner, qint32 sliderOffset, qint32 &
 
     pTextfield = spLabel::create(sliderOffset - 140);
     pTextfield->setStyle(style);
-    pTextfield->setHtmlText(tr("Global Volume: "));
+    pTextfield->setHtmlText(tr("Master Volume: "));
     pTextfield->setPosition(10, y);
     pOwner->addItem(pTextfield);
     spSlider pSlider = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 0, 100);
-    pSlider->setTooltipText(tr("Selects the global volume for the game"));
+    pSlider->setTooltipText(tr("Selects the master volume for the game."));
     pSlider->setPosition(sliderOffset - 130, y);
     pSlider->setCurrentValue(Settings::getTotalVolume());
     connect(pSlider.get(), &Slider::sliderValueChanged, pSignalOwner, [=](qint32 value)
@@ -859,7 +859,7 @@ void OptionMenue::showSoundOptions(spPanel pOwner, qint32 sliderOffset, qint32 &
     pTextfield->setPosition(10, y);
     pOwner->addItem(pTextfield);
     pSlider = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 0, 100);
-    pSlider->setTooltipText(tr("Selects the music volume for the game"));
+    pSlider->setTooltipText(tr("Selects the music volume for the game."));
     pSlider->setPosition(sliderOffset - 130, y);
     pSlider->setCurrentValue(Settings::getMusicVolume());
     connect(pSlider.get(), &Slider::sliderValueChanged, pSignalOwner, [=](qint32 value)
@@ -876,7 +876,7 @@ void OptionMenue::showSoundOptions(spPanel pOwner, qint32 sliderOffset, qint32 &
     pTextfield->setPosition(10, y);
     pOwner->addItem(pTextfield);
     pSlider = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 0, 100);
-    pSlider->setTooltipText(tr("Selects the sound volume for the game"));
+    pSlider->setTooltipText(tr("Selects the sound volume for the game."));
     pSlider->setPosition(sliderOffset - 130, y);
     pSlider->setCurrentValue(Settings::getSoundVolume());
     connect(pSlider.get(), &Slider::sliderValueChanged, [=](qint32 value)
@@ -923,12 +923,12 @@ void OptionMenue::showMods()
     pLabel->setHtmlText(tr("Advance Wars Game:"));
     m_ModSelector->addChild(pLabel);
     qint32 y = 0;
-    QStringList versions = {tr("Unkown"),
+    QStringList versions = {tr("Unknown"),
                                  tr("Commander Wars"),
                                  tr("Advance Wars DS"),
                                  tr("Advance Wars DC")};
     m_pModSelection = spDropDownmenu::create(300, versions);
-    m_pModSelection->setTooltipText(tr("Select an Advance Wars Game to preselect all mods which are required to play like this Advance Wars Game"));
+    m_pModSelection->setTooltipText(tr("Select an Advance Wars Game preset to enable mods to mimic a specific Advance Wars Game."));
     m_pModSelection->setX(260);
     connect(m_pModSelection.get(), &DropDownmenu::sigItemChanged, this, &OptionMenue::selectMods, Qt::QueuedConnection);
     m_ModSelector->addChild(m_pModSelection);
@@ -1021,7 +1021,7 @@ void OptionMenue::showMods()
     tags.sort();
     tags.push_front(tr("All"));
     spDropDownmenu pTagSelection = spDropDownmenu::create(300, tags);
-    pTagSelection->setTooltipText(tr("Filters the mods by the given tags"));
+    pTagSelection->setTooltipText(tr("Filters mods by given tags."));
     pTagSelection->setPosition(260, y);
     connect(pTagSelection.get(), &DropDownmenu::sigItemChanged, this, [this, tags](qint32 value)
     {
@@ -1110,7 +1110,7 @@ void OptionMenue::loadModInfo(oxygine::Box9Sprite* pPtrBox,
     QString cosmeticInfo;
     if (isComsetic)
     {
-        cosmeticInfo = QString("\n\n") + tr("The mod is claimed to be pure cosmetic by the creator and may be used during multiplayer games based on the game rules.");
+        cosmeticInfo = QString("\n\n") + tr("The mod author designated this mod as 'Cosmetic' and may be used during multiplayer matches based on the game rules.");
     }
     QString modInfo = "\n\n" + tr("Compatible Mods:\n");
     for (const auto & mod : compatibleMods)

--- a/menue/replaymenu.cpp
+++ b/menue/replaymenu.cpp
@@ -602,7 +602,7 @@ void ReplayMenu::showConfig()
     pTextfield->setPosition(10, y);
     pPanel->addItem(pTextfield);
     spCheckbox pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active walk, capture power animations and so on will be shown"));
+    pCheckbox->setTooltipText(tr("If active: walk, capture power animations, and so on will be shown."));
     pCheckbox->setChecked(Settings::getOverworldAnimations());
     connect(pCheckbox.get(), &Checkbox::checkChanged, Settings::getInstance(), &Settings::setOverworldAnimations, Qt::QueuedConnection);
     pCheckbox->setPosition(width - 130, y);
@@ -618,7 +618,7 @@ void ReplayMenu::showConfig()
     spDropDownmenu pAnimationMode = spDropDownmenu::create(450, items);
     pAnimationMode->setCurrentItem(static_cast<qint32>(Settings::getBattleAnimationMode()));
     pAnimationMode->setPosition(width - 130, y);
-    pAnimationMode->setTooltipText(tr("Select which ingame animations are played."));
+    pAnimationMode->setTooltipText(tr("Select which in-game animations are played."));
     pPanel->addItem(pAnimationMode);
     connect(pAnimationMode.get(), &DropDownmenu::sigItemChanged, [=](qint32 value)
     {
@@ -633,7 +633,7 @@ void ReplayMenu::showConfig()
     pPanel->addItem(pTextfield);
     items = {tr("Detailed"), tr("Overworld")};
     spDropDownmenu pBattleAnimationMode = spDropDownmenu::create(450, items);
-    pBattleAnimationMode->setTooltipText(tr("Selects which battle animations are played when fighting an enemy."));
+    pBattleAnimationMode->setTooltipText(tr("Selects which battle animations are played during combat."));
     pBattleAnimationMode->setCurrentItem(static_cast<qint32>(Settings::getBattleAnimationType()));
     pBattleAnimationMode->setPosition(width - 130, y);
     pPanel->addItem(pBattleAnimationMode);
@@ -717,7 +717,7 @@ void ReplayMenu::showConfig()
     pTextfield->setPosition(10, y);
     pPanel->addItem(pTextfield);
     spSlider pAnimationSpeed = spSlider::create(Settings::getWidth() - 20 - width, 1, 100, "");
-    pAnimationSpeed->setTooltipText(tr("Selects the speed at which animations are played. Except battle animations."));
+    pAnimationSpeed->setTooltipText(tr("Selects the speed at which animations are played. Note: This does not include capture or battle animations."));
     pAnimationSpeed->setPosition(width - 150, y);
     pAnimationSpeed->setCurrentValue(static_cast<qint32>(Settings::getAnimationSpeedValue()));
     pPanel->addItem(pAnimationSpeed);

--- a/menue/shopmenu.cpp
+++ b/menue/shopmenu.cpp
@@ -162,7 +162,7 @@ void Shopmenu::filterChanged(qint32 item)
         m_shoppingList.append(false);
         spCheckbox pCheckbox = spCheckbox::create();
         pCheckbox->setPosition(10, y);
-        pCheckbox->setTooltipText(tr("Check to but the item on the buy list. Afterwards click buy to confirm your shopping."));
+        pCheckbox->setTooltipText(tr("Check any items you'd like to buy from the shop, then click 'Buy' to confirm your purchase."));
         qint32 costs = item.price;
         qint32 itemPos = m_shoppingList.size() - 1;
         connect(pCheckbox.get(), &Checkbox::checkChanged, this, [this, itemPos, costs](bool checked)

--- a/menue/victorymenue.cpp
+++ b/menue/victorymenue.cpp
@@ -547,7 +547,7 @@ void VictoryMenue::createStatisticsView()
         items.append(tr("Player ") + QString::number(i + 1));
     }
     m_pStatisticPlayer = spDropDownmenu::create(250, items);
-    m_pStatisticPlayer->setTooltipText(tr("The player for which the statistics should be shown."));
+    m_pStatisticPlayer->setTooltipText(tr("Select which player's statistics you'd like to see."));
     m_pStatisticPlayer->setPosition(10, 10);
     m_statisticsBox->addChild(m_pStatisticPlayer);
     connect(m_pStatisticPlayer.get(), &DropDownmenu::sigItemChanged, this, [this](qint32 item)

--- a/mods/aw2_co/mod.txt
+++ b/mods/aw2_co/mod.txt
@@ -1,5 +1,5 @@
 name=Advance Wars 2 CO Mod
-description=This mod changes all CO's so that they don't have a CO-Zone or CO-Unit and bring them to their Advance Wars 2 power level if present. It also changes the Tagpower-System to that of Adavance Wars Dual Strike. It also makes only the first CO apply effects. Created  by Robosturm
+description=This mod changes all CO's so that they don't have a CO-Zone or CO-Unit and bring them to their Advance Wars 2 power level if present. It also changes the Tagpower-System to that of Adavance Wars Dual Strike. It also makes only the first CO apply effects. Created by Robosturm
 version=1.0.0
 compatible_mods=
 incompatible_mods=mods/awdc_co;mods/awds_co;mods/aw_co

--- a/mods/aw_co/mod.txt
+++ b/mods/aw_co/mod.txt
@@ -1,5 +1,5 @@
 name=Advance Wars 1 CO Mod
-description=This mod changes all CO's so that they don't have a CO-Zone or CO-Unit and bring them to their Advance Wars 1 power level if present. It also changes the Tagpower-System to that of Adavance Wars Dual Strike. It also makes only the first CO apply effects. Created  by Robosturm
+description=This mod changes all CO's so that they don't have a CO-Zone or CO-Unit and bring them to their Advance Wars 1 power level if present. It also changes the Tagpower-System to that of Adavance Wars Dual Strike. It also makes only the first CO apply effects. Created by Robosturm
 version=1.0.0
 compatible_mods=
 incompatible_mods=mods/awdc_co;mods/awds_co;mods/aw2_co

--- a/mods/awdc_co/mod.txt
+++ b/mods/awdc_co/mod.txt
@@ -1,5 +1,5 @@
-name=Advance Wars Darc Conflict CO Mod
-description=This mod changes all CO's so that they can't use a power or tagpower. All CO's get a 6 Star Power bar. CO's present in Advance Wars Darc Conflict work like in that game. All other CO's get their Power as Superpower. Created  by Robosturm
+name=Advance Wars Dark Conflict CO Mod
+description=This mod changes all CO's so that they can't use a power or tagpower. All CO's get a 6 Star Power bar. CO's present in Advance Wars Darc Conflict work like in that game. All other CO's get their Power as Superpower. Created by Robosturm
 version=1.0.0
 compatible_mods=
 incompatible_mods=mods/awds_co;mods/aw2_co;mods/aw_co

--- a/mods/awdc_image/mod.txt
+++ b/mods/awdc_image/mod.txt
@@ -1,5 +1,5 @@
-name=Advance Wars Darc Conflict Image Mod 
-description=This mod brings back the Advance Wars Darc Conflict Terrain Sprites to Commander Wars. Created by Robosturm
+name=Advance Wars Dark Conflict Image Mod 
+description=This mod brings back the Advance Wars Dark Conflict Terrain Sprites to Commander Wars. Created by Robosturm
 version=1.0.0
 CompatibleMods=
 IncompatibleMods=

--- a/mods/awdc_weather/mod.txt
+++ b/mods/awdc_weather/mod.txt
@@ -1,4 +1,4 @@
-name=Advance Wars Darc Conflict Weather Mod
+name=Advance Wars Dark Conflict Weather Mod
 description=This mod changes all Weather effects to Advance Wars DC.
 version=1.0.0
 compatible_mods=

--- a/mods/awds_co/mod.txt
+++ b/mods/awds_co/mod.txt
@@ -1,5 +1,5 @@
 name=Advance Wars Dual Strike CO Mod
-description=This mod changes all CO's so that they don't have a CO-Zone or CO-Unit. It also brings back the Advance Wars Dual Strike Tagpower-System. It also makes only the first CO apply effects. Created  by Robosturm
+description=This mod changes all CO's so that they don't have a CO-Zone or CO-Unit. It also brings back the Advance Wars Dual Strike Tagpower-System. It also makes only the first CO apply effects. Created by Robosturm
 version=1.0.1
 compatible_mods=
 incompatible_mods=mods/awdc_co;mods/aw2_co;mods/aw_co

--- a/mods/coop_mod/mod.txt
+++ b/mods/coop_mod/mod.txt
@@ -1,5 +1,5 @@
 name=Cooperation Mod
-description=This mod enables cooperation between players for transporting, repairing and supporting units. This means unit can be repaired, transported or supported by allied units and buildings.  Created by Chopper385 and XnKradst
+description=This mod enables cooperation between players for transporting, repairing and supporting units. This means unit can be repaired, transported or supported by allied units and buildings. Created by Chopper385 and XnKradst
 version=1.0.0
 compatible_mods=
 incompatible_mods=

--- a/mods/map_creator/mod.txt
+++ b/mods/map_creator/mod.txt
@@ -1,5 +1,5 @@
 name=Commander Wars Map Creator Mod
-description=This mod removes the limitations for placing terrain and units for vanilla units and terrains. This mod is only meant to be used for creating custom maps. This mod is not meant to be used to play a map with. The results are mostlikely horrible. 
+description=This mod removes the limitations for placing terrain and units for vanilla units and terrains. This mod is only meant to be used for creating custom maps. This mod is not meant to be used to play a map with. The results are most likely horrible. 
 version=1.0.0
 compatible_mods=
 incompatible_mods=

--- a/multiplayer/lobbymenu.cpp
+++ b/multiplayer/lobbymenu.cpp
@@ -106,7 +106,7 @@ LobbyMenu::LobbyMenu()
     });
     connect(this, &LobbyMenu::sigObserveGame, this, &LobbyMenu::observeGame, Qt::QueuedConnection);
 
-    oxygine::spButton pButtonJoinAdress = ObjectManager::createButton(tr("Join Adress"));
+    oxygine::spButton pButtonJoinAdress = ObjectManager::createButton(tr("Join Address"));
     addChild(pButtonJoinAdress);
     pButtonJoinAdress->setPosition(Settings::getWidth() / 2 - 10 - pButtonJoinAdress->getWidth(), Settings::getHeight() - pButtonExit->getHeight() - 10);
     pButtonJoinAdress->addEventListener(oxygine::TouchEvent::CLICK, [this](oxygine::Event * )->void
@@ -115,7 +115,7 @@ LobbyMenu::LobbyMenu()
     });
     connect(this, &LobbyMenu::sigJoinAdress, this, &LobbyMenu::joinAdress, Qt::QueuedConnection);
 
-    oxygine::spButton pButtonObserveAdress = ObjectManager::createButton(tr("Observe Adress"));
+    oxygine::spButton pButtonObserveAdress = ObjectManager::createButton(tr("Observe Address"));
     addChild(pButtonObserveAdress);
     pButtonObserveAdress->setPosition(Settings::getWidth() / 2 - 10 - pButtonJoinAdress->getWidth(), pButtonJoinAdress->getY() - pButtonJoinAdress->getHeight());
     pButtonObserveAdress->addEventListener(oxygine::TouchEvent::CLICK, [this](oxygine::Event * )->void

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -52,7 +52,7 @@ Multiplayermenu::Multiplayermenu(QString adress, quint16 port, QString password,
     }
     else
     {
-        m_pHostAdresse = ObjectManager::createButton("Show Adresses");
+        m_pHostAdresse = ObjectManager::createButton("Show Addresses");
         addChild(m_pHostAdresse);
         m_pHostAdresse->addEventListener(oxygine::TouchEvent::CLICK, [this](oxygine::Event * )->void
         {
@@ -141,8 +141,8 @@ void Multiplayermenu::showIPs()
     style.multiline = true;
     oxygine::spTextField info = oxygine::spTextField::create();
     info->setStyle(style);
-    info->setHtmlText((tr("Please use one of the following IP-Adresses to connect to this Host. Not all IP-Adresses") +
-                       tr(" may work for each client depending on the network settings. Please use cmd and the ping command to verify if an IP-Adress may work")));
+    info->setHtmlText((tr("Please use one of the following IP-Addresses to connect to this Host. Not all IP-Addresses") +
+                       tr(" may work for each client depending on their network settings. Please use CMD and the ping command to verify if an IP-Address will work")));
     info->setSize(Settings::getWidth() - 80, 500);
     info->setPosition(10, 10);
     pPanel->addItem(info);
@@ -401,7 +401,7 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         else if (messageType == NetworkCommands::SERVERNOGAMESLOTSAVAILABLE)
         {
             spDialogMessageBox pDialogMessageBox;
-            pDialogMessageBox = spDialogMessageBox::create(tr("Server doesn't have any more slots for playing a game."));
+            pDialogMessageBox = spDialogMessageBox::create(tr("Server doesn't have any more slots for players."));
             connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
             addChild(pDialogMessageBox);
         }

--- a/objects/dialogs/editor/dialogmodifybuilding.cpp
+++ b/objects/dialogs/editor/dialogmodifybuilding.cpp
@@ -76,7 +76,7 @@ DialogModifyBuilding::DialogModifyBuilding(GameMap* pMap, Building* pBuilding)
     }
     items.append(tr("Neutral"));
     spDropDownmenu pDropdownmenu = spDropDownmenu::create(300, items);
-    pDropdownmenu->setTooltipText(tr("Selects the Owner of the current unit. This is immediatly applied."));
+    pDropdownmenu->setTooltipText(tr("Selects the Owner of the current unit. This is immediately applied."));
     pDropdownmenu->setPosition(sliderOffset - 160, y);
 
     Player* pPlayer = m_pBuilding->getOwner();
@@ -108,7 +108,7 @@ DialogModifyBuilding::DialogModifyBuilding(GameMap* pMap, Building* pBuilding)
     pLabel->setHtmlText(tr("Name:"));
     pLabel->setPosition(10, y);
     spTextbox pTextbox = spTextbox::create(m_pPanel->getContentWidth() - 100 - 200 - pLabel->getWidth());
-    pTextbox->setTooltipText(tr("Custom Name of the Terrain. Empty name equals the default name."));
+    pTextbox->setTooltipText(tr("Custom Name of the Terrain. Leave the name empty to use its Default Name."));
     pTextbox->setPosition(sliderOffset - 160, y);
     pTextbox->setCurrentText(m_pBuilding->getBuildingName());
     connect(pTextbox.get(), &Textbox::sigTextChanged, m_pBuilding, &Building::setBuildingName, Qt::QueuedConnection);

--- a/objects/dialogs/editor/dialogmodifyunit.cpp
+++ b/objects/dialogs/editor/dialogmodifyunit.cpp
@@ -101,7 +101,7 @@ void DialogModifyUnit::updateData()
     spTextbox pTexbox = spTextbox::create(Settings::getWidth() - 40 - sliderOffset);
     pTexbox->setPosition(sliderOffset - 160, y);
     pTexbox->setCurrentText(m_pUnit->getName());
-    pTexbox->setTooltipText(tr("Selects the custom name of the unit shown instead of the actual unit name. An empty name equals the actual unit name"));
+    pTexbox->setTooltipText(tr("Selects the custom name of the unit shown instead of the actual unit name. An empty name will display the default name for that unit."));
     connect(pTexbox.get(), &Textbox::sigTextChanged, [this](QString value)
     {
         m_pUnit->setCustomName(value);
@@ -115,7 +115,7 @@ void DialogModifyUnit::updateData()
     pLabel->setPosition(10, y);
     m_pPanel->addItem(pLabel);
     spSlider pSlider = spSlider::create(Settings::getWidth() - 40 - sliderOffset, 1, 10, tr("HP"));
-    pSlider->setTooltipText(tr("Selects the HP of the current unit. This is immediatly applied."));
+    pSlider->setTooltipText(tr("Selects the HP of the current unit. This is immediately applied."));
     pSlider->setPosition(sliderOffset - 160, y);
     pSlider->setCurrentValue(m_pUnit->getHpRounded());
     connect(pSlider.get(), &Slider::sliderValueChanged, [this](qint32 value)
@@ -132,7 +132,7 @@ void DialogModifyUnit::updateData()
         pLabel->setPosition(10, y);
         m_pPanel->addItem(pLabel);
         spSlider pSlider = spSlider::create(Settings::getWidth() - 40 - sliderOffset, 0, m_pUnit->getMaxFuel(), tr("Fuel"));
-        pSlider->setTooltipText(tr("Selects the Fuel of the current unit. This is immediatly applied."));
+        pSlider->setTooltipText(tr("Selects the Fuel of the current unit. This is immediately applied."));
         pSlider->setPosition(sliderOffset - 160, y);
         pSlider->setCurrentValue(m_pUnit->getFuel());
         connect(pSlider.get(), &Slider::sliderValueChanged, [this](qint32 value)
@@ -158,7 +158,7 @@ void DialogModifyUnit::updateData()
         pLabel->setPosition(10, y);
         m_pPanel->addItem(pLabel);
         spSlider pSlider = spSlider::create(Settings::getWidth() - 40 - sliderOffset, 0, m_pUnit->getMaxAmmo1(), tr("Ammo"));
-        pSlider->setTooltipText(tr("Selects the Ammo 1 of the current unit. This is immediatly applied."));
+        pSlider->setTooltipText(tr("Selects the Ammo 1 of the current unit. This is immediately applied."));
         pSlider->setPosition(sliderOffset - 160, y);
         pSlider->setCurrentValue(m_pUnit->getAmmo1());
         connect(pSlider.get(), &Slider::sliderValueChanged, [this](qint32 value)
@@ -184,7 +184,7 @@ void DialogModifyUnit::updateData()
         pLabel->setPosition(10, y);
         m_pPanel->addItem(pLabel);
         spSlider pSlider = spSlider::create(Settings::getWidth() - 40 - sliderOffset, 0, m_pUnit->getMaxAmmo2(), tr("Ammo"));
-        pSlider->setTooltipText(tr("Selects the Ammo 2 of the current unit. This is immediatly applied."));
+        pSlider->setTooltipText(tr("Selects the Ammo 2 of the current unit. This is immediately applied."));
         pSlider->setPosition(sliderOffset - 160, y);
         pSlider->setCurrentValue(m_pUnit->getAmmo2());
         connect(pSlider.get(), &Slider::sliderValueChanged, [this](qint32 value)
@@ -215,7 +215,7 @@ void DialogModifyUnit::updateData()
         items.append(tr("Player ") + QString::number(i + 1));
     }
     spDropDownmenu pDropdownmenu = spDropDownmenu::create(300, items);
-    pDropdownmenu->setTooltipText(tr("Selects the Owner of the current unit. This is immediatly applied."));
+    pDropdownmenu->setTooltipText(tr("Selects the Owner of the current unit. This is immediately applied."));
     pDropdownmenu->setPosition(sliderOffset - 160, y);
     pDropdownmenu->setCurrentItem(m_pUnit->getOwner()->getPlayerID());
     connect(pDropdownmenu.get(), &DropDownmenu::sigItemChanged, this, [this](qint32 value)
@@ -240,7 +240,7 @@ void DialogModifyUnit::updateData()
                                      "Hold AI the ai only attacks but never moves with this unit.\n"
                                      "Patrol the unit will move to each position in the given order\n"
                                      "Patrol Loop the unit will move to each position in the given order and restart at the first\n"
-                                     "This is immediatly applied."));
+                                     "This is immediately applied."));
     pDropdownmenu->setPosition(sliderOffset - 160, y);
     pDropdownmenu->setCurrentItem(static_cast<qint32>(m_pUnit->getAiMode()));
     connect(pDropdownmenu.get(), &DropDownmenu::sigItemChanged, [this](qint32 value)
@@ -266,7 +266,7 @@ void DialogModifyUnit::updateData()
     items.append(tr("CO 1"));
     items.append(tr("CO 2"));
     pDropdownmenu = spDropDownmenu::create(300, items);
-    pDropdownmenu->setTooltipText(tr("Selects the Rank of this Unit. CO Ranks may be replaced with highest rang. This is immediatly applied."));
+    pDropdownmenu->setTooltipText(tr("Selects the Rank of this Unit. CO Ranks may be replaced with highest rank. This is immediately applied."));
     pDropdownmenu->setPosition(sliderOffset - 160, y);
     pDropdownmenu->setCurrentItem(static_cast<qint32>(m_pUnit->getUnitRank()));
     qint32 size = items.size();
@@ -342,7 +342,7 @@ void DialogModifyUnit::addLoadUnit(qint32 index, qint32 sliderOffset, qint32& y)
     };
     spDropDownmenuSprite pDropdownmenu = spDropDownmenuSprite::create(105, items, unitCreator, 30);
     pDropdownmenu->setPosition(sliderOffset - 160, y);
-    pDropdownmenu->setTooltipText(tr("Selects the unit loaded by the transporter. - for no unit. This is immediatly applied."));
+    pDropdownmenu->setTooltipText(tr("Selects the unit loaded by the transporter. Enter '-' for no unit. This is immediately applied."));
     Unit* pLoadedUnit = m_pUnit->getLoadedUnit(index);
     if (pLoadedUnit != nullptr)
     {

--- a/objects/dialogs/editor/dialograndommap.cpp
+++ b/objects/dialogs/editor/dialograndommap.cpp
@@ -101,7 +101,7 @@ DialogRandomMap::DialogRandomMap()
     text->setPosition(30, 5 + y );
     m_pPanel->addItem(text);
     m_MapWidth = spSpinBox::create(300, 1, 999, SpinBox::Mode::Int);
-    m_MapWidth->setTooltipText(tr("Selects the width for the new map."));
+    m_MapWidth->setTooltipText(tr("Selects the width of the new map."));
     m_MapWidth->setPosition(text->getX() + width, text->getY());
     m_MapWidth->setCurrentValue(20);
     m_pPanel->addItem(m_MapWidth);
@@ -114,7 +114,7 @@ DialogRandomMap::DialogRandomMap()
     text->setPosition(30, 5 + y + text->getHeight());
     m_pPanel->addItem(text);
     m_MapHeigth = spSpinBox::create(300, 1, 999, SpinBox::Mode::Int);
-    m_MapHeigth->setTooltipText(tr("Selects the heigth for the new map."));
+    m_MapHeigth->setTooltipText(tr("Selects the height of the new map."));
     m_MapHeigth->setPosition(text->getX() + width, text->getY());
     m_MapHeigth->setCurrentValue(20);
     m_pPanel->addItem(m_MapHeigth);
@@ -154,7 +154,7 @@ DialogRandomMap::DialogRandomMap()
     text->setPosition(30, 5 + y + text->getHeight());
     m_pPanel->addItem(text);
     m_Seed = spSpinBox::create(300, 0, std::numeric_limits<qint32>::max() - 1, SpinBox::Mode::Int);
-    m_Seed->setTooltipText(tr("The seed to generate the new map. Same map settings with the same seed generate the same map."));
+    m_Seed->setTooltipText(tr("The seed to generate the new map. Using the same map settings with the same seed will generate the same map."));
     m_Seed->setPosition(text->getX() + width, text->getY());
     m_Seed->setCurrentValue(GlobalUtils::randInt(0, std::numeric_limits<qint32>::max() - 1));
     m_pPanel->addItem(m_Seed);
@@ -181,7 +181,7 @@ DialogRandomMap::DialogRandomMap()
     m_pPanel->addItem(text);
     m_BaseSize = spSlider::create(Settings::getWidth() - 220 - width, 0, 100);
     m_BaseSize->setCurrentValue(10);
-    m_BaseSize->setTooltipText(tr("The percent distribution between randomly placed buildings and buildings placed near each HQ. A lower distributes more buildings randomly across the whole map."));
+    m_BaseSize->setTooltipText(tr("The percent of randomly placed buildings versus buildings placed near each HQ. A lower percentage places more buildings randomly across the whole map."));
     m_BaseSize->setPosition(text->getX() + width, y);
     m_pPanel->addItem(m_BaseSize);
 
@@ -213,7 +213,7 @@ DialogRandomMap::DialogRandomMap()
     m_unitCountLabel->setPosition(30, 5 + y );
     m_pPanel->addItem(m_unitCountLabel);
     m_unitCount = spSpinBox::create(300, 0, 9999, SpinBox::Mode::Int);
-    m_unitCount->setTooltipText(tr("Total amount of units that get spawned. If no valid position for a unit is found no unit gets spawned instead"));
+    m_unitCount->setTooltipText(tr("Total amount of units that get spawned. If no valid position for a unit is found no unit will be spawned."));
     m_unitCount->setPosition(m_unitCountLabel->getX() + width, m_unitCountLabel->getY());
     m_unitCount->setCurrentValue(0);
     m_pPanel->addItem(m_unitCount);
@@ -227,7 +227,7 @@ DialogRandomMap::DialogRandomMap()
     m_pPanel->addItem(m_unitsNearHqLabel);
     m_unitsNearHq = spSpinBox::create(300, 0, 100, SpinBox::Mode::Int);
     m_unitsNearHq->setUnit("%");
-    m_unitsNearHq->setTooltipText(tr("The percantage of units which get spawned near the HQ of the player."));
+    m_unitsNearHq->setTooltipText(tr("The percentage of units which are spawned near the HQ of the player."));
     m_unitsNearHq->setPosition(text->getX() + width, text->getY());
     m_unitsNearHq->setCurrentValue(100);
     m_pPanel->addItem(m_unitsNearHq);
@@ -240,7 +240,7 @@ DialogRandomMap::DialogRandomMap()
     m_pPanel->addItem(m_unitDistributionLabel);
     QStringList items = {tr("Random"), tr("Distributed")};
     m_unitDistributionSelection = spDropDownmenu::create(300, items);
-    m_unitDistributionSelection->setTooltipText(tr("Random for units getting spawned at random.\nDistributed for units beeing spawned at the given rate."));
+    m_unitDistributionSelection->setTooltipText(tr("Random: Units are spawned at random.\nDistributed: Units are spawned at the given rate."));
     m_unitDistributionSelection->setPosition(text->getX() + width, text->getY());
     m_unitDistributionSelection->setCurrentItem(1);
     m_pPanel->addItem(m_unitDistributionSelection);
@@ -420,7 +420,7 @@ void DialogRandomMap::DialogRandomMap::generatorChanged(QString filename)
             }
         }
         m_TerrainChances = spMultislider::create(terrainStrings, Settings::getWidth() - 150, terrainChances);
-        m_TerrainChances->setTooltipText(tr("The percent distribution between the different terrains when a terrain is placed."));
+        m_TerrainChances->setTooltipText(tr("The percentage of different terrain types distributed."));
         m_TerrainChances->setPosition(30, m_TerrainChanceLabel->getY() + 40);
         m_pPanel->addItem(m_TerrainChances);
 
@@ -437,7 +437,7 @@ void DialogRandomMap::DialogRandomMap::generatorChanged(QString filename)
             }
         }
         m_BuildingChances = spMultislider::create(buildingStrings, Settings::getWidth() - 150, buildingChances);
-        m_BuildingChances->setTooltipText(tr("The percent distribution between the different buildings when a building is placed."));
+        m_BuildingChances->setTooltipText(tr("The percentage of different buildings types distributed."));
         m_BuildingChances->setPosition(30, m_BuildingChanceLabel->getY() + 40);
         m_pPanel->addItem(m_BuildingChances);
         m_OwnerDistributionLabel->setY(m_BuildingChances->getY() + 40 * buildingStrings.size());
@@ -469,7 +469,7 @@ void DialogRandomMap::playerChanged(qreal)
         playerChances.append(0);
     }
     m_OwnerDistribution = spMultislider::create(playerStrings, Settings::getWidth() - 150, playerChances);
-    m_OwnerDistribution->setTooltipText(tr("The percent building distribution between the players. Note buildings close to an Player HQ may be ignored."));
+    m_OwnerDistribution->setTooltipText(tr("The percentage of buildings distributed between the players. Note buildings close to an Player HQ may be ignored."));
     m_OwnerDistribution->setPosition(30, m_OwnerDistributionLabel->getY() + 40);
     m_pPanel->addItem(m_OwnerDistribution);
     createUnitChances();

--- a/objects/dialogs/rules/perkselectiondialog.cpp
+++ b/objects/dialogs/rules/perkselectiondialog.cpp
@@ -77,7 +77,7 @@ PerkSelectionDialog::PerkSelectionDialog(GameMap* pMap, Player* pPlayer, qint32 
         pLabel->setPosition(pDropDownmenu->getX() + pDropDownmenu->getWidth() + 10, 30);
         pSpriteBox->addChild(pLabel);
         m_randomFillCheckbox = spCheckbox::create();
-        m_randomFillCheckbox->setTooltipText(tr("If checked clicking the random button. The selected perks are filled up to the maximum."));
+        m_randomFillCheckbox->setTooltipText(tr("If checked: clicking the 'Random' Button will fill all available perk slots instead of just 1."));
         m_randomFillCheckbox->setPosition(pLabel->getX() + pLabel->getWidth() + 10, 30);
         pSpriteBox->addChild(m_randomFillCheckbox);
         oxygine::spButton randomButton = pObjectManager->createButton(tr("Random"), 150);

--- a/objects/gameplayandkeys.cpp
+++ b/objects/gameplayandkeys.cpp
@@ -49,7 +49,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spCheckbox pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active walk, capture power animations and so on will be shown"));
+    pCheckbox->setTooltipText(tr("If active walk, capture, power animations, etc. will be shown"));
     pCheckbox->setChecked(Settings::getOverworldAnimations());
     connect(pCheckbox.get(), &Checkbox::checkChanged, Settings::getInstance(), &Settings::setOverworldAnimations, Qt::QueuedConnection);
     pCheckbox->setPosition(sliderOffset - 130, y);
@@ -65,7 +65,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     spDropDownmenu pAnimationMode = spDropDownmenu::create(450, items);
     pAnimationMode->setCurrentItem(static_cast<qint32>(Settings::getBattleAnimationMode()));
     pAnimationMode->setPosition(sliderOffset - 130, y);
-    pAnimationMode->setTooltipText(tr("Select which ingame animations are played."));
+    pAnimationMode->setTooltipText(tr("Select which in-game animations are played."));
     m_pOptions->addItem(pAnimationMode);
     connect(pAnimationMode.get(), &DropDownmenu::sigItemChanged, [=](qint32 value)
     {
@@ -85,7 +85,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
              tr("Fullscreen Transparent")};
     spDropDownmenu pBattleAnimationMode = spDropDownmenu::create(450, items);
     pBattleAnimationMode->setTooltipText(tr("Selects which battle animations are played when fighting an enemy.\n"
-                                            "Detailed    - Normal Battleanimation\n"
+                                            "Detailed    - Normal battle animations\n"
                                             "Transparent - Colored background is semi-transparent\n"
                                             "Fullscreen  - Animations are upscaled based on the resolution\n"));
     pBattleAnimationMode->setCurrentItem(static_cast<qint32>(Settings::getBattleAnimationType()));
@@ -104,7 +104,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     m_pOptions->addItem(pTextfield);
     items = {tr("off"), tr("on")};
     spDropDownmenu pDialogAnimationMode = spDropDownmenu::create(450, items);
-    pDialogAnimationMode->setTooltipText(tr("Selects if the dialogs are shown or not."));
+    pDialogAnimationMode->setTooltipText(tr("Selects if dialogs are shown or not."));
     pDialogAnimationMode->setCurrentItem(static_cast<qint32>(Settings::getDialogAnimation()));
     pDialogAnimationMode->setPosition(sliderOffset - 130, y);
     m_pOptions->addItem(pDialogAnimationMode);
@@ -171,7 +171,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSlider pAnimationSpeed = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 1, 100, "");
-    pAnimationSpeed->setTooltipText(tr("Selects the speed at which animations are played. Except battle and walking animations."));
+    pAnimationSpeed->setTooltipText(tr("Selects the speed at which animations are played. This does not include battle and walking animations."));
     pAnimationSpeed->setPosition(sliderOffset - 130, y);
     pAnimationSpeed->setCurrentValue(static_cast<qint32>(Settings::getAnimationSpeedValue()));
     m_pOptions->addItem(pAnimationSpeed);
@@ -267,7 +267,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the game will automatically end your turn if you can't give any orders anymore."));
+    pCheckbox->setTooltipText(tr("If enabled the game will automatically end your turn if you can't give any orders anymore."));
     pCheckbox->setChecked(Settings::getAutoEndTurn());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -283,7 +283,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the game will show a detailed battle forecast info."));
+    pCheckbox->setTooltipText(tr("If enabled the game will show a detailed battle forecast info."));
     pCheckbox->setChecked(Settings::getShowDetailedBattleForcast());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -303,7 +303,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSlider pMenuItemHeigth = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 5, (Settings::getHeight() - GameMap::getImageSize() * 2) / GameMap::getImageSize(), "");
-    pMenuItemHeigth->setTooltipText(tr("Amount of items per row for ingame menus before a new row is added."));
+    pMenuItemHeigth->setTooltipText(tr("Amount of items per row for in-game menus before a new row is added."));
     pMenuItemHeigth->setPosition(sliderOffset - 130, y);
     pMenuItemHeigth->setCurrentValue(static_cast<qint32>(Settings::getMenuItemCount()));
     m_pOptions->addItem(pMenuItemHeigth);
@@ -319,7 +319,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     spSlider pMenuItemWidth = spSlider::create(Settings::getWidth() - 20 - sliderOffset, 1, 20, "");
-    pMenuItemWidth->setTooltipText(tr("Amount of columns for ingame menus before a scrollable menu is shown."));
+    pMenuItemWidth->setTooltipText(tr("Amount of columns for in-game menus before a scrollable menu is shown."));
     pMenuItemWidth->setPosition(sliderOffset - 130, y);
     pMenuItemWidth->setCurrentValue(static_cast<qint32>(Settings::getMenuItemRowCount()));
     m_pOptions->addItem(pMenuItemWidth);
@@ -336,7 +336,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     m_pOptions->addItem(pTextfield);
     spSpinBox showCoCount = spSpinBox::create(200, 0, std::numeric_limits<qint32>::max());
     showCoCount->setInfinityValue(0);
-    showCoCount->setTooltipText(tr("Selects the amount of players shown in game on the sidebar."));
+    showCoCount->setTooltipText(tr("Selects the amount of players shown in-game on the sidebar."));
     showCoCount->setCurrentValue(Settings::getShowCoCount());
     showCoCount->setPosition(sliderOffset - 130, y);
     connect(showCoCount.get(), &SpinBox::sigValueChanged, Settings::getInstance(), &Settings::setShowCoCount);
@@ -365,7 +365,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the windows cursors is hidden during a game. Giving you a more Gameboy like feeling."));
+    pCheckbox->setTooltipText(tr("If active the Computer's cursor is hidden during a game, giving you a more Gameboy like feeling."));
     pCheckbox->setChecked(Settings::getShowCursor());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -381,7 +381,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the windows cursors is moved to the first entry when opening menus or similar actions. Only disable it if you intend to play the mouse only."));
+    pCheckbox->setTooltipText(tr("If active the Computer's cursor is moved to the first entry when opening menus or similar actions. Only disable this feature if you intend to play using a mouse only."));
     pCheckbox->setChecked(Settings::getAutoMoveCursor());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -397,7 +397,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the currently selectable fiedls get animated."));
+    pCheckbox->setTooltipText(tr("If active the currently selectable fields get animated."));
     pCheckbox->setChecked(!Settings::getStaticMarkedFields());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -416,7 +416,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     spDropDownmenu pCoInfOMode = spDropDownmenu::create(450, items);
     pCoInfOMode->setCurrentItem(static_cast<qint32>(Settings::getCoInfoPosition()));
     pCoInfOMode->setPosition(sliderOffset - 130, y);
-    pCoInfOMode->setTooltipText(tr("Select where the CO Info is shown. Where Flipping positions it at the opposite side of the cursor."));
+    pCoInfOMode->setTooltipText(tr("Select where the CO Info is shown. 'Flipping' positions the info opposite the side of the screen where the cursor is located."));
     m_pOptions->addItem(pCoInfOMode);
     connect(pCoInfOMode.get(), &DropDownmenu::sigItemChanged, [=](qint32 value)
     {
@@ -430,7 +430,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the map is scrolled automatically while the cursor is at the screen borders."));
+    pCheckbox->setTooltipText(tr("If active: the map is scrolled automatically when the cursor is at the edge of the screen."));
     pCheckbox->setChecked(Settings::getAutoScrolling());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -450,7 +450,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the map coordinates are shown during a game."));
+    pCheckbox->setTooltipText(tr("If active: map coordinates are shown during a game."));
     pCheckbox->setChecked(Settings::getShowIngameCoordinates());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -466,7 +466,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active the map is centered on the unit action during other player turns. If the field is visible to the player."));
+    pCheckbox->setTooltipText(tr("If active: the screen will center on every unit performing an action, except when not visible within Fog of War."));
     pCheckbox->setChecked(Settings::getAutoCamera());
     connect(pCheckbox.get(), &Checkbox::checkChanged, [=](bool value)
     {
@@ -485,7 +485,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     spDropDownmenu pAutoFocusMode = spDropDownmenu::create(450, items);
     pAutoFocusMode->setCurrentItem(static_cast<qint32>(Settings::getAutoFocusing()));
     pAutoFocusMode->setPosition(sliderOffset - 130, y);
-    pAutoFocusMode->setTooltipText(tr("Select where the game starts during a human player phase, when auto focusing is active."));
+    pAutoFocusMode->setTooltipText(tr("Select where the screen starts during your player phase. This setting only applies while auto focusing is active."));
     m_pOptions->addItem(pAutoFocusMode);
     connect(pAutoFocusMode.get(), &DropDownmenu::sigItemChanged, [=](qint32 value)
     {
@@ -514,7 +514,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     spCheckbox pSyncAnimations = spCheckbox::create();
     pSyncAnimations->setChecked(Settings::getSyncAnimations());
     pSyncAnimations->setPosition(sliderOffset - 130, y);
-    pSyncAnimations->setTooltipText(tr("If checked units and building animations on the map are synchronized. Note: changing this doesn't have an immediate effect, while playing."));
+    pSyncAnimations->setTooltipText(tr("If checked: units and building animations on the map are synchronized. Note: changing this doesn't have an immediate effect in-game."));
     m_pOptions->addItem(pSyncAnimations);
     connect(pSyncAnimations.get(), &Checkbox::checkChanged, Settings::getInstance(), Settings::setSyncAnimations, Qt::QueuedConnection);
     y += 40;
@@ -525,7 +525,7 @@ GameplayAndKeys::GameplayAndKeys(qint32 heigth)
     pTextfield->setPosition(10, y);
     m_pOptions->addItem(pTextfield);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If active units and actions can be canceld by long press. This is only recommended for devices without a keyboard."));
+    pCheckbox->setTooltipText(tr("If active units and actions can be canceled by a long-press. This is only recommended for devices without a keyboard."));
     pCheckbox->setChecked(Settings::getSimpleDeselect());
     connect(pCheckbox.get(), &Checkbox::checkChanged, this, [=](bool value)
     {

--- a/objects/playerselection.cpp
+++ b/objects/playerselection.cpp
@@ -441,7 +441,7 @@ void PlayerSelection::showPlayerSelection()
 
     itemIndex = 3;
     spSpinBox allStartFundsSpinBox = spSpinBox::create(xPositions[itemIndex + 1] - xPositions[itemIndex] - 10, 0, 100000);
-    allStartFundsSpinBox->setTooltipText(tr("Select with how much funds all player start the game."));
+    allStartFundsSpinBox->setTooltipText(tr("Select how much funds all player start the game with."));
     allStartFundsSpinBox->setSpinSpeed(500);
     allStartFundsSpinBox->setPosition(xPositions[itemIndex], y);
     allStartFundsSpinBox->setCurrentValue(0);
@@ -689,7 +689,7 @@ void PlayerSelection::showPlayerSelection()
 
         itemIndex++;
         spDropDownmenuColor playerColor = spDropDownmenuColor::create(xPositions[itemIndex + 1] - xPositions[itemIndex] - 10, playerColors);
-        playerColor->setTooltipText(tr("Select the Color for this players army."));
+        playerColor->setTooltipText(tr("Select the Color for this player's army."));
         playerColor->setPosition(xPositions[itemIndex], y);
         playerColor->setCurrentItem(tableColorToDisplayColor(m_pMap->getPlayer(i)->getColor()));
         m_pPlayerSelection->addItem(playerColor);
@@ -795,7 +795,7 @@ void PlayerSelection::showPlayerSelection()
 
         itemIndex++;
         spSpinBox playerStartFundsSpinBox = spSpinBox::create(xPositions[itemIndex + 1] - xPositions[itemIndex] - 10, 0, 100000);
-        playerStartFundsSpinBox->setTooltipText(tr("Select with how much funds this player starts the game."));
+        playerStartFundsSpinBox->setTooltipText(tr("Select how much funds this player starts the game with."));
         playerStartFundsSpinBox->setPosition(xPositions[itemIndex], y);
         playerStartFundsSpinBox->setCurrentValue(m_pMap->getPlayer(i)->getFunds());
         playerStartFundsSpinBox->setSpinSpeed(500);
@@ -869,7 +869,7 @@ void PlayerSelection::showPlayerSelection()
         if (m_pNetworkInterface.get() != nullptr)
         {
             spCheckbox pCheckbox = spCheckbox::create();
-            pCheckbox->setTooltipText(tr("Shows which player is ready to start the game. All players need to be checked in order to start a game."));
+            pCheckbox->setTooltipText(tr("Shows which players are ready to start the game. All players need to be checked in order to start a game."));
             pCheckbox->setPosition(xPositions[itemIndex] + labelminStepSize / 2 - pCheckbox->getWidth(), y);
             pCheckbox->setEnabled(false);
             m_pReadyBoxes.append(pCheckbox);

--- a/objects/ruleselection.cpp
+++ b/objects/ruleselection.cpp
@@ -154,7 +154,7 @@ void RuleSelection::showRuleSelection(bool advanced)
     textField->setPosition(30, y);
     addChild(textField);
     spCheckbox pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("Check this to see all game rules"));
+    pCheckbox->setTooltipText(tr("Check this to see all game rules."));
     pCheckbox->setPosition(textWidth, textField->getY());
     addChild(pCheckbox);
     pCheckbox->setChecked(advanced);
@@ -201,7 +201,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         pCheckbox = spCheckbox::create();
         pCheckbox->setPosition(textWidth, y);
         pCheckbox->setChecked(false);
-        pCheckbox->setTooltipText(tr("If checked cosmetic mods can be different on host and client site.\nWarning this may lead to asynchron games or crashes in case one of the mods is not a pure cosmetic mod."));
+        pCheckbox->setTooltipText(tr("If checked cosmetic mods can be different between host and players.\nWarning this may lead to desynced games or crashes if one of the mods is not a purely cosmetic mod."));
         pCheckbox->setEnabled(m_ruleChangeEabled);
         connect(pCheckbox.get(), &Checkbox::checkChanged, m_pMap->getGameRules(), &GameRules::setCosmeticModsAllowed, Qt::QueuedConnection);
         addChild(pCheckbox);
@@ -338,7 +338,7 @@ void RuleSelection::showRuleSelection(bool advanced)
     textField->setPosition(30, y);
     addChild(textField);
     pCheckbox = spCheckbox::create();
-    pCheckbox->setTooltipText(tr("If checked CO's have their day to day abilities else only perks are active. This has no impact on co powers."));
+    pCheckbox->setTooltipText(tr("If checked CO's have their day to day abilities, when unchecked CO's only have perks active. This has no impact on co powers."));
     pCheckbox->setPosition(textWidth, textField->getY());
     pCheckbox->setEnabled(m_ruleChangeEabled);
     addChild(pCheckbox);
@@ -355,7 +355,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked you can only select a single co for a player."));
+        pCheckbox->setTooltipText(tr("If checked players may only select a single CO."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -497,7 +497,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pSpinbox = spSpinBox::create(400, 0, 1, SpinBox::Mode::Float);
-        pSpinbox->setTooltipText(tr("The percentage of the co gauge lost when the co unit gets destroyed."));
+        pSpinbox->setTooltipText(tr("The percentage of the CO gauge lost when the CO unit gets destroyed."));
         pSpinbox->setInfinityValue(-1.0);
         pSpinbox->setSpinSpeed(0.1f);
         pSpinbox->setPosition(textWidth, textField->getY());
@@ -523,7 +523,7 @@ void RuleSelection::showRuleSelection(bool advanced)
     addChild(textField);
     QStringList fogModes = {tr("Off"), tr("Mist of War"), tr("Fog of War"), tr("Shroud of War")};
     spDropDownmenu fogOfWar = spDropDownmenu::create(400, fogModes);
-    fogOfWar->setTooltipText(tr("Select the fog of war rule for the current game."));
+    fogOfWar->setTooltipText(tr("Select the fog of war rule for the current game. \n In Mist of War all units can be seen but not targeted without Vision. \n In Fog of War all units cannot be seen without vision. \n In Shroud of War none of the map can be seen until explored, all units cannot be seen without vision."));
     fogOfWar->setPosition(textWidth, textField->getY());
     auto fogMode = m_pMap->getGameRules()->getFogMode();
     if (fogMode == GameEnums::Fog_OfMist)
@@ -566,7 +566,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked units can't see over certain terrains. Reducing their vision range. Air units are unaffected by this effect."));
+        pCheckbox->setTooltipText(tr("If checked units can't see over certain terrains, reducing their vision range. Air units are unaffected by this effect."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -580,7 +580,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked most buildings deny vision. E.g. you can hide a unit in a building similar to a forest."));
+        pCheckbox->setTooltipText(tr("If checked most buildings deny vision. This means you can hide a unit in a building similar to a forest."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -595,7 +595,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         addChild(textField);
         QStringList dayModes = {tr("Default"), tr("Permanent")};
         spDropDownmenu pDropDownmenu = spDropDownmenu::create(400, dayModes);
-        pDropDownmenu->setTooltipText(tr("Defines if the day to day banner is shown permanent for human or not. Decision is depending of chosen fog of war."));
+        pDropDownmenu->setTooltipText(tr("If set to 'Permanent' the New Day screen for Human players will remain on screen until dismissed. If set to 'Default' this feature will be off except in Fog of War games. This setting only takes effect in games with more than 1 Human players on the Host's PC."));
         pDropDownmenu->setPosition(textWidth, textField->getY());
         pDropDownmenu->setEnabled(m_ruleChangeEabled);
         addChild(pDropDownmenu);
@@ -687,7 +687,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked the impact of terrain defense stars is reduced the less hp a unit has."));
+        pCheckbox->setTooltipText(tr("If checked: the impact of terrain defense stars is reduced the less hp a unit has."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -701,7 +701,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked ships and boats can move through bridges placed on sea tiles, like in advance wars darc conflict."));
+        pCheckbox->setTooltipText(tr("If checked: ships and boats can move through bridges placed on sea tiles, like in Advance Wars Dark conflict."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -715,7 +715,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked units can move after getting unload. If the unit remained in their transporter for more than one turn."));
+        pCheckbox->setTooltipText(tr("If checked: units can move after getting unloaded if the unit had remained in their transporter for more than one turn."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -780,7 +780,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked CO's that are randomly selected are unique. Note: If not enough CO's are available this may select no co for a player"));
+        pCheckbox->setTooltipText(tr("If checked: CO's that are randomly selected are unique. Note: If not enough CO's are available this may select no CO for a player"));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);
@@ -808,7 +808,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         spSpinBox pSpinbox = spSpinBox::create(400, 0, 1, SpinBox::Mode::Float);
-        pSpinbox->setTooltipText(tr("The amount of funds you get back for selling a unit. Only has an impact if the sell action is active"));
+        pSpinbox->setTooltipText(tr("The amount of funds you are refunded for selling a unit. Selling is only possible if the 'Sell' action is active"));
         pSpinbox->setInfinityValue(-1.0);
         pSpinbox->setSpinSpeed(0.1f);
         pSpinbox->setUnit("%");
@@ -825,7 +825,7 @@ void RuleSelection::showRuleSelection(bool advanced)
         textField->setPosition(30, y);
         addChild(textField);
         pCheckbox = spCheckbox::create();
-        pCheckbox->setTooltipText(tr("If checked units of the same team have the same direction rather than based on player order."));
+        pCheckbox->setTooltipText(tr("If checked units of the same team face the same direction rather than based on player order."));
         pCheckbox->setPosition(textWidth, textField->getY());
         pCheckbox->setEnabled(m_ruleChangeEabled);
         addChild(pCheckbox);


### PR DESCRIPTION
This is a collection of English-oriented suggestions to improve readability and access for English speakers. Suggestions include typo corrections, grammar edits, and expansion of some tooltips to increase clarity for English speakers.