### PR TITLE
Minor graphical bug fixes for Linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
+# IDE-related files
+/.idea
+
+# Temporary build files
+/*.cmake
+CMakeCache.txt
+/CMakeFiles
 CMakeLists.txt.user
+/commander_wars
+/Commander_Wars_autogen
+/*.depends
+/*.log
+/Makefile
+/qrc_*
+/.qt
+
+# Files the game puts in the current directory
+/Commander_Wars.ini
+/*.dat
+/logs
+/savegames

--- a/3rd_party/oxygine-framework/oxygine/core/gamewindow.cpp
+++ b/3rd_party/oxygine-framework/oxygine/core/gamewindow.cpp
@@ -33,11 +33,9 @@ namespace oxygine
 #ifdef GRAPHICSUPPORT
         setObjectName("GameWindow");
         QSurfaceFormat newFormat = format();
-        newFormat.setProfile(QSurfaceFormat::CoreProfile);
+
         // set OpenGL-related parameters
         newFormat.setProfile(QSurfaceFormat::CoreProfile);
-        newFormat.setSamples(2);    // Set the number of samples used for multisampling
-
         newFormat.setRenderableType(getRenderableType());
         newFormat.setSamples(2);
 

--- a/commander_wars.nix
+++ b/commander_wars.nix
@@ -1,0 +1,15 @@
+{ stdenv, lib, cmake, qt6, libressl, wrapQtAppsHook, pkg-config }:
+
+stdenv.mkDerivation {
+    pname = "commander_wars";
+    version = "1.0";
+
+    src = ./.;
+
+    cmakeFlags = [
+        "-DOPENSSL_USE_STATIC_LIBS:BOOL=OFF"
+    ];
+
+    buildInputs = [ qt6.qtbase qt6.qtdeclarative qt6.qttools qt6.qtmultimedia libressl ];
+    nativeBuildInputs = [ cmake wrapQtAppsHook pkg-config ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735617354,
+        "narHash": "sha256-5zJyv66q68QZJZsXtmjDBazGnF0id593VSy+8eSckoo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "69b9a8c860bdbb977adfa9c5e817ccb717884182",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+
+    outputs = { systems, nixpkgs, ... }@inputs:
+        let
+            eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+            systems = [
+                "aarch64-darwin"
+                "aarch64-linux"
+                "x86_64-darwin"
+                "x86_64-linux"
+            ];
+        in {
+            packages = eachSystem (pkgs: rec {
+                CommanderWars = pkgs.kdePackages.callPackage ./CommanderWars.nix { };
+            });
+
+            devShells = eachSystem (pkgs: {
+                default = pkgs.mkShell (with pkgs; {
+                    buildInputs = [ qt6.qtbase qt6.qtdeclarative qt6.qttools qt6.qtmultimedia libressl ];
+                    nativeBuildInputs = [ cmake pkg-config ];
+                });
+            });
+        };
+}

--- a/system/frac_matrix_shader.glsl
+++ b/system/frac_matrix_shader.glsl
@@ -5,12 +5,13 @@ uniform lowp vec4 brightness_color;
 uniform lowp sampler2D base_texture;
 uniform sampler2D colorTable;
 uniform mediump float gamma;
+
 void main()
-{	
-	mediump vec4 color = texture2D(base_texture, result_uv);
-        gl_FragColor = texture2D(colorTable, vec2(color.r, color.g))  * result_color;
-	gl_FragColor.a = color.a * result_color.a;
-        gl_FragColor = gl_FragColor + add_color * gl_FragColor.a;
-        gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / gamma));
-        gl_FragColor = gl_FragColor - brightness_color;
+{
+    mediump vec4 color = texture2D(base_texture, result_uv);
+    gl_FragColor = texture2D(colorTable, vec2(color.r, color.g))  * result_color;
+    gl_FragColor.a = color.a * result_color.a;
+    gl_FragColor = gl_FragColor + add_color * gl_FragColor.a;
+    gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / gamma));
+    gl_FragColor = gl_FragColor - brightness_color;
 }

--- a/system/frac_shader.glsl
+++ b/system/frac_shader.glsl
@@ -4,10 +4,11 @@ uniform lowp vec4 add_color;
 uniform lowp vec4 brightness_color;
 uniform lowp sampler2D base_texture;
 uniform mediump float gamma;
+
 void main()
-{	
-	gl_FragColor = texture2D(base_texture, result_uv) * result_color;
-	gl_FragColor = gl_FragColor + add_color * gl_FragColor.a;
-        gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / gamma));
-        gl_FragColor = gl_FragColor - brightness_color;
+{
+    gl_FragColor = texture2D(base_texture, result_uv) * result_color;
+    gl_FragColor = gl_FragColor + add_color * gl_FragColor.a;
+    gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / gamma));
+    gl_FragColor = gl_FragColor - brightness_color;
 }

--- a/system/frac_table_shader.glsl
+++ b/system/frac_table_shader.glsl
@@ -5,12 +5,13 @@ uniform lowp vec4 brightness_color;
 uniform lowp sampler2D base_texture;
 uniform sampler2D colorTable;
 uniform mediump float gamma;
+
 void main()
-{	
-	mediump vec4 color = texture2D(base_texture, result_uv);
-        gl_FragColor = texture2D(colorTable, vec2(color.r, 0.0))  * result_color;
-	gl_FragColor.a = color.a * result_color.a;
-        gl_FragColor = gl_FragColor + add_color * gl_FragColor.a;
-        gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / gamma));
-        gl_FragColor = gl_FragColor - brightness_color;
+{
+    mediump vec4 color = texture2D(base_texture, result_uv);
+    gl_FragColor = texture2D(colorTable, vec2(color.r, 0.0))  * result_color;
+    gl_FragColor.a = color.a * result_color.a;
+    gl_FragColor = gl_FragColor + add_color * gl_FragColor.a;
+    gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / gamma));
+    gl_FragColor = gl_FragColor - brightness_color;
 }

--- a/system/vertex_shader.glsl
+++ b/system/vertex_shader.glsl
@@ -4,9 +4,10 @@ uniform highp mat4 mat;
 attribute vec3 position;
 attribute vec4 color;
 attribute vec2 uv;
+
 void main()
 {
-        gl_Position = mat * vec4(position, 1);
+	gl_Position = mat * vec4(position, 1);
 	result_color = color;
 	result_uv = uv;
 }


### PR DESCRIPTION
This fixes a few small issues on Linux:
* Issues with background windows showing through due to how transparency is handled on Linux.
* Prevents flickering of the window on game startup due to resetting the graphics mode.

This also adds a flake.nix script to help build Commander Wars on NixOS/with Nix. I added this for my personal use, but no sense in not committing it.