### PR TITLE
Send game version with slave despawn payload

### DIFF
--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -1414,6 +1414,11 @@ bool GameMenue::doDespawnSlave()
             mods.insert(JsonKeys::JSONKEY_MOD + QString::number(i), activeMods[i]);
         }
         data.insert(JsonKeys::JSONKEY_USEDMODS, mods);
+        GameVersion gameVersion;
+        data.insert(JsonKeys::JSONKEY_VERSION_MAJOR, gameVersion.getMajor());
+        data.insert(JsonKeys::JSONKEY_VERSION_MINOR, gameVersion.getMinor());
+        data.insert(JsonKeys::JSONKEY_VERSION_REVISION, gameVersion.getRevision());
+        data.insert(JsonKeys::JSONKEY_VERSION_SUFIX, gameVersion.getSufix());
         QJsonArray usernames;
         qint32 count = m_pMap->getPlayerCount();
         for (qint32 i = 0; i < count; ++i)

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -241,6 +241,11 @@ QJsonDocument Multiplayermenu::doSaveLobbyState(const QString & saveFile, const 
         mods.insert(JsonKeys::JSONKEY_MOD + QString::number(i), activeMods[i]);
     }
     data.insert(JsonKeys::JSONKEY_USEDMODS, mods);
+    GameVersion gameVersion;
+    data.insert(JsonKeys::JSONKEY_VERSION_MAJOR, gameVersion.getMajor());
+    data.insert(JsonKeys::JSONKEY_VERSION_MINOR, gameVersion.getMinor());
+    data.insert(JsonKeys::JSONKEY_VERSION_REVISION, gameVersion.getRevision());
+    data.insert(JsonKeys::JSONKEY_VERSION_SUFIX, gameVersion.getSufix());
     data.insert(JsonKeys::JSONKEY_USERNAMES, m_pPlayerSelection->getUserNames());
     return QJsonDocument(data);
 }


### PR DESCRIPTION
GameMenue::doDespawnSlave and Multiplayermenu::doSaveLobbyState constructed the SLAVEINFODESPAWNING JSON manually and never inserted versionMajor / versionMinor / versionRevision / versionSufix. MainServer::onSlaveInfoDespawning called NetworkGameData::fromJson on the message, which read those missing keys as 0 and the empty string, so each suspended-slave entry in m_runningSlaves and m_runningLobbies got stamped 0.0.0- as its game version. When a player tried to rejoin from the My Games view, LobbyMenu::checkGameVersion compared 0.0.0- against GameVersion() (the live binary) and refused the join with "Game has a different version. Game version: 0.0.0-".

Insert the four version keys at both call sites, mirroring NetworkGameData:: toJson, so suspended games carry their actual version through the despawn / relaunch round trip.