### PR TITLE
Fix canRepair() not working for ZCOUNIT units

### DIFF
--- a/game/building.cpp
+++ b/game/building.cpp
@@ -1164,11 +1164,6 @@ float Building::getTerrainAnimationMoveSpeed()
     }
 }
 
-bool Building::canRepair(Unit* pUnit)
-{
-    return this.canRepair(pUnit, false);
-}
-
 bool Building::canRepair(Unit* pUnit, bool always)
 {
     Interpreter* pInterpreter = Interpreter::getInstance();

--- a/game/building.cpp
+++ b/game/building.cpp
@@ -1164,7 +1164,12 @@ float Building::getTerrainAnimationMoveSpeed()
     }
 }
 
-bool Building::canRepair(Unit* pUnit, bool always = false)
+bool Building::canRepair(Unit* pUnit)
+{
+    return this.canRepair(pUnit, false);
+}
+
+bool Building::canRepair(Unit* pUnit, bool always)
 {
     Interpreter* pInterpreter = Interpreter::getInstance();
     QString function1 = "canRepair";

--- a/game/building.cpp
+++ b/game/building.cpp
@@ -1167,10 +1167,16 @@ float Building::getTerrainAnimationMoveSpeed()
 bool Building::canRepair(Unit* pUnit)
 {
     Interpreter* pInterpreter = Interpreter::getInstance();
-    QString function1 = "getConstructionList";
-    QJSValueList args({JsThis::getJsThis(m_pMap)});
-    QJSValue erg = pInterpreter->doFunction(m_BuildingID, function1, args);
-    return erg.toVariant().toStringList().contains(pUnit->getUnitID());
+    QString function1 = "canRepair";
+    QJSValueList args({m_jsThis,
+                       JsThis::getJsThis(pUnit),
+                       JsThis::getJsThis(m_pMap)});
+    QJSValue ret = pInterpreter->doFunction(m_BuildingID, function1, args);
+    if (ret.isBool())
+    {
+        return ret.toBool();
+    }
+    return false;
 }
 
 bool Building::isCaptureOrMissileBuilding(bool hasSiloTarget)

--- a/game/building.cpp
+++ b/game/building.cpp
@@ -1164,13 +1164,14 @@ float Building::getTerrainAnimationMoveSpeed()
     }
 }
 
-bool Building::canRepair(Unit* pUnit)
+bool Building::canRepair(Unit* pUnit, bool always = false)
 {
     Interpreter* pInterpreter = Interpreter::getInstance();
     QString function1 = "canRepair";
     QJSValueList args({m_jsThis,
                        JsThis::getJsThis(pUnit),
-                       JsThis::getJsThis(m_pMap)});
+                       JsThis::getJsThis(m_pMap),
+                       always});
     QJSValue ret = pInterpreter->doFunction(m_BuildingID, function1, args);
     if (ret.isBool())
     {

--- a/game/building.h
+++ b/game/building.h
@@ -478,16 +478,10 @@ public:
     /**
      * @brief canRepair
      * @param pUnit
-     * @return
-     */
-    Q_INVOKABLE bool canRepair(Unit* pUnit);
-    /**
-     * @brief canRepair
-     * @param pUnit
      * @param always
      * @return
      */
-    Q_INVOKABLE bool canRepair(Unit* pUnit, bool always);
+    Q_INVOKABLE bool canRepair(Unit* pUnit, bool always = false);
     /**
      * @brief isCaptureOrMissileBuilding
      * @return

--- a/game/building.h
+++ b/game/building.h
@@ -482,6 +482,13 @@ public:
      */
     Q_INVOKABLE bool canRepair(Unit* pUnit);
     /**
+     * @brief canRepair
+     * @param pUnit
+     * @param always
+     * @return
+     */
+    Q_INVOKABLE bool canRepair(Unit* pUnit, bool always);
+    /**
      * @brief isCaptureOrMissileBuilding
      * @return
      */

--- a/resources/scripts/general/building.js
+++ b/resources/scripts/general/building.js
@@ -228,7 +228,7 @@ var BUILDING =
         // default impl replenishes our units
         // gets called at the start of a turn
         var unit = building.getTerrain().getUnit();
-        if (BUILDING.canRepair(building, unit, map, always))
+        if (building.canRepair(building, unit, map, always))
         {
             var x = unit.getX();
             var y = unit.getY();

--- a/resources/scripts/general/building.js
+++ b/resources/scripts/general/building.js
@@ -221,7 +221,7 @@ var BUILDING =
             (unit.getOwner() === building.getOwner() || always) &&
             ((repairList.indexOf(unit.getUnitType()) >= 0) ||
              (constructionList.indexOf(unit.getUnitID()) >= 0));
-    }
+    },
 
     replenishUnit : function(building, map, health = 2, fuelAmount = 1, ammo1Amount = 1, ammo2Amount = 1, always = false)
     {

--- a/resources/scripts/general/building.js
+++ b/resources/scripts/general/building.js
@@ -220,7 +220,7 @@ var BUILDING =
         return (unit !== null) && 
             (unit.getOwner() === building.getOwner() || always) &&
             ((repairList.indexOf(unit.getUnitType()) >= 0) ||
-             (constructionList.indexOf(unit.getUnitID()) >= 0)));
+             (constructionList.indexOf(unit.getUnitID()) >= 0));
     }
 
     replenishUnit : function(building, map, health = 2, fuelAmount = 1, ammo1Amount = 1, ammo2Amount = 1, always = false)

--- a/resources/scripts/general/building.js
+++ b/resources/scripts/general/building.js
@@ -213,17 +213,22 @@ var BUILDING =
         return[];
     },
 
+    canRepair : function(building, unit, map, always = false)
+    {
+        var constructionList = building.getConstructionList();
+        var repairList = building.getRepairTypes();
+        return (unit !== null) && 
+            (unit.getOwner() === building.getOwner() || always) &&
+            ((repairList.indexOf(unit.getUnitType()) >= 0) ||
+             (constructionList.indexOf(unit.getUnitID()) >= 0)));
+    }
+
     replenishUnit : function(building, map, health = 2, fuelAmount = 1, ammo1Amount = 1, ammo2Amount = 1, always = false)
     {
         // default impl replenishes our units
         // gets called at the start of a turn
-        var constructionList = building.getConstructionList();
-        var repairList = building.getRepairTypes();
         var unit = building.getTerrain().getUnit();
-        if ((unit !== null) &&
-            (unit.getOwner() === building.getOwner() || always) &&
-            ((repairList.indexOf(unit.getUnitType()) >= 0) ||
-             (constructionList.indexOf(unit.getUnitID()) >= 0)))
+        if (BUILDING.canRepair(building, unit, map, always))
         {
             var x = unit.getX();
             var y = unit.getY();

--- a/resources/scripts/general/building.js
+++ b/resources/scripts/general/building.js
@@ -228,7 +228,7 @@ var BUILDING =
         // default impl replenishes our units
         // gets called at the start of a turn
         var unit = building.getTerrain().getUnit();
-        if (building.canRepair(building, unit, map, always))
+        if (building.canRepair(unit, always))
         {
             var x = unit.getX();
             var y = unit.getY();


### PR DESCRIPTION
`canRepair()` only uses `building.getConstructionList()` so far
the actual `BUILDING.replenishUnit()` uses both `building.getConstructionList()` and `building.getRepairTypes()`
so there's a mismatch for the units that have a matching type, but aren't in the construction list (the ZCOUNIT units)

- Moved the conditional in `BUILDING.replenishUnit()` into `BUILDING.canRepair()`
- Changed `building.canRepair()` to use the js `<BUILDING_TYPE>.canRepair()`