### PR TITLE
Conrad is not supposed to have luck

### DIFF
--- a/resources/scripts/cos/co_conrad.js
+++ b/resources/scripts/cos/co_conrad.js
@@ -194,7 +194,7 @@ var Constructor = function()
     {
         if (CO.isActive(co))
         {
-            return -unit.getHpRounded();
+            return -10;
         }
         return 0;
     };


### PR DESCRIPTION
Changed `unit.getHpRounded()` to just `10`
luck damage already factors unit hp in

before change:
![image](https://github.com/Robosturm/Commander_Wars/assets/48808663/ce3af58a-8f6a-4d5c-bf4a-2251d55ccad0)
![image](https://github.com/Robosturm/Commander_Wars/assets/48808663/bc3fbe29-fa2c-41d1-8e9b-fe3121c50735)
Conrad has luck. This is bad.

after change:
![image](https://github.com/Robosturm/Commander_Wars/assets/48808663/91885240-b9f6-45d4-bbe5-9b8cd84d4b18)
Conrad has no luck. This is good.