### PR TITLE
(Untested) Proposed change to fix the multiple problems uncovered in #1824

### DIFF
--- a/game/unit.cpp
+++ b/game/unit.cpp
@@ -2111,7 +2111,7 @@ qint32 Unit::getBaseMovementCosts(qint32 x, qint32 y, qint32 curX, qint32 curY, 
 qint32 Unit::getMovementCosts(qint32 x, qint32 y, qint32 curX, qint32 curY, bool trapChecking)
 {
     qint32 baseCosts = getBaseMovementCosts(x, y, curX, curY, trapChecking);
-    if (baseCosts == 0)
+    if (baseCosts <= 0)
     {
         return baseCosts;
     }
@@ -2136,10 +2136,6 @@ qint32 Unit::getMovementCosts(qint32 x, qint32 y, qint32 curX, qint32 curY, bool
     if ((costs <= 0) && (baseCosts > 0))
     {
         return 1;
-    }
-    else if (weatherCosts + costs >= 0 && costs + baseCosts < 0)
-    {
-        return -1;
     }
     else
     {

--- a/resources/scripts/cos/co_amy.js
+++ b/resources/scripts/cos/co_amy.js
@@ -269,12 +269,15 @@ var Constructor = function()
     {
         if (CO.isActive(co))
         {
-            if (map === null ||
-                (map !== null && map.getGameRules().getCoGlobalD2D()))
+            if (unit.getOwner() === co.getOwner())
             {
-                if (map.getTerrain(posX, posY).getTerrainID() === "REAF")
+                if (map === null ||
+                    (map !== null && map.getGameRules().getCoGlobalD2D()))
                 {
-                    return -999;
+                    if (map.getTerrain(posX, posY).getTerrainID() === "REAF")
+                    {
+                        return -999;
+                    }
                 }
             }
         }

--- a/resources/scripts/cos/co_olaf.js
+++ b/resources/scripts/cos/co_olaf.js
@@ -219,7 +219,7 @@ var Constructor = function()
     };
     this.getMovementcostModifier = function(co, unit, posX, posY, map)
     {
-        if (CO.isActive(co) && CO_OLAF.d2dRainMalus === true)
+        if (CO.isActive(co) && CO_OLAF.d2dRainMalus === true && unit.getOwner() === co.getOwner())
         {
             if (map !== null)
             {


### PR DESCRIPTION
Olaf applies his movement cost penalty to all players' units; changed that to apply only to his own units.

I searched all existing COs and found that Amy had the same problem, so this fixes that as well.

A change to unit.cpp ensures that COs' movement penalties won't be allowing units to move over illegal terrain, even if they're a modded CO that applies a movement penalty of +2 or more in one go.

Haven't tested these changes, as I don't know how to compile the game.