### PR TITLE
Auto tank refreshes better

### DIFF
--- a/resources/scripts/units/ZCOUNIT_AUTO_TANK.js
+++ b/resources/scripts/units/ZCOUNIT_AUTO_TANK.js
@@ -89,6 +89,10 @@ var Constructor = function()
                 unit.setHasMoved(false);
                 unit.addMovementBonus(-999, 1);
                 unitAttackVariable.writeDataInt32(1);
+            } else if (attackedOnce === 1)
+            {
+                unitAttackVariable.writeDataInt32(0);
+                unit.addMovementBonus(999, 1);
             }
         }
     };


### PR DESCRIPTION
In the niche case that an auto tank is refreshed (by Eagle Lightning Strike for example), it acts as if it is on its second move (stationary and doesn't get a fourth attack). This will (probably) fix that.