### PR TITLE
Remove getFirerangeModifier from desert pipe seams

### DIFF
--- a/resources/scripts/building/zdesertweld_e_w.js
+++ b/resources/scripts/building/zdesertweld_e_w.js
@@ -31,10 +31,6 @@ var Constructor = function()
     {
         return "minimap_weld";
     };
-    this.getFirerangeModifier = function(terrain, unit)
-    {
-        return -1;
-    };
     this.onDestroyed = function(terrain, map)
     {
         // called when the terrain is destroyed and replacing of this terrain starts

--- a/resources/scripts/building/zdesertweld_n_s.js
+++ b/resources/scripts/building/zdesertweld_n_s.js
@@ -31,10 +31,6 @@ var Constructor = function()
     {
         return "minimap_weld";
     };
-    this.getFirerangeModifier = function(terrain, unit)
-    {
-        return -1;
-    };
     this.onDestroyed = function(terrain, map)
     {
         // called when the terrain is destroyed and replacing of this terrain starts


### PR DESCRIPTION
It looks like these are the only desert tiles with getFirerangeModifier remaining
Probably an oversight, so I made this PR