### PR TITLE
Add mod-sync: clients can download a host's mod set on mismatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,6 +540,7 @@ set(${PROJECT_NAME}_SRCS
     objects/dialogs/filedialog.cpp objects/dialogs/filedialog.h
     objects/dialogs/dialogcostyle.cpp objects/dialogs/dialogcostyle.h
     objects/dialogs/dialogmessagebox.cpp objects/dialogs/dialogmessagebox.h
+    objects/dialogs/dialogmodsyncprogress.cpp objects/dialogs/dialogmodsyncprogress.h
     objects/dialogs/dialogtextinput.cpp objects/dialogs/dialogtextinput.h
     objects/dialogs/folderdialog.cpp objects/dialogs/folderdialog.h
     objects/dialogs/dialogvaluecounter.cpp objects/dialogs/dialogvaluecounter.h

--- a/coreengine/commandlineparser.cpp
+++ b/coreengine/commandlineparser.cpp
@@ -32,6 +32,7 @@ const char* const CommandLineParser::ARG_AISLAVE                = "aiSlave";
 const char* const CommandLineParser::ARG_USERPATH               = "userPath";
 const char* const CommandLineParser::ARG_DEBUGLEVEL             = "debugLevel";
 const char* const CommandLineParser::ARG_SLAVETRAINING          = "slaveTraining";
+const char* const CommandLineParser::ARG_REJOINPASSWORD          = "rejoin-password";
 
 // options required for hosting a dedicated server
 const char* const CommandLineParser::ARG_SERVER                     = "server";
@@ -88,7 +89,8 @@ CommandLineParser::CommandLineParser()
       m_mailServerSendAddress(ARG_MAILSERVERSENDADDRESS, tr("E-Mail address used on the mail server for the server for sending mails to accounts."), tr("address"), ""),
       m_mailServerAuthMethod(ARG_MAILSERVERAUTHMETHOD, tr("Mail server authentication type (Plain, Login) for the server for sending mails to accounts."), tr("method"), ""),
       m_serverSaveFile(ARG_SERVERSAVEFILE, tr("Path to the server game save file"), tr("path"), ""),
-      m_slaveTraining(ARG_SLAVETRAINING, tr("mode for starting an ai training session."))
+      m_slaveTraining(ARG_SLAVETRAINING, tr("mode for starting an ai training session.")),
+      m_rejoinPassword(ARG_REJOINPASSWORD, tr("Password used by the auto-rejoin path after a mod-sync restart. Internal; not for manual use."), tr("password"), "")
 {
     Interpreter::setCppOwnerShip(this);
     m_parser.setApplicationDescription("Commander Wars game");
@@ -130,6 +132,7 @@ CommandLineParser::CommandLineParser()
     m_parser.addOption(m_mailServerAuthMethod);
     m_parser.addOption(m_serverSaveFile);
     m_parser.addOption(m_slaveTraining);
+    m_parser.addOption(m_rejoinPassword);
 }
 
 void CommandLineParser::parseArgsPhaseOne(QCoreApplication & app)
@@ -173,6 +176,10 @@ void CommandLineParser::parseArgsPhaseOne(QCoreApplication & app)
     {
         QString value = m_parser.value(m_update);
         Settings::getInstance()->setUpdateStep(value);
+    }
+    if (m_parser.isSet(m_rejoinPassword))
+    {
+        Mainapp::setRejoinPassword(m_parser.value(m_rejoinPassword));
     }
 }
 

--- a/coreengine/commandlineparser.h
+++ b/coreengine/commandlineparser.h
@@ -26,6 +26,7 @@ public:
     static const char* const ARG_USERPATH;
     static const char* const ARG_DEBUGLEVEL;
     static const char* const ARG_SLAVETRAINING;
+    static const char* const ARG_REJOINPASSWORD;
 
     static const char* const ARG_SERVER;
     static const char* const ARG_SERVERSLAVEHOSTOPTIONS;
@@ -93,6 +94,7 @@ private:
     QCommandLineOption m_mailServerAuthMethod;
     QCommandLineOption m_serverSaveFile;
     QCommandLineOption m_slaveTraining;
+    QCommandLineOption m_rejoinPassword;
 
     QCommandLineParser m_parser;
 };

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -905,3 +905,88 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
     QFile::remove(path);
     return applied;
 }
+
+QString Filesupport::rejoinManifestPath(const QString & userDataPath)
+{
+    return joinPath(userDataPath, QStringLiteral(".rejoin.json"));
+}
+
+bool Filesupport::writeRejoinManifest(const QString & userDataPath, const QString & host, quint16 port)
+{
+    if (host.isEmpty() || port == 0)
+    {
+        return false;
+    }
+    QJsonObject root;
+    root.insert(QStringLiteral("version"), 1);
+    root.insert(QStringLiteral("host"), host);
+    root.insert(QStringLiteral("port"), static_cast<qint32>(port));
+    root.insert(QStringLiteral("timestamp"), QDateTime::currentSecsSinceEpoch());
+    const QString path = rejoinManifestPath(userDataPath);
+    QSaveFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+    {
+        CONSOLE_PRINT("Failed to open rejoin manifest for write: " + path, GameConsole::eERROR);
+        return false;
+    }
+    f.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+    if (!f.commit())
+    {
+        CONSOLE_PRINT("Failed to commit rejoin manifest: " + path, GameConsole::eERROR);
+        return false;
+    }
+    return true;
+}
+
+Filesupport::RejoinManifest Filesupport::consumeRejoinManifest(const QString & userDataPath)
+{
+    RejoinManifest result;
+    const QString path = rejoinManifestPath(userDataPath);
+    QFile f(path);
+    if (!f.exists())
+    {
+        return result;
+    }
+    constexpr qint64 kMaxRejoinManifestBytes = 4 * 1024;
+    if (f.size() > kMaxRejoinManifestBytes)
+    {
+        CONSOLE_PRINT("Rejoin manifest oversize, discarding: " + path, GameConsole::eERROR);
+        QFile::remove(path);
+        return result;
+    }
+    if (!f.open(QIODevice::ReadOnly))
+    {
+        CONSOLE_PRINT("Rejoin manifest exists but cannot be read: " + path, GameConsole::eERROR);
+        QFile::remove(path);
+        return result;
+    }
+    const QByteArray data = f.readAll();
+    f.close();
+    QFile::remove(path);
+    QJsonParseError parseErr;
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &parseErr);
+    if (parseErr.error != QJsonParseError::NoError || !doc.isObject())
+    {
+        CONSOLE_PRINT("Rejoin manifest invalid JSON: " + parseErr.errorString(), GameConsole::eERROR);
+        return result;
+    }
+    const QJsonObject root = doc.object();
+    if (root.value(QStringLiteral("version")).toInt(0) != 1)
+    {
+        CONSOLE_PRINT("Rejoin manifest unknown version, discarding", GameConsole::eERROR);
+        return result;
+    }
+    const QString host = root.value(QStringLiteral("host")).toString();
+    const qint32 port = root.value(QStringLiteral("port")).toInt(0);
+    const qint64 timestamp = root.value(QStringLiteral("timestamp")).toVariant().toLongLong();
+    if (host.isEmpty() || port <= 0 || port > 0xFFFF)
+    {
+        CONSOLE_PRINT("Rejoin manifest has invalid host or port, discarding", GameConsole::eERROR);
+        return result;
+    }
+    result.valid = true;
+    result.host = host;
+    result.port = static_cast<quint16>(port);
+    result.timestamp = timestamp;
+    return result;
+}

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -820,6 +820,8 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
     const QJsonArray swaps = root.value(QStringLiteral("swaps")).toArray();
     // UTC + ms keeps backup names lexically sorted across DST and avoids same-second collision on rapid retries.
     const QString isoStamp = QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMdd-HHmmsszzzZ"));
+    // Read the flag once before the swap loop so settings cannot drift mid-batch. Must be called after Settings::loadSettings has run its binding loop; today the boot order at settings.cpp:1557 satisfies that.
+    const bool keepBackups = Settings::getInstance()->getModSyncKeepBackups();
     for (const auto & v : swaps)
     {
         const QJsonObject entry = v.toObject();
@@ -901,6 +903,14 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
         }
         CONSOLE_PRINT("Mod sync applied: " + finalRel, GameConsole::eINFO);
         applied.append(finalRel);
+        // Backup retention is opt-in; remove the .bak directory now if disabled. Failure to remove just leaves the dir for the next reapModSyncFolders pass.
+        if (finalExisted && !keepBackups && !backupAbs.isEmpty())
+        {
+            if (!QDir(backupAbs).removeRecursively())
+            {
+                CONSOLE_PRINT("Failed to remove .bak after successful sync; reaper will clean up: " + backupAbs, GameConsole::eWARNING);
+            }
+        }
     }
     QFile::remove(path);
     return applied;

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -435,7 +435,8 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
         return pkg;
     }
     pkg.declaredUncompressedSize = static_cast<qint32>(serialized.size());
-    pkg.compressedBlob = qCompress(serialized);
+    // Level 1 = zlib best-speed; ~few percent worse ratio on text-heavy mods, big drop in host CPU stall.
+    pkg.compressedBlob = qCompress(serialized, 1);
     pkg.fileCount = fileCount;
     if (pkg.compressedBlob.size() > caps.perModBytes)
     {

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -11,6 +11,8 @@
 #include <QJsonObject>
 #include <QSaveFile>
 #include <QSet>
+#include <QtEndian>
+#include <limits>
 
 const char* const Filesupport::LIST_FILENAME_ENDING = ".bl";
 
@@ -354,12 +356,30 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
     {
         const QString absolute = it.next();
         const QString rel = QDir(modRoot).relativeFilePath(absolute);
-        // Filter VCS metadata, build artefacts, and our own staging/backup dirs.
-        if (rel.startsWith(QStringLiteral(".git/")) ||
-            rel.startsWith(QStringLiteral(".svn/")) ||
-            rel.startsWith(QStringLiteral("__pycache__/")) ||
-            rel.contains(QStringLiteral(".sync-staging-")) ||
-            rel.contains(QStringLiteral(".bak-")))
+        const QStringList relSegs = rel.split(QChar('/'));
+        const QString basename = relSegs.isEmpty() ? rel : relSegs.last();
+        // Segment-based filter; substrings would false-positive legit filenames containing .bak- or .sync-staging-.
+        bool cruft = false;
+        for (qint32 si = 0; si < relSegs.size(); ++si)
+        {
+            const QString & seg = relSegs[si];
+            if (seg == QStringLiteral(".git") || seg == QStringLiteral(".svn") || seg == QStringLiteral("__pycache__"))
+            {
+                cruft = true;
+                break;
+            }
+            const bool isDir = (si + 1 < relSegs.size());
+            if (isDir && (seg.startsWith(QStringLiteral(".sync-staging-")) || seg.startsWith(QStringLiteral(".bak-"))))
+            {
+                cruft = true;
+                break;
+            }
+        }
+        if (cruft)
+        {
+            continue;
+        }
+        if (basename == QStringLiteral(".DS_Store") || basename == QStringLiteral("Thumbs.db") || basename == QStringLiteral("desktop.ini"))
         {
             continue;
         }
@@ -399,7 +419,18 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
     {
         QDataStream stream(&serialized, QIODevice::WriteOnly);
         stream.setVersion(QDataStream::Version::Qt_6_5);
-        writeMap(stream, files);
+        // Custom format: keys as UTF-8 QByteArrays so the receiver can run a length-bounded reader.
+        stream << static_cast<qint32>(files.size());
+        for (auto iter = files.constBegin(); iter != files.constEnd(); ++iter)
+        {
+            stream << iter.key().toUtf8();
+            stream << iter.value();
+        }
+    }
+    if (serialized.size() > caps.perModBytes || serialized.size() > std::numeric_limits<qint32>::max())
+    {
+        pkg.rejectReason = kModSyncSizeCapExceeded;
+        return pkg;
     }
     pkg.declaredUncompressedSize = static_cast<qint32>(serialized.size());
     pkg.compressedBlob = qCompress(serialized);
@@ -417,6 +448,11 @@ QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & 
 {
     rejectReason = 0;
     QMap<QString, QByteArray> files;
+    if (caps.perModBytes < 0 || caps.fileCountMax < 0 || caps.relPathMaxLen <= 0)
+    {
+        rejectReason = kModSyncInternalError;
+        return files;
+    }
     if (compressedBlob.size() > caps.perModBytes)
     {
         rejectReason = kModSyncSizeCapExceeded;
@@ -427,57 +463,97 @@ QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & 
         rejectReason = kModSyncSizeCapExceeded;
         return files;
     }
+    // qCompress prefixes a 4-byte big-endian uncompressed size used for pre-allocation; gate it before qUncompress to bound memory.
+    if (compressedBlob.size() < 4)
+    {
+        rejectReason = kModSyncInternalError;
+        return files;
+    }
+    const quint32 framingSize = qFromBigEndian<quint32>(reinterpret_cast<const uchar *>(compressedBlob.constData()));
+    if (framingSize > static_cast<quint32>(caps.perModBytes) || static_cast<qint32>(framingSize) != declaredUncompressedSize)
+    {
+        rejectReason = kModSyncSizeCapExceeded;
+        return files;
+    }
     const QByteArray serialized = qUncompress(compressedBlob);
     if (serialized.isEmpty() || serialized.size() != declaredUncompressedSize)
     {
         rejectReason = kModSyncInternalError;
         return files;
     }
-    QByteArray mut = serialized;
-    QDataStream stream(&mut, QIODevice::ReadOnly);
+    QDataStream stream(serialized);
     stream.setVersion(QDataStream::Version::Qt_6_5);
-    auto map = readMap<QString, QByteArray, QMap>(stream);
-    if (stream.status() != QDataStream::Ok)
+    qint32 mapSize = 0;
+    stream >> mapSize;
+    if (stream.status() != QDataStream::Ok || mapSize < 0 || mapSize > caps.fileCountMax)
     {
-        rejectReason = kModSyncInternalError;
-        return files;
+        rejectReason = kModSyncFileCountCapExceeded;
+        return QMap<QString, QByteArray>();
     }
-    qint32 fileCount = 0;
-    qint64 uncompressedTotal = 0;
-    for (auto iter = map.constBegin(); iter != map.constEnd(); ++iter)
+    // Validate length header before allocation; defends against decompression-bomb pre-allocation in operator>>.
+    auto readBoundedBytes = [&stream](QByteArray & out, qint64 maxBytes) -> bool
     {
-        if (!validateRelativeFilePath(iter.key(), caps.relPathMaxLen))
+        quint32 declared = 0;
+        stream >> declared;
+        if (stream.status() != QDataStream::Ok)
+        {
+            return false;
+        }
+        if (declared == 0xFFFFFFFFu)
+        {
+            out.clear();
+            return true;
+        }
+        if (declared > static_cast<quint32>(maxBytes))
+        {
+            return false;
+        }
+        out.resize(static_cast<qint32>(declared));
+        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
+        {
+            return false;
+        }
+        return true;
+    };
+    qint64 uncompressedTotal = 0;
+    for (qint32 i = 0; i < mapSize; ++i)
+    {
+        QByteArray keyUtf8;
+        QByteArray value;
+        // UTF-8 max 4 bytes per code point; cap key bytes at relPathMaxLen * 4.
+        if (!readBoundedBytes(keyUtf8, static_cast<qint64>(caps.relPathMaxLen) * 4))
         {
             rejectReason = kModSyncInvalidPath;
-            files.clear();
-            return files;
+            return QMap<QString, QByteArray>();
         }
-        if (iter.value().size() > caps.perModBytes)
+        if (!readBoundedBytes(value, caps.perModBytes))
         {
             rejectReason = kModSyncSizeCapExceeded;
-            files.clear();
-            return files;
+            return QMap<QString, QByteArray>();
         }
-        uncompressedTotal += iter.value().size();
+        const QString key = QString::fromUtf8(keyUtf8);
+        if (!validateRelativeFilePath(key, caps.relPathMaxLen))
+        {
+            rejectReason = kModSyncInvalidPath;
+            return QMap<QString, QByteArray>();
+        }
+        uncompressedTotal += value.size();
         if (uncompressedTotal > caps.perModBytes)
         {
             rejectReason = kModSyncSizeCapExceeded;
-            files.clear();
-            return files;
+            return QMap<QString, QByteArray>();
         }
-        ++fileCount;
-        if (fileCount > caps.fileCountMax)
+        if (files.contains(key))
         {
-            rejectReason = kModSyncFileCountCapExceeded;
-            files.clear();
-            return files;
+            rejectReason = kModSyncInvalidPath;
+            return QMap<QString, QByteArray>();
         }
+        files.insert(key, value);
     }
-    files = map;
     return files;
 }
 
-QString Filesupport::stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, qint32 & rejectReason)
+QString Filesupport::stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, const ModSyncCaps & caps, qint32 & rejectReason)
 {
     rejectReason = 0;
     if (!validateModPath(modPath))
@@ -485,44 +561,71 @@ QString Filesupport::stageModSync(const QString & installRoot, const QString & m
         rejectReason = kModSyncInvalidPath;
         return QString();
     }
-    const qint64 pid = QCoreApplication::applicationPid();
-    const QString stagingPath = joinPath(installRoot, modPath) + QStringLiteral(".sync-staging-") + QString::number(pid);
-    QDir stagingDir(stagingPath);
-    if (stagingDir.exists())
+    if (files.size() > caps.fileCountMax)
     {
-        stagingDir.removeRecursively();
+        rejectReason = kModSyncFileCountCapExceeded;
+        return QString();
     }
-    if (!QDir().mkpath(stagingPath))
+    qint64 totalBytes = 0;
+    for (auto iter = files.constBegin(); iter != files.constEnd(); ++iter)
+    {
+        if (!validateRelativeFilePath(iter.key(), caps.relPathMaxLen))
+        {
+            rejectReason = kModSyncInvalidPath;
+            return QString();
+        }
+        if (iter.value().size() > caps.perModBytes)
+        {
+            rejectReason = kModSyncSizeCapExceeded;
+            return QString();
+        }
+        totalBytes += iter.value().size();
+        if (totalBytes > caps.perModBytes)
+        {
+            rejectReason = kModSyncSizeCapExceeded;
+            return QString();
+        }
+    }
+    const qint64 pid = QCoreApplication::applicationPid();
+    const QString stagingRel = modPath + QStringLiteral(".sync-staging-") + QString::number(pid);
+    const QString stagingAbs = joinPath(installRoot, stagingRel);
+    QDir stagingDir(stagingAbs);
+    if (stagingDir.exists() && !stagingDir.removeRecursively())
+    {
+        rejectReason = kModSyncInternalError;
+        return QString();
+    }
+    if (!QDir().mkpath(stagingAbs))
     {
         rejectReason = kModSyncInternalError;
         return QString();
     }
     for (auto iter = files.constBegin(); iter != files.constEnd(); ++iter)
     {
-        const QString full = joinPath(stagingPath, iter.key());
+        const QString full = joinPath(stagingAbs, iter.key());
         const QFileInfo fi(full);
         if (!QDir().mkpath(fi.absolutePath()))
         {
-            QDir(stagingPath).removeRecursively();
+            QDir(stagingAbs).removeRecursively();
             rejectReason = kModSyncInternalError;
             return QString();
         }
         QSaveFile f(full);
         if (!f.open(QIODevice::WriteOnly))
         {
-            QDir(stagingPath).removeRecursively();
+            QDir(stagingAbs).removeRecursively();
             rejectReason = kModSyncInternalError;
             return QString();
         }
         f.write(iter.value());
         if (!f.commit())
         {
-            QDir(stagingPath).removeRecursively();
+            QDir(stagingAbs).removeRecursively();
             rejectReason = kModSyncInternalError;
             return QString();
         }
     }
-    return stagingPath;
+    return stagingRel;
 }
 
 void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupKeep)
@@ -609,18 +712,27 @@ bool Filesupport::writePendingModSyncManifest(const QString & userDataPath, cons
     return true;
 }
 
-void Filesupport::executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath)
+QStringList Filesupport::executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath)
 {
+    QStringList applied;
     const QString path = pendingModSyncManifestPath(userDataPath);
     QFile f(path);
     if (!f.exists())
     {
-        return;
+        return applied;
+    }
+    // Oversize manifest is treated as corrupt or tampered: discard rather than try to parse partial state.
+    constexpr qint64 kMaxManifestBytes = 1 * 1024 * 1024;
+    if (f.size() > kMaxManifestBytes)
+    {
+        CONSOLE_PRINT("Pending mod-sync manifest oversize, discarding: " + path, GameConsole::eERROR);
+        QFile::remove(path);
+        return applied;
     }
     if (!f.open(QIODevice::ReadOnly))
     {
         CONSOLE_PRINT("Pending mod-sync manifest exists but cannot be read: " + path, GameConsole::eERROR);
-        return;
+        return applied;
     }
     const QByteArray data = f.readAll();
     f.close();
@@ -630,17 +742,18 @@ void Filesupport::executePendingModSyncManifest(const QString & installRoot, con
     {
         CONSOLE_PRINT("Pending mod-sync manifest is invalid JSON: " + parseErr.errorString(), GameConsole::eERROR);
         QFile::remove(path);
-        return;
+        return applied;
     }
     const QJsonObject root = doc.object();
     if (root.value(QStringLiteral("version")).toInt(0) != 1)
     {
         CONSOLE_PRINT("Pending mod-sync manifest has unknown version, discarding", GameConsole::eERROR);
         QFile::remove(path);
-        return;
+        return applied;
     }
     const QJsonArray swaps = root.value(QStringLiteral("swaps")).toArray();
-    const QString isoStamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
+    // UTC + ms keeps backup names lexically sorted across DST and avoids same-second collision on rapid retries.
+    const QString isoStamp = QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMdd-HHmmsszzzZ"));
     for (const auto & v : swaps)
     {
         const QJsonObject entry = v.toObject();
@@ -651,16 +764,59 @@ void Filesupport::executePendingModSyncManifest(const QString & installRoot, con
             CONSOLE_PRINT("Manifest entry has invalid final path, skipping: " + finalRel, GameConsole::eERROR);
             continue;
         }
+        // Pin staging to the exact shape stageModSync writes: <finalRel>.sync-staging-<digits>.
+        const QString stagingPrefix = finalRel + QStringLiteral(".sync-staging-");
+        if (!stagingRel.startsWith(stagingPrefix))
+        {
+            CONSOLE_PRINT("Manifest staging path shape mismatch, skipping: " + stagingRel, GameConsole::eERROR);
+            continue;
+        }
+        const QString suffix = stagingRel.mid(stagingPrefix.size());
+        bool suffixDigits = !suffix.isEmpty();
+        for (const QChar c : suffix)
+        {
+            if (c < QChar('0') || c > QChar('9'))
+            {
+                suffixDigits = false;
+                break;
+            }
+        }
+        if (!suffixDigits)
+        {
+            CONSOLE_PRINT("Manifest staging suffix not numeric pid, skipping: " + stagingRel, GameConsole::eERROR);
+            continue;
+        }
         const QString stagingAbs = joinPath(installRoot, stagingRel);
         const QString finalAbs = joinPath(installRoot, finalRel);
-        if (!QFileInfo::exists(stagingAbs))
+        const QFileInfo stagingInfo(stagingAbs);
+        if (!stagingInfo.exists())
         {
             CONSOLE_PRINT("Manifest staging missing, skipping: " + stagingAbs, GameConsole::eERROR);
             continue;
         }
-        if (QFileInfo::exists(finalAbs))
+        // Defends against a tampered manifest pointing the staging slot at a regular file.
+        if (!stagingInfo.isDir())
         {
-            const QString backupAbs = finalAbs + QStringLiteral(".bak-") + isoStamp;
+            CONSOLE_PRINT("Manifest staging path is not a directory, skipping: " + stagingAbs, GameConsole::eERROR);
+            continue;
+        }
+        QString backupAbs;
+        const QFileInfo finalInfo(finalAbs);
+        const bool finalExisted = finalInfo.exists();
+        if (finalExisted)
+        {
+            // Symmetric guard with stagingInfo.isDir(); skip the swap if a regular file occupies the mod slot.
+            if (!finalInfo.isDir())
+            {
+                CONSOLE_PRINT("Manifest final path is not a directory, skipping: " + finalAbs, GameConsole::eERROR);
+                continue;
+            }
+            // Loop suffix defends against duplicate manifest entries for the same finalRel sharing one isoStamp.
+            backupAbs = finalAbs + QStringLiteral(".bak-") + isoStamp;
+            for (qint32 n = 1; QFileInfo::exists(backupAbs); ++n)
+            {
+                backupAbs = finalAbs + QStringLiteral(".bak-") + isoStamp + QStringLiteral("-") + QString::number(n);
+            }
             if (!QDir().rename(finalAbs, backupAbs))
             {
                 CONSOLE_PRINT("Failed to back up existing mod folder: " + finalAbs + " -> " + backupAbs, GameConsole::eERROR);
@@ -670,9 +826,16 @@ void Filesupport::executePendingModSyncManifest(const QString & installRoot, con
         if (!QDir().rename(stagingAbs, finalAbs))
         {
             CONSOLE_PRINT("Failed to swap staging into place: " + stagingAbs + " -> " + finalAbs, GameConsole::eERROR);
+            // Roll the backup back so the active mod folder is not left missing.
+            if (finalExisted && !QDir().rename(backupAbs, finalAbs))
+            {
+                CONSOLE_PRINT("CRITICAL: rollback also failed; mod folder is at " + backupAbs, GameConsole::eERROR);
+            }
             continue;
         }
         CONSOLE_PRINT("Mod sync applied: " + finalRel, GameConsole::eINFO);
+        applied.append(finalRel);
     }
     QFile::remove(path);
+    return applied;
 }

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -639,11 +639,76 @@ void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupK
     const auto entries = modsDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
     QMap<QString, QList<QFileInfo>> backupsByMod;
     const QDateTime cutoff = QDateTime::currentDateTime().addSecs(-3600);
+    // Match only exact slice-2-generated shapes; substring matching would catch legitimate mod folder names.
+    auto matchStagingShape = [](const QString & name, QString & outPrefix) -> bool
+    {
+        const qint32 idx = name.lastIndexOf(QStringLiteral(".sync-staging-"));
+        if (idx <= 0)
+        {
+            return false;
+        }
+        const QString prefix = name.left(idx);
+        const QString suffix = name.mid(idx + QStringLiteral(".sync-staging-").size());
+        if (suffix.isEmpty() || !validateModPath(QStringLiteral("mods/") + prefix))
+        {
+            return false;
+        }
+        for (const QChar c : suffix)
+        {
+            if (c < QChar('0') || c > QChar('9'))
+            {
+                return false;
+            }
+        }
+        outPrefix = prefix;
+        return true;
+    };
+    auto matchBackupShape = [](const QString & name, QString & outPrefix) -> bool
+    {
+        const qint32 idx = name.lastIndexOf(QStringLiteral(".bak-"));
+        if (idx <= 0)
+        {
+            return false;
+        }
+        const QString prefix = name.left(idx);
+        const QString suffix = name.mid(idx + QStringLiteral(".bak-").size());
+        if (!validateModPath(QStringLiteral("mods/") + prefix))
+        {
+            return false;
+        }
+        // Generated suffix is exactly yyyyMMdd-HHmmsszzzZ (19 chars) with optional -<digits> collision counter.
+        if (suffix.size() < 19)
+        {
+            return false;
+        }
+        auto isDigit = [](QChar c) { return c >= QChar('0') && c <= QChar('9'); };
+        for (qint32 i = 0; i < 8; ++i)
+        {
+            if (!isDigit(suffix[i])) return false;
+        }
+        if (suffix[8] != QChar('-')) return false;
+        for (qint32 i = 9; i < 18; ++i)
+        {
+            if (!isDigit(suffix[i])) return false;
+        }
+        if (suffix[18] != QChar('Z')) return false;
+        if (suffix.size() > 19)
+        {
+            // Collision-counter form requires `-<digits>` after the timestamp; bare `-` is invalid.
+            if (suffix[19] != QChar('-') || suffix.size() < 21) return false;
+            for (qint32 i = 20; i < suffix.size(); ++i)
+            {
+                if (!isDigit(suffix[i])) return false;
+            }
+        }
+        outPrefix = prefix;
+        return true;
+    };
     for (const auto & entry : entries)
     {
         const QString name = entry.fileName();
-        const qint32 stagingIdx = name.indexOf(QStringLiteral(".sync-staging-"));
-        if (stagingIdx > 0)
+        QString prefix;
+        if (matchStagingShape(name, prefix))
         {
             // Mtime fallback heuristic; cheap, no platform-specific PID liveness check.
             if (entry.lastModified() < cutoff)
@@ -653,10 +718,9 @@ void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupK
             }
             continue;
         }
-        const qint32 bakIdx = name.indexOf(QStringLiteral(".bak-"));
-        if (bakIdx > 0)
+        if (matchBackupShape(name, prefix))
         {
-            backupsByMod[name.left(bakIdx)].append(entry);
+            backupsByMod[prefix].append(entry);
         }
     }
     for (auto iter = backupsByMod.begin(); iter != backupsByMod.end(); ++iter)

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -4,6 +4,12 @@
 
 #include <QDirIterator>
 #include <QCoreApplication>
+#include <QDateTime>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
 #include <QSet>
 
 const char* const Filesupport::LIST_FILENAME_ENDING = ".bl";
@@ -231,4 +237,442 @@ Filesupport::StringList Filesupport::readList(const QString & file)
         CONSOLE_PRINT("Unable to open file: " + file + " using empty list", GameConsole::eWARNING);
     }
     return ret;
+}
+
+namespace
+{
+    constexpr qint32 kModSyncDisabled = 1;
+    constexpr qint32 kModSyncUnknownMod = 2;
+    constexpr qint32 kModSyncSizeCapExceeded = 3;
+    constexpr qint32 kModSyncFileCountCapExceeded = 4;
+    constexpr qint32 kModSyncInvalidPath = 5;
+    constexpr qint32 kModSyncInternalError = 6;
+
+    bool segmentClean(const QString & seg)
+    {
+        static const QSet<QChar> kInvalid = {
+            QChar('<'), QChar('>'), QChar(':'), QChar('"'),
+            QChar('|'), QChar('?'), QChar('*'),
+        };
+        if (seg.isEmpty() || seg == QStringLiteral(".") || seg == QStringLiteral(".."))
+        {
+            return false;
+        }
+        if (seg.endsWith(QChar('.')) || seg.endsWith(QChar(' ')))
+        {
+            return false;
+        }
+        for (const QChar c : seg)
+        {
+            if (c.unicode() < 0x20 || c.unicode() == 0x7F)
+            {
+                return false;
+            }
+            if (kInvalid.contains(c))
+            {
+                return false;
+            }
+        }
+        static const QSet<QString> kReserved = {
+            QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
+            QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
+            QStringLiteral("COM0"), QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
+            QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"),
+            QStringLiteral("COM8"), QStringLiteral("COM9"),
+            QStringLiteral("LPT0"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
+            QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
+            QStringLiteral("LPT8"), QStringLiteral("LPT9"),
+        };
+        const qint32 dotIdx = seg.indexOf(QChar('.'));
+        const QString basename = (dotIdx >= 0) ? seg.left(dotIdx) : seg;
+        if (kReserved.contains(basename.toUpper()))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    QString joinPath(const QString & a, const QString & b)
+    {
+        if (a.isEmpty())
+        {
+            return b;
+        }
+        if (a.endsWith(QChar('/')))
+        {
+            return a + b;
+        }
+        return a + QChar('/') + b;
+    }
+}
+
+bool Filesupport::validateRelativeFilePath(const QString & relPath, qint32 maxLen)
+{
+    if (relPath.isEmpty() || relPath.size() > maxLen)
+    {
+        return false;
+    }
+    if (relPath.startsWith(QChar('/')) || relPath.contains(QChar('\\')))
+    {
+        return false;
+    }
+    if (relPath.size() >= 2 && relPath[1] == QChar(':'))
+    {
+        return false;
+    }
+    const QStringList segments = relPath.split(QChar('/'));
+    for (const auto & seg : segments)
+    {
+        if (!segmentClean(seg))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & installRoot, const QString & modPath, const ModSyncCaps & caps)
+{
+    ModSyncPackage pkg;
+    if (!validateModPath(modPath))
+    {
+        pkg.rejectReason = kModSyncInvalidPath;
+        return pkg;
+    }
+    const QString modRoot = joinPath(installRoot, modPath);
+    QDir modDir(modRoot);
+    if (!modDir.exists())
+    {
+        pkg.rejectReason = kModSyncUnknownMod;
+        return pkg;
+    }
+    QMap<QString, QByteArray> files;
+    qint64 uncompressedTotal = 0;
+    qint32 fileCount = 0;
+    QDirIterator it(modRoot, QDir::Files | QDir::NoSymLinks, QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        const QString absolute = it.next();
+        const QString rel = QDir(modRoot).relativeFilePath(absolute);
+        // Filter VCS metadata, build artefacts, and our own staging/backup dirs.
+        if (rel.startsWith(QStringLiteral(".git/")) ||
+            rel.startsWith(QStringLiteral(".svn/")) ||
+            rel.startsWith(QStringLiteral("__pycache__/")) ||
+            rel.contains(QStringLiteral(".sync-staging-")) ||
+            rel.contains(QStringLiteral(".bak-")))
+        {
+            continue;
+        }
+        if (!validateRelativeFilePath(rel, caps.relPathMaxLen))
+        {
+            pkg.rejectReason = kModSyncInvalidPath;
+            return pkg;
+        }
+        QFile f(absolute);
+        if (!f.open(QIODevice::ReadOnly))
+        {
+            pkg.rejectReason = kModSyncInternalError;
+            return pkg;
+        }
+        const qint64 size = f.size();
+        if (size > caps.perModBytes)
+        {
+            pkg.rejectReason = kModSyncSizeCapExceeded;
+            return pkg;
+        }
+        uncompressedTotal += size;
+        if (uncompressedTotal > caps.perModBytes)
+        {
+            pkg.rejectReason = kModSyncSizeCapExceeded;
+            return pkg;
+        }
+        ++fileCount;
+        if (fileCount > caps.fileCountMax)
+        {
+            pkg.rejectReason = kModSyncFileCountCapExceeded;
+            return pkg;
+        }
+        files.insert(rel, f.readAll());
+        f.close();
+    }
+    QByteArray serialized;
+    {
+        QDataStream stream(&serialized, QIODevice::WriteOnly);
+        stream.setVersion(QDataStream::Version::Qt_6_5);
+        writeMap(stream, files);
+    }
+    pkg.declaredUncompressedSize = static_cast<qint32>(serialized.size());
+    pkg.compressedBlob = qCompress(serialized);
+    pkg.fileCount = fileCount;
+    if (pkg.compressedBlob.size() > caps.perModBytes)
+    {
+        pkg.rejectReason = kModSyncSizeCapExceeded;
+        pkg.compressedBlob.clear();
+        return pkg;
+    }
+    return pkg;
+}
+
+QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & compressedBlob, qint32 declaredUncompressedSize, const ModSyncCaps & caps, qint32 & rejectReason)
+{
+    rejectReason = 0;
+    QMap<QString, QByteArray> files;
+    if (compressedBlob.size() > caps.perModBytes)
+    {
+        rejectReason = kModSyncSizeCapExceeded;
+        return files;
+    }
+    if (declaredUncompressedSize <= 0 || declaredUncompressedSize > caps.perModBytes)
+    {
+        rejectReason = kModSyncSizeCapExceeded;
+        return files;
+    }
+    const QByteArray serialized = qUncompress(compressedBlob);
+    if (serialized.isEmpty() || serialized.size() != declaredUncompressedSize)
+    {
+        rejectReason = kModSyncInternalError;
+        return files;
+    }
+    QByteArray mut = serialized;
+    QDataStream stream(&mut, QIODevice::ReadOnly);
+    stream.setVersion(QDataStream::Version::Qt_6_5);
+    auto map = readMap<QString, QByteArray, QMap>(stream);
+    if (stream.status() != QDataStream::Ok)
+    {
+        rejectReason = kModSyncInternalError;
+        return files;
+    }
+    qint32 fileCount = 0;
+    qint64 uncompressedTotal = 0;
+    for (auto iter = map.constBegin(); iter != map.constEnd(); ++iter)
+    {
+        if (!validateRelativeFilePath(iter.key(), caps.relPathMaxLen))
+        {
+            rejectReason = kModSyncInvalidPath;
+            files.clear();
+            return files;
+        }
+        if (iter.value().size() > caps.perModBytes)
+        {
+            rejectReason = kModSyncSizeCapExceeded;
+            files.clear();
+            return files;
+        }
+        uncompressedTotal += iter.value().size();
+        if (uncompressedTotal > caps.perModBytes)
+        {
+            rejectReason = kModSyncSizeCapExceeded;
+            files.clear();
+            return files;
+        }
+        ++fileCount;
+        if (fileCount > caps.fileCountMax)
+        {
+            rejectReason = kModSyncFileCountCapExceeded;
+            files.clear();
+            return files;
+        }
+    }
+    files = map;
+    return files;
+}
+
+QString Filesupport::stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, qint32 & rejectReason)
+{
+    rejectReason = 0;
+    if (!validateModPath(modPath))
+    {
+        rejectReason = kModSyncInvalidPath;
+        return QString();
+    }
+    const qint64 pid = QCoreApplication::applicationPid();
+    const QString stagingPath = joinPath(installRoot, modPath) + QStringLiteral(".sync-staging-") + QString::number(pid);
+    QDir stagingDir(stagingPath);
+    if (stagingDir.exists())
+    {
+        stagingDir.removeRecursively();
+    }
+    if (!QDir().mkpath(stagingPath))
+    {
+        rejectReason = kModSyncInternalError;
+        return QString();
+    }
+    for (auto iter = files.constBegin(); iter != files.constEnd(); ++iter)
+    {
+        const QString full = joinPath(stagingPath, iter.key());
+        const QFileInfo fi(full);
+        if (!QDir().mkpath(fi.absolutePath()))
+        {
+            QDir(stagingPath).removeRecursively();
+            rejectReason = kModSyncInternalError;
+            return QString();
+        }
+        QSaveFile f(full);
+        if (!f.open(QIODevice::WriteOnly))
+        {
+            QDir(stagingPath).removeRecursively();
+            rejectReason = kModSyncInternalError;
+            return QString();
+        }
+        f.write(iter.value());
+        if (!f.commit())
+        {
+            QDir(stagingPath).removeRecursively();
+            rejectReason = kModSyncInternalError;
+            return QString();
+        }
+    }
+    return stagingPath;
+}
+
+void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupKeep)
+{
+    const QString modsRoot = joinPath(installRoot, QStringLiteral("mods"));
+    QDir modsDir(modsRoot);
+    if (!modsDir.exists())
+    {
+        return;
+    }
+    const auto entries = modsDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    QMap<QString, QList<QFileInfo>> backupsByMod;
+    const QDateTime cutoff = QDateTime::currentDateTime().addSecs(-3600);
+    for (const auto & entry : entries)
+    {
+        const QString name = entry.fileName();
+        const qint32 stagingIdx = name.indexOf(QStringLiteral(".sync-staging-"));
+        if (stagingIdx > 0)
+        {
+            // Mtime fallback heuristic; cheap, no platform-specific PID liveness check.
+            if (entry.lastModified() < cutoff)
+            {
+                CONSOLE_PRINT("Reaping stale staging dir: " + entry.absoluteFilePath(), GameConsole::eINFO);
+                QDir(entry.absoluteFilePath()).removeRecursively();
+            }
+            continue;
+        }
+        const qint32 bakIdx = name.indexOf(QStringLiteral(".bak-"));
+        if (bakIdx > 0)
+        {
+            backupsByMod[name.left(bakIdx)].append(entry);
+        }
+    }
+    for (auto iter = backupsByMod.begin(); iter != backupsByMod.end(); ++iter)
+    {
+        auto & list = iter.value();
+        if (list.size() <= backupKeep)
+        {
+            continue;
+        }
+        std::sort(list.begin(), list.end(), [](const QFileInfo & a, const QFileInfo & b)
+        {
+            return a.lastModified() > b.lastModified();
+        });
+        for (qint32 i = backupKeep; i < list.size(); ++i)
+        {
+            CONSOLE_PRINT("Pruning old mod-sync backup: " + list[i].absoluteFilePath(), GameConsole::eINFO);
+            QDir(list[i].absoluteFilePath()).removeRecursively();
+        }
+    }
+}
+
+QString Filesupport::pendingModSyncManifestPath(const QString & userDataPath)
+{
+    return joinPath(userDataPath, QStringLiteral(".pending-mod-sync.json"));
+}
+
+bool Filesupport::writePendingModSyncManifest(const QString & userDataPath, const QList<QPair<QString, QString>> & swaps)
+{
+    QJsonArray jsonSwaps;
+    for (const auto & pair : swaps)
+    {
+        QJsonObject entry;
+        entry.insert(QStringLiteral("staging"), pair.first);
+        entry.insert(QStringLiteral("final"), pair.second);
+        jsonSwaps.append(entry);
+    }
+    QJsonObject root;
+    root.insert(QStringLiteral("version"), 1);
+    root.insert(QStringLiteral("swaps"), jsonSwaps);
+    const QString path = pendingModSyncManifestPath(userDataPath);
+    QSaveFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+    {
+        CONSOLE_PRINT("Failed to open pending mod-sync manifest for write: " + path, GameConsole::eERROR);
+        return false;
+    }
+    f.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+    if (!f.commit())
+    {
+        CONSOLE_PRINT("Failed to commit pending mod-sync manifest: " + path, GameConsole::eERROR);
+        return false;
+    }
+    return true;
+}
+
+void Filesupport::executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath)
+{
+    const QString path = pendingModSyncManifestPath(userDataPath);
+    QFile f(path);
+    if (!f.exists())
+    {
+        return;
+    }
+    if (!f.open(QIODevice::ReadOnly))
+    {
+        CONSOLE_PRINT("Pending mod-sync manifest exists but cannot be read: " + path, GameConsole::eERROR);
+        return;
+    }
+    const QByteArray data = f.readAll();
+    f.close();
+    QJsonParseError parseErr;
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &parseErr);
+    if (parseErr.error != QJsonParseError::NoError || !doc.isObject())
+    {
+        CONSOLE_PRINT("Pending mod-sync manifest is invalid JSON: " + parseErr.errorString(), GameConsole::eERROR);
+        QFile::remove(path);
+        return;
+    }
+    const QJsonObject root = doc.object();
+    if (root.value(QStringLiteral("version")).toInt(0) != 1)
+    {
+        CONSOLE_PRINT("Pending mod-sync manifest has unknown version, discarding", GameConsole::eERROR);
+        QFile::remove(path);
+        return;
+    }
+    const QJsonArray swaps = root.value(QStringLiteral("swaps")).toArray();
+    const QString isoStamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
+    for (const auto & v : swaps)
+    {
+        const QJsonObject entry = v.toObject();
+        const QString stagingRel = entry.value(QStringLiteral("staging")).toString();
+        const QString finalRel = entry.value(QStringLiteral("final")).toString();
+        if (!validateModPath(finalRel))
+        {
+            CONSOLE_PRINT("Manifest entry has invalid final path, skipping: " + finalRel, GameConsole::eERROR);
+            continue;
+        }
+        const QString stagingAbs = joinPath(installRoot, stagingRel);
+        const QString finalAbs = joinPath(installRoot, finalRel);
+        if (!QFileInfo::exists(stagingAbs))
+        {
+            CONSOLE_PRINT("Manifest staging missing, skipping: " + stagingAbs, GameConsole::eERROR);
+            continue;
+        }
+        if (QFileInfo::exists(finalAbs))
+        {
+            const QString backupAbs = finalAbs + QStringLiteral(".bak-") + isoStamp;
+            if (!QDir().rename(finalAbs, backupAbs))
+            {
+                CONSOLE_PRINT("Failed to back up existing mod folder: " + finalAbs + " -> " + backupAbs, GameConsole::eERROR);
+                continue;
+            }
+        }
+        if (!QDir().rename(stagingAbs, finalAbs))
+        {
+            CONSOLE_PRINT("Failed to swap staging into place: " + stagingAbs + " -> " + finalAbs, GameConsole::eERROR);
+            continue;
+        }
+        CONSOLE_PRINT("Mod sync applied: " + finalRel, GameConsole::eINFO);
+    }
+    QFile::remove(path);
 }

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -54,13 +54,38 @@ void Filesupport::addHash(QCryptographicHash & hash, const QString & folder, con
     }
 }
 
-QByteArray Filesupport::getRuntimeHash(const QStringList & mods)
+QByteArray Filesupport::getLegacyRuntimeHash(const QStringList & mods)
 {
     QStringList folders = mods;
     folders.append("resources/scripts");
     folders.append("resources/aidata");
     QStringList filter = {"*.js", "*.csv"};
     return getHash(filter, folders);
+}
+
+QByteArray Filesupport::hashSingleFolder(const QString & folder, const QStringList & filter)
+{
+    return getHash(filter, QStringList{folder});
+}
+
+QMap<QString, QByteArray> Filesupport::getPerModHashes(const QStringList & mods)
+{
+    const QStringList filter = {"*.js", "*.csv"};
+    QMap<QString, QByteArray> result;
+    for (const auto & mod : std::as_const(mods))
+    {
+        result.insert(mod, hashSingleFolder(mod, filter));
+    }
+    return result;
+}
+
+QMap<QString, QByteArray> Filesupport::getResourceFolderHashes()
+{
+    const QStringList filter = {"*.js", "*.csv"};
+    QMap<QString, QByteArray> result;
+    result.insert(QStringLiteral("resources/scripts"), hashSingleFolder(QStringLiteral("resources/scripts"), filter));
+    result.insert(QStringLiteral("resources/aidata"), hashSingleFolder(QStringLiteral("resources/aidata"), filter));
+    return result;
 }
 
 void Filesupport::writeByteArray(QDataStream& stream, const QByteArray& array)

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -348,14 +348,16 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
         pkg.rejectReason = kModSyncUnknownMod;
         return pkg;
     }
+    // Resolve to an absolute root once; QDir::relativeFilePath short-circuits to verbatim when either operand is relative.
+    const QDir absModDir(modDir.absolutePath());
     QMap<QString, QByteArray> files;
     qint64 uncompressedTotal = 0;
     qint32 fileCount = 0;
     QDirIterator it(modRoot, QDir::Files | QDir::NoSymLinks, QDirIterator::Subdirectories);
     while (it.hasNext())
     {
-        const QString absolute = it.next();
-        const QString rel = QDir(modRoot).relativeFilePath(absolute);
+        const QString absolute = QFileInfo(it.next()).absoluteFilePath();
+        const QString rel = absModDir.relativeFilePath(absolute);
         const QStringList relSegs = rel.split(QChar('/'));
         const QString basename = relSegs.isEmpty() ? rel : relSegs.last();
         // Segment-based filter; substrings would false-positive legit filenames containing .bak- or .sync-staging-.

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -4,6 +4,7 @@
 
 #include <QDirIterator>
 #include <QCoreApplication>
+#include <QSet>
 
 const char* const Filesupport::LIST_FILENAME_ENDING = ".bl";
 
@@ -86,6 +87,72 @@ QMap<QString, QByteArray> Filesupport::getResourceFolderHashes()
     result.insert(QStringLiteral("resources/scripts"), hashSingleFolder(QStringLiteral("resources/scripts"), filter));
     result.insert(QStringLiteral("resources/aidata"), hashSingleFolder(QStringLiteral("resources/aidata"), filter));
     return result;
+}
+
+bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
+{
+    if (modPath.isEmpty() || modPath.size() > maxLen)
+    {
+        return false;
+    }
+    if (!modPath.startsWith(QStringLiteral("mods/")))
+    {
+        return false;
+    }
+    if (modPath.contains(QChar('\\')))
+    {
+        return false;
+    }
+    const QStringList segments = modPath.split(QChar('/'));
+    if (segments.size() != 2)
+    {
+        return false;
+    }
+    static const QSet<QChar> kInvalidChars = {
+        QChar('<'), QChar('>'), QChar(':'), QChar('"'),
+        QChar('|'), QChar('?'), QChar('*'),
+    };
+    for (const auto & segment : segments)
+    {
+        if (segment.isEmpty() || segment == QStringLiteral(".") || segment == QStringLiteral(".."))
+        {
+            return false;
+        }
+        // Windows strips trailing dots and spaces at create time; rejecting them avoids name collisions.
+        if (segment.endsWith(QChar('.')) || segment.endsWith(QChar(' ')))
+        {
+            return false;
+        }
+        for (const QChar c : segment)
+        {
+            if (c.unicode() < 0x20 || c.unicode() == 0x7F)
+            {
+                return false;
+            }
+            if (kInvalidChars.contains(c))
+            {
+                return false;
+            }
+        }
+    }
+    static const QSet<QString> kReservedNames = {
+        QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
+        QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
+        QStringLiteral("COM0"), QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
+        QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"),
+        QStringLiteral("COM8"), QStringLiteral("COM9"),
+        QStringLiteral("LPT0"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
+        QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
+        QStringLiteral("LPT8"), QStringLiteral("LPT9"),
+    };
+    const QString & nameSegment = segments[1];
+    const qint32 dotIdx = nameSegment.indexOf(QChar('.'));
+    const QString basename = (dotIdx >= 0) ? nameSegment.left(dotIdx) : nameSegment;
+    if (kReservedNames.contains(basename.toUpper()))
+    {
+        return false;
+    }
+    return true;
 }
 
 void Filesupport::writeByteArray(QDataStream& stream, const QByteArray& array)

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -202,6 +202,104 @@ namespace
         }
         return a + QChar('/') + b;
     }
+
+    // Deliberately ASCII-only; QChar::isDigit also accepts non-ASCII Unicode digits.
+    bool isAsciiDigit(QChar c)
+    {
+        return c >= QChar('0') && c <= QChar('9');
+    }
+
+    // Validate length header before allocation; defends against decompression-bomb pre-allocation in operator>>.
+    bool readBoundedBytes(QDataStream & stream, QByteArray & out, qint64 maxBytes)
+    {
+        quint32 declared = 0;
+        stream >> declared;
+        if (stream.status() != QDataStream::Ok)
+        {
+            return false;
+        }
+        if (declared == kQDataStreamNullSentinel)
+        {
+            out.clear();
+            return true;
+        }
+        if (declared > static_cast<quint32>(maxBytes))
+        {
+            return false;
+        }
+        out.resize(static_cast<qint32>(declared));
+        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
+        {
+            return false;
+        }
+        return true;
+    }
+
+    // Match only exact slice-2-generated shapes; substring matching would catch legitimate mod folder names.
+    bool matchStagingShape(const QString & name, QString & outPrefix)
+    {
+        const qint32 idx = name.lastIndexOf(kSyncStagingMarker);
+        if (idx <= 0)
+        {
+            return false;
+        }
+        const QString prefix = name.left(idx);
+        const QString suffix = name.mid(idx + kSyncStagingMarker.size());
+        if (suffix.isEmpty() || !Filesupport::validateModPath(QStringLiteral("mods/") + prefix))
+        {
+            return false;
+        }
+        for (const QChar c : suffix)
+        {
+            if (!isAsciiDigit(c))
+            {
+                return false;
+            }
+        }
+        outPrefix = prefix;
+        return true;
+    }
+
+    bool matchBackupShape(const QString & name, QString & outPrefix)
+    {
+        const qint32 idx = name.lastIndexOf(QStringLiteral(".bak-"));
+        if (idx <= 0)
+        {
+            return false;
+        }
+        const QString prefix = name.left(idx);
+        const QString suffix = name.mid(idx + QStringLiteral(".bak-").size());
+        if (!Filesupport::validateModPath(QStringLiteral("mods/") + prefix))
+        {
+            return false;
+        }
+        // Generated suffix is exactly yyyyMMdd-HHmmsszzzZ with optional -<digits> collision counter.
+        if (suffix.size() < kBakTimestampLength)
+        {
+            return false;
+        }
+        for (qint32 i = 0; i < kBakTimestampDateLength; ++i)
+        {
+            if (!isAsciiDigit(suffix[i])) return false;
+        }
+        if (suffix[kBakTimestampDateLength] != QChar('-')) return false;
+        for (qint32 i = kBakTimestampDateLength + 1; i < kBakTimestampDateTimeLength; ++i)
+        {
+            if (!isAsciiDigit(suffix[i])) return false;
+        }
+        if (suffix[kBakTimestampDateTimeLength] != QChar('Z')) return false;
+        if (suffix.size() > kBakTimestampLength)
+        {
+            // Collision-counter form requires `-<digits>` after the timestamp; bare `-` is invalid.
+            if (suffix[kBakTimestampLength] != QChar('-') || suffix.size() < kBakCollisionCounterMinLength) return false;
+            for (qint32 i = kBakTimestampLength + 1; i < suffix.size(); ++i)
+            {
+                if (!isAsciiDigit(suffix[i])) return false;
+            }
+        }
+        outPrefix = prefix;
+        return true;
+    }
 }
 
 bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
@@ -496,42 +594,17 @@ QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & 
         rejectReason = kModSyncFileCountCapExceeded;
         return QMap<QString, QByteArray>();
     }
-    // Validate length header before allocation; defends against decompression-bomb pre-allocation in operator>>.
-    auto readBoundedBytes = [&stream](QByteArray & out, qint64 maxBytes) -> bool
-    {
-        quint32 declared = 0;
-        stream >> declared;
-        if (stream.status() != QDataStream::Ok)
-        {
-            return false;
-        }
-        if (declared == kQDataStreamNullSentinel)
-        {
-            out.clear();
-            return true;
-        }
-        if (declared > static_cast<quint32>(maxBytes))
-        {
-            return false;
-        }
-        out.resize(static_cast<qint32>(declared));
-        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
-        {
-            return false;
-        }
-        return true;
-    };
     qint64 uncompressedTotal = 0;
     for (qint32 i = 0; i < mapSize; ++i)
     {
         QByteArray keyUtf8;
         QByteArray value;
-        if (!readBoundedBytes(keyUtf8, static_cast<qint64>(caps.relPathMaxLen) * kUtf8MaxBytesPerCodePoint))
+        if (!readBoundedBytes(stream, keyUtf8, static_cast<qint64>(caps.relPathMaxLen) * kUtf8MaxBytesPerCodePoint))
         {
             rejectReason = kModSyncInvalidPath;
             return QMap<QString, QByteArray>();
         }
-        if (!readBoundedBytes(value, caps.perModBytes))
+        if (!readBoundedBytes(stream, value, caps.perModBytes))
         {
             rejectReason = kModSyncSizeCapExceeded;
             return QMap<QString, QByteArray>();
@@ -644,71 +717,6 @@ void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupK
     const auto entries = modsDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
     QMap<QString, QList<QFileInfo>> backupsByMod;
     const QDateTime cutoff = QDateTime::currentDateTime().addSecs(-3600);
-    // Match only exact slice-2-generated shapes; substring matching would catch legitimate mod folder names.
-    auto matchStagingShape = [](const QString & name, QString & outPrefix) -> bool
-    {
-        const qint32 idx = name.lastIndexOf(kSyncStagingMarker);
-        if (idx <= 0)
-        {
-            return false;
-        }
-        const QString prefix = name.left(idx);
-        const QString suffix = name.mid(idx + kSyncStagingMarker.size());
-        if (suffix.isEmpty() || !validateModPath(QStringLiteral("mods/") + prefix))
-        {
-            return false;
-        }
-        for (const QChar c : suffix)
-        {
-            if (c < QChar('0') || c > QChar('9'))
-            {
-                return false;
-            }
-        }
-        outPrefix = prefix;
-        return true;
-    };
-    auto matchBackupShape = [](const QString & name, QString & outPrefix) -> bool
-    {
-        const qint32 idx = name.lastIndexOf(QStringLiteral(".bak-"));
-        if (idx <= 0)
-        {
-            return false;
-        }
-        const QString prefix = name.left(idx);
-        const QString suffix = name.mid(idx + QStringLiteral(".bak-").size());
-        if (!validateModPath(QStringLiteral("mods/") + prefix))
-        {
-            return false;
-        }
-        // Generated suffix is exactly yyyyMMdd-HHmmsszzzZ with optional -<digits> collision counter.
-        if (suffix.size() < kBakTimestampLength)
-        {
-            return false;
-        }
-        auto isDigit = [](QChar c) { return c >= QChar('0') && c <= QChar('9'); };
-        for (qint32 i = 0; i < kBakTimestampDateLength; ++i)
-        {
-            if (!isDigit(suffix[i])) return false;
-        }
-        if (suffix[kBakTimestampDateLength] != QChar('-')) return false;
-        for (qint32 i = kBakTimestampDateLength + 1; i < kBakTimestampDateTimeLength; ++i)
-        {
-            if (!isDigit(suffix[i])) return false;
-        }
-        if (suffix[kBakTimestampDateTimeLength] != QChar('Z')) return false;
-        if (suffix.size() > kBakTimestampLength)
-        {
-            // Collision-counter form requires `-<digits>` after the timestamp; bare `-` is invalid.
-            if (suffix[kBakTimestampLength] != QChar('-') || suffix.size() < kBakCollisionCounterMinLength) return false;
-            for (qint32 i = kBakTimestampLength + 1; i < suffix.size(); ++i)
-            {
-                if (!isDigit(suffix[i])) return false;
-            }
-        }
-        outPrefix = prefix;
-        return true;
-    };
     for (const auto & entry : entries)
     {
         const QString name = entry.fileName();
@@ -845,7 +853,7 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
         bool suffixDigits = !suffix.isEmpty();
         for (const QChar c : suffix)
         {
-            if (c < QChar('0') || c > QChar('9'))
+            if (!isAsciiDigit(c))
             {
                 suffixDigits = false;
                 break;

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -230,31 +230,10 @@ namespace
         return c >= QChar('0') && c <= QChar('9');
     }
 
-    // Validate length header before allocation; defends against decompression-bomb pre-allocation in operator>>.
-    bool readBoundedBytes(QDataStream & stream, QByteArray & out, qint64 maxBytes)
-    {
-        quint32 declared = 0;
-        stream >> declared;
-        if (stream.status() != QDataStream::Ok)
-        {
-            return false;
-        }
-        if (declared == kQDataStreamNullSentinel)
-        {
-            out.clear();
-            return true;
-        }
-        if (declared > static_cast<quint32>(maxBytes))
-        {
-            return false;
-        }
-        out.resize(static_cast<qint32>(declared));
-        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
-        {
-            return false;
-        }
-        return true;
-    }
+    // QDataStream::operator>> pre-resizes to the declared length; the bounded readers reject the header before allocation.
+    constexpr quint32 kInt32MaxAsU32 = 0x7FFFFFFFu;
+    constexpr qint32 kBytesPerUtf16CodeUnit = 2;
+    constexpr qint32 kBitsPerByte = 8;
 
     // Match only exact slice-2-generated shapes; substring matching would catch legitimate mod folder names.
     bool matchStagingShape(const QString & name, QString & outPrefix)
@@ -568,6 +547,74 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
         return pkg;
     }
     return pkg;
+}
+
+bool Filesupport::readBoundedBytes(QDataStream & stream, QByteArray & out, qint64 maxBytes)
+{
+    if (maxBytes < 0)
+    {
+        return false;
+    }
+    quint32 declared = 0;
+    stream >> declared;
+    if (stream.status() != QDataStream::Ok)
+    {
+        return false;
+    }
+    if (declared == kQDataStreamNullSentinel)
+    {
+        out.clear();
+        return true;
+    }
+    if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes)
+    {
+        return false;
+    }
+    out.resize(static_cast<qint32>(declared));
+    if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
+    {
+        return false;
+    }
+    return true;
+}
+
+bool Filesupport::readBoundedString(QDataStream & stream, QString & out, qint32 maxChars)
+{
+    if (maxChars < 0)
+    {
+        return false;
+    }
+    quint32 declared = 0;
+    stream >> declared;
+    if (stream.status() != QDataStream::Ok)
+    {
+        return false;
+    }
+    if (declared == kQDataStreamNullSentinel)
+    {
+        out.clear();
+        return true;
+    }
+    const qint64 maxBytes = static_cast<qint64>(maxChars) * kBytesPerUtf16CodeUnit;
+    if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes || (declared % kBytesPerUtf16CodeUnit) != 0)
+    {
+        return false;
+    }
+    QByteArray buf;
+    buf.resize(static_cast<qint32>(declared));
+    if (buf.size() > 0 && stream.readRawData(buf.data(), buf.size()) != buf.size())
+    {
+        return false;
+    }
+    const qint32 codeUnits = buf.size() / kBytesPerUtf16CodeUnit;
+    out.resize(codeUnits);
+    const uchar * src = reinterpret_cast<const uchar *>(buf.constData());
+    // Wire is big-endian; build each code unit explicitly to skip platform-endian conversion in fromUtf16.
+    for (qint32 i = 0; i < codeUnits; ++i)
+    {
+        out[i] = QChar(static_cast<ushort>((src[i * kBytesPerUtf16CodeUnit] << kBitsPerByte) | src[i * kBytesPerUtf16CodeUnit + 1]));
+    }
+    return true;
 }
 
 QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & compressedBlob, qint32 declaredUncompressedSize, const ModSyncCaps & caps, qint32 & rejectReason)

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -131,6 +131,8 @@ namespace
     constexpr qint64 kMaxPendingManifestBytes = 1 * 1024 * 1024;
     // Cap raw bytes a rejoin manifest may occupy on disk before being treated as corrupt.
     constexpr qint64 kMaxRejoinManifestBytes = 4 * 1024;
+    // Marker between mod folder name and PID during atomic swap; stageModSync, reapModSyncFolders, and the staging scanners must agree on the exact string.
+    const auto kSyncStagingMarker = QStringLiteral(".sync-staging-");
 
     bool segmentClean(const QString & seg)
     {
@@ -362,7 +364,7 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
                 break;
             }
             const bool isDir = (si + 1 < relSegs.size());
-            if (isDir && (seg.startsWith(QStringLiteral(".sync-staging-")) || seg.startsWith(QStringLiteral(".bak-"))))
+            if (isDir && (seg.startsWith(kSyncStagingMarker) || seg.startsWith(QStringLiteral(".bak-"))))
             {
                 cruft = true;
                 break;
@@ -578,7 +580,7 @@ QString Filesupport::stageModSync(const QString & installRoot, const QString & m
         }
     }
     const qint64 pid = QCoreApplication::applicationPid();
-    const QString stagingRel = modPath + QStringLiteral(".sync-staging-") + QString::number(pid);
+    const QString stagingRel = modPath + kSyncStagingMarker + QString::number(pid);
     const QString stagingAbs = joinPath(installRoot, stagingRel);
     QDir stagingDir(stagingAbs);
     if (stagingDir.exists() && !stagingDir.removeRecursively())
@@ -633,13 +635,13 @@ void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupK
     // Match only exact slice-2-generated shapes; substring matching would catch legitimate mod folder names.
     auto matchStagingShape = [](const QString & name, QString & outPrefix) -> bool
     {
-        const qint32 idx = name.lastIndexOf(QStringLiteral(".sync-staging-"));
+        const qint32 idx = name.lastIndexOf(kSyncStagingMarker);
         if (idx <= 0)
         {
             return false;
         }
         const QString prefix = name.left(idx);
-        const QString suffix = name.mid(idx + QStringLiteral(".sync-staging-").size());
+        const QString suffix = name.mid(idx + kSyncStagingMarker.size());
         if (suffix.isEmpty() || !validateModPath(QStringLiteral("mods/") + prefix))
         {
             return false;
@@ -821,7 +823,7 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
             continue;
         }
         // Pin staging to the exact shape stageModSync writes: <finalRel>.sync-staging-<digits>.
-        const QString stagingPrefix = finalRel + QStringLiteral(".sync-staging-");
+        const QString stagingPrefix = finalRel + kSyncStagingMarker;
         if (!stagingRel.startsWith(stagingPrefix))
         {
             CONSOLE_PRINT("Manifest staging path shape mismatch, skipping: " + stagingRel, GameConsole::eERROR);

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -97,6 +97,77 @@ QMap<QString, QByteArray> Filesupport::getResourceFolderHashes()
     return result;
 }
 
+namespace
+{
+    // reject codes
+    constexpr qint32 kModSyncDisabled = 1;
+    constexpr qint32 kModSyncUnknownMod = 2;
+    constexpr qint32 kModSyncSizeCapExceeded = 3;
+    constexpr qint32 kModSyncFileCountCapExceeded = 4;
+    constexpr qint32 kModSyncInvalidPath = 5;
+    constexpr qint32 kModSyncInternalError = 6;
+    constexpr qint32 kModPathSegments = 2;
+    constexpr qint32 kSpaceCodePoint = 0x20;
+    constexpr qint32 kDelCodePoint = 0x7F;
+
+    bool segmentClean(const QString & seg)
+    {
+        static const QSet<QChar> kInvalid = {
+            QChar('<'), QChar('>'), QChar(':'), QChar('"'),
+            QChar('|'), QChar('?'), QChar('*'),
+        };
+        if (seg.isEmpty() || seg == QStringLiteral(".") || seg == QStringLiteral(".."))
+        {
+            return false;
+        }
+        if (seg.endsWith(QChar('.')) || seg.endsWith(QChar(' ')))
+        {
+            return false;
+        }
+        for (const QChar c : seg)
+        {
+            if (c.unicode() < kSpaceCodePoint || c.unicode() == kDelCodePoint)
+            {
+                return false;
+            }
+            if (kInvalid.contains(c))
+            {
+                return false;
+            }
+        }
+        static const QSet<QString> kReserved = {
+            QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
+            QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
+            QStringLiteral("COM0"), QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
+            QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"),
+            QStringLiteral("COM8"), QStringLiteral("COM9"),
+            QStringLiteral("LPT0"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
+            QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
+            QStringLiteral("LPT8"), QStringLiteral("LPT9"),
+        };
+        const qint32 dotIdx = seg.indexOf(QChar('.'));
+        const QString basename = (dotIdx >= 0) ? seg.left(dotIdx) : seg;
+        if (kReserved.contains(basename.toUpper()))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    QString joinPath(const QString & a, const QString & b)
+    {
+        if (a.isEmpty())
+        {
+            return b;
+        }
+        if (a.endsWith(QChar('/')))
+        {
+            return a + b;
+        }
+        return a + QChar('/') + b;
+    }
+}
+
 bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
 {
     if (modPath.isEmpty() || modPath.size() > maxLen)
@@ -116,50 +187,14 @@ bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
     {
         return false;
     }
-    static const QSet<QChar> kInvalidChars = {
-        QChar('<'), QChar('>'), QChar(':'), QChar('"'),
-        QChar('|'), QChar('?'), QChar('*'),
-    };
-    for (const auto & segment : segments)
+    for (const auto & seg : segments)
     {
-        if (segment.isEmpty() || segment == QStringLiteral(".") || segment == QStringLiteral(".."))
+        if (!segmentClean(seg))
         {
             return false;
         }
-        // Windows strips trailing dots and spaces at create time; rejecting them avoids name collisions.
-        if (segment.endsWith(QChar('.')) || segment.endsWith(QChar(' ')))
-        {
-            return false;
-        }
-        for (const QChar c : segment)
-        {
-            if (c.unicode() < kSpaceCodePoint || c.unicode() == kDelCodePoint)
-            {
-                return false;
-            }
-            if (kInvalidChars.contains(c))
-            {
-                return false;
-            }
-        }
     }
-    static const QSet<QString> kReservedNames = {
-        QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
-        QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
-        QStringLiteral("COM0"), QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
-        QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"),
-        QStringLiteral("COM8"), QStringLiteral("COM9"),
-        QStringLiteral("LPT0"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
-        QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
-        QStringLiteral("LPT8"), QStringLiteral("LPT9"),
-    };
-    const QString & nameSegment = segments[1];
-    const qint32 dotIdx = nameSegment.indexOf(QChar('.'));
-    const QString basename = (dotIdx >= 0) ? nameSegment.left(dotIdx) : nameSegment;
-    if (kReservedNames.contains(basename.toUpper()))
-    {
-        return false;
-    }
+    
     return true;
 }
 
@@ -241,76 +276,6 @@ Filesupport::StringList Filesupport::readList(const QString & file)
     return ret;
 }
 
-namespace
-{
-    // reject codes
-    constexpr qint32 kModSyncDisabled = 1;
-    constexpr qint32 kModSyncUnknownMod = 2;
-    constexpr qint32 kModSyncSizeCapExceeded = 3;
-    constexpr qint32 kModSyncFileCountCapExceeded = 4;
-    constexpr qint32 kModSyncInvalidPath = 5;
-    constexpr qint32 kModSyncInternalError = 6;
-    constexpr qint32 kModPathSegments = 2;
-    constexpr qint32 kSpaceCodePoint = 0x20;
-    constexpr qint32 kDelCodePoint = 0x7F;
-
-    bool segmentClean(const QString & seg)
-    {
-        static const QSet<QChar> kInvalid = {
-            QChar('<'), QChar('>'), QChar(':'), QChar('"'),
-            QChar('|'), QChar('?'), QChar('*'),
-        };
-        if (seg.isEmpty() || seg == QStringLiteral(".") || seg == QStringLiteral(".."))
-        {
-            return false;
-        }
-        if (seg.endsWith(QChar('.')) || seg.endsWith(QChar(' ')))
-        {
-            return false;
-        }
-        for (const QChar c : seg)
-        {
-            if (c.unicode() < kSpaceCodePoint || c.unicode() == kDelCodePoint)
-            {
-                return false;
-            }
-            if (kInvalid.contains(c))
-            {
-                return false;
-            }
-        }
-        static const QSet<QString> kReserved = {
-            QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
-            QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
-            QStringLiteral("COM0"), QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
-            QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"),
-            QStringLiteral("COM8"), QStringLiteral("COM9"),
-            QStringLiteral("LPT0"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
-            QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
-            QStringLiteral("LPT8"), QStringLiteral("LPT9"),
-        };
-        const qint32 dotIdx = seg.indexOf(QChar('.'));
-        const QString basename = (dotIdx >= 0) ? seg.left(dotIdx) : seg;
-        if (kReserved.contains(basename.toUpper()))
-        {
-            return false;
-        }
-        return true;
-    }
-
-    QString joinPath(const QString & a, const QString & b)
-    {
-        if (a.isEmpty())
-        {
-            return b;
-        }
-        if (a.endsWith(QChar('/')))
-        {
-            return a + b;
-        }
-        return a + QChar('/') + b;
-    }
-}
 
 bool Filesupport::validateRelativeFilePath(const QString & relPath, qint32 maxLen)
 {

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -109,6 +109,18 @@ namespace
     constexpr qint32 kModPathSegments = 2;
     constexpr qint32 kSpaceCodePoint = 0x20;
     constexpr qint32 kDelCodePoint = 0x7F;
+    // QDataStream encodes a null QByteArray or QString length as 0xFFFFFFFFu.
+    constexpr quint32 kQDataStreamNullSentinel = 0xFFFFFFFFu;
+    // TCP/UDP port number ceiling (16-bit unsigned per RFC 793).
+    constexpr qint32 kTcpPortMax = 0xFFFF;
+    // Backup folder timestamp format yyyyMMdd-HHmmsszzzZ; the validator below cross-checks size against these.
+    constexpr qint32 kBakTimestampLength = 19;
+    constexpr qint32 kBakTimestampDateLength = 8;        // yyyyMMdd
+    constexpr qint32 kBakTimestampDateTimeLength = 18;   // yyyyMMdd-HHmmsszzz
+    // Same-second collision suffix is "-<digits>" appended; minimum total length is timestamp + separator + one digit.
+    constexpr qint32 kBakCollisionCounterMinLength = 21;
+    static_assert(kBakTimestampLength == kBakTimestampDateTimeLength + 1, "Z follows datetime");
+    static_assert(kBakCollisionCounterMinLength == kBakTimestampLength + 2, "min counter = timestamp + '-' + 1 digit");
 
     bool segmentClean(const QString & seg)
     {
@@ -471,7 +483,7 @@ QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & 
         {
             return false;
         }
-        if (declared == 0xFFFFFFFFu)
+        if (declared == kQDataStreamNullSentinel)
         {
             out.clear();
             return true;
@@ -648,27 +660,27 @@ void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupK
         {
             return false;
         }
-        // Generated suffix is exactly yyyyMMdd-HHmmsszzzZ (19 chars) with optional -<digits> collision counter.
-        if (suffix.size() < 19)
+        // Generated suffix is exactly yyyyMMdd-HHmmsszzzZ with optional -<digits> collision counter.
+        if (suffix.size() < kBakTimestampLength)
         {
             return false;
         }
         auto isDigit = [](QChar c) { return c >= QChar('0') && c <= QChar('9'); };
-        for (qint32 i = 0; i < 8; ++i)
+        for (qint32 i = 0; i < kBakTimestampDateLength; ++i)
         {
             if (!isDigit(suffix[i])) return false;
         }
-        if (suffix[8] != QChar('-')) return false;
-        for (qint32 i = 9; i < 18; ++i)
+        if (suffix[kBakTimestampDateLength] != QChar('-')) return false;
+        for (qint32 i = kBakTimestampDateLength + 1; i < kBakTimestampDateTimeLength; ++i)
         {
             if (!isDigit(suffix[i])) return false;
         }
-        if (suffix[18] != QChar('Z')) return false;
-        if (suffix.size() > 19)
+        if (suffix[kBakTimestampDateTimeLength] != QChar('Z')) return false;
+        if (suffix.size() > kBakTimestampLength)
         {
             // Collision-counter form requires `-<digits>` after the timestamp; bare `-` is invalid.
-            if (suffix[19] != QChar('-') || suffix.size() < 21) return false;
-            for (qint32 i = 20; i < suffix.size(); ++i)
+            if (suffix[kBakTimestampLength] != QChar('-') || suffix.size() < kBakCollisionCounterMinLength) return false;
+            for (qint32 i = kBakTimestampLength + 1; i < suffix.size(); ++i)
             {
                 if (!isDigit(suffix[i])) return false;
             }
@@ -959,7 +971,7 @@ Filesupport::RejoinManifest Filesupport::consumeRejoinManifest(const QString & u
     const QString host = root.value(QStringLiteral("host")).toString();
     const qint32 port = root.value(QStringLiteral("port")).toInt(0);
     const qint64 timestamp = root.value(QStringLiteral("timestamp")).toVariant().toLongLong();
-    if (host.isEmpty() || port <= 0 || port > 0xFFFF)
+    if (host.isEmpty() || port <= 0 || port > kTcpPortMax)
     {
         CONSOLE_PRINT("Rejoin manifest has invalid host or port, discarding", GameConsole::eERROR);
         return result;

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -112,7 +112,7 @@ bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
         return false;
     }
     const QStringList segments = modPath.split(QChar('/'));
-    if (segments.size() != 2)
+    if (segments.size() != kModPathSegments)
     {
         return false;
     }
@@ -133,7 +133,7 @@ bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
         }
         for (const QChar c : segment)
         {
-            if (c.unicode() < 0x20 || c.unicode() == 0x7F)
+            if (c.unicode() < kSpaceCodePoint || c.unicode() == kDelCodePoint)
             {
                 return false;
             }
@@ -243,12 +243,16 @@ Filesupport::StringList Filesupport::readList(const QString & file)
 
 namespace
 {
+    // reject codes
     constexpr qint32 kModSyncDisabled = 1;
     constexpr qint32 kModSyncUnknownMod = 2;
     constexpr qint32 kModSyncSizeCapExceeded = 3;
     constexpr qint32 kModSyncFileCountCapExceeded = 4;
     constexpr qint32 kModSyncInvalidPath = 5;
     constexpr qint32 kModSyncInternalError = 6;
+    constexpr qint32 kModPathSegments = 2;
+    constexpr qint32 kSpaceCodePoint = 0x20;
+    constexpr qint32 kDelCodePoint = 0x7F;
 
     bool segmentClean(const QString & seg)
     {
@@ -266,7 +270,7 @@ namespace
         }
         for (const QChar c : seg)
         {
-            if (c.unicode() < 0x20 || c.unicode() == 0x7F)
+            if (c.unicode() < kSpaceCodePoint || c.unicode() == kDelCodePoint)
             {
                 return false;
             }

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -148,6 +148,12 @@ namespace
     const auto kJsonKeyHost = QStringLiteral("host");
     const auto kJsonKeyPort = QStringLiteral("port");
     const auto kJsonKeyTimestamp = QStringLiteral("timestamp");
+    constexpr qint32 kPendingManifestVersion = 1;
+    constexpr qint32 kRejoinManifestVersion = 1;
+    // Length of a Windows drive-letter prefix ("C:").
+    constexpr qint32 kWindowsDrivePrefixLength = 2;
+    // Staging dirs older than this are presumed orphaned by a dead process and reaped.
+    constexpr qint64 kStaleStagingMaxAgeSecs = 3600;
 
     // Bounds of the documented COM<n>/LPT<n> digit suffix. https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
     constexpr qint32 kDosDeviceMinDigit = 1;
@@ -436,7 +442,7 @@ bool Filesupport::validateRelativeFilePath(const QString & relPath, qint32 maxLe
     {
         return false;
     }
-    if (relPath.size() >= 2 && relPath[1] == QChar(':'))
+    if (relPath.size() >= kWindowsDrivePrefixLength && relPath[1] == QChar(':'))
     {
         return false;
     }
@@ -731,7 +737,7 @@ void Filesupport::reapModSyncFolders(const QString & installRoot, qint32 backupK
     }
     const auto entries = modsDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
     QMap<QString, QList<QFileInfo>> backupsByMod;
-    const QDateTime cutoff = QDateTime::currentDateTime().addSecs(-3600);
+    const QDateTime cutoff = QDateTime::currentDateTime().addSecs(-kStaleStagingMaxAgeSecs);
     for (const auto & entry : entries)
     {
         const QString name = entry.fileName();
@@ -786,7 +792,7 @@ bool Filesupport::writePendingModSyncManifest(const QString & userDataPath, cons
         jsonSwaps.append(entry);
     }
     QJsonObject root;
-    root.insert(kJsonKeyVersion, 1);
+    root.insert(kJsonKeyVersion, kPendingManifestVersion);
     root.insert(kJsonKeySwaps, jsonSwaps);
     const QString path = pendingModSyncManifestPath(userDataPath);
     QSaveFile f(path);
@@ -836,7 +842,7 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
         return applied;
     }
     const QJsonObject root = doc.object();
-    if (root.value(kJsonKeyVersion).toInt(0) != 1)
+    if (root.value(kJsonKeyVersion).toInt(0) != kPendingManifestVersion)
     {
         CONSOLE_PRINT("Pending mod-sync manifest has unknown version, discarding", GameConsole::eERROR);
         QFile::remove(path);
@@ -953,7 +959,7 @@ bool Filesupport::writeRejoinManifest(const QString & userDataPath, const QStrin
         return false;
     }
     QJsonObject root;
-    root.insert(kJsonKeyVersion, 1);
+    root.insert(kJsonKeyVersion, kRejoinManifestVersion);
     root.insert(kJsonKeyHost, host);
     root.insert(kJsonKeyPort, static_cast<qint32>(port));
     root.insert(kJsonKeyTimestamp, QDateTime::currentSecsSinceEpoch());
@@ -1005,7 +1011,7 @@ Filesupport::RejoinManifest Filesupport::consumeRejoinManifest(const QString & u
         return result;
     }
     const QJsonObject root = doc.object();
-    if (root.value(kJsonKeyVersion).toInt(0) != 1)
+    if (root.value(kJsonKeyVersion).toInt(0) != kRejoinManifestVersion)
     {
         CONSOLE_PRINT("Rejoin manifest unknown version, discarding", GameConsole::eERROR);
         return result;

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -121,6 +121,16 @@ namespace
     constexpr qint32 kBakCollisionCounterMinLength = 21;
     static_assert(kBakTimestampLength == kBakTimestampDateTimeLength + 1, "Z follows datetime");
     static_assert(kBakCollisionCounterMinLength == kBakTimestampLength + 2, "min counter = timestamp + '-' + 1 digit");
+    // zlib best-speed; few percent worse ratio on text-heavy mods, big drop in host CPU stall.
+    constexpr qint32 kQCompressBestSpeedLevel = 1;
+    // qCompress prefixes a 4-byte big-endian uncompressed-size header used for pre-allocation; gate it before qUncompress to bound memory.
+    constexpr qint32 kQCompressFramingHeaderBytes = 4;
+    // UTF-8 encodes a Unicode code point in at most 4 bytes.
+    constexpr qint32 kUtf8MaxBytesPerCodePoint = 4;
+    // Cap raw bytes a pending mod-sync manifest may occupy on disk before being treated as corrupt.
+    constexpr qint64 kMaxPendingManifestBytes = 1 * 1024 * 1024;
+    // Cap raw bytes a rejoin manifest may occupy on disk before being treated as corrupt.
+    constexpr qint64 kMaxRejoinManifestBytes = 4 * 1024;
 
     bool segmentClean(const QString & seg)
     {
@@ -416,8 +426,7 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
         return pkg;
     }
     pkg.declaredUncompressedSize = static_cast<qint32>(serialized.size());
-    // Level 1 = zlib best-speed; ~few percent worse ratio on text-heavy mods, big drop in host CPU stall.
-    pkg.compressedBlob = qCompress(serialized, 1);
+    pkg.compressedBlob = qCompress(serialized, kQCompressBestSpeedLevel);
     pkg.fileCount = fileCount;
     if (pkg.compressedBlob.size() > caps.perModBytes)
     {
@@ -447,8 +456,7 @@ QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & 
         rejectReason = kModSyncSizeCapExceeded;
         return files;
     }
-    // qCompress prefixes a 4-byte big-endian uncompressed size used for pre-allocation; gate it before qUncompress to bound memory.
-    if (compressedBlob.size() < 4)
+    if (compressedBlob.size() < kQCompressFramingHeaderBytes)
     {
         rejectReason = kModSyncInternalError;
         return files;
@@ -504,8 +512,7 @@ QMap<QString, QByteArray> Filesupport::extractModSyncPackage(const QByteArray & 
     {
         QByteArray keyUtf8;
         QByteArray value;
-        // UTF-8 max 4 bytes per code point; cap key bytes at relPathMaxLen * 4.
-        if (!readBoundedBytes(keyUtf8, static_cast<qint64>(caps.relPathMaxLen) * 4))
+        if (!readBoundedBytes(keyUtf8, static_cast<qint64>(caps.relPathMaxLen) * kUtf8MaxBytesPerCodePoint))
         {
             rejectReason = kModSyncInvalidPath;
             return QMap<QString, QByteArray>();
@@ -770,8 +777,7 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
         return applied;
     }
     // Oversize manifest is treated as corrupt or tampered: discard rather than try to parse partial state.
-    constexpr qint64 kMaxManifestBytes = 1 * 1024 * 1024;
-    if (f.size() > kMaxManifestBytes)
+    if (f.size() > kMaxPendingManifestBytes)
     {
         CONSOLE_PRINT("Pending mod-sync manifest oversize, discarding: " + path, GameConsole::eERROR);
         QFile::remove(path);
@@ -939,7 +945,6 @@ Filesupport::RejoinManifest Filesupport::consumeRejoinManifest(const QString & u
     {
         return result;
     }
-    constexpr qint64 kMaxRejoinManifestBytes = 4 * 1024;
     if (f.size() > kMaxRejoinManifestBytes)
     {
         CONSOLE_PRINT("Rejoin manifest oversize, discarding: " + path, GameConsole::eERROR);

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -134,6 +134,27 @@ namespace
     // Marker between mod folder name and PID during atomic swap; stageModSync, reapModSyncFolders, and the staging scanners must agree on the exact string.
     const auto kSyncStagingMarker = QStringLiteral(".sync-staging-");
 
+    // Bounds of the documented COM<n>/LPT<n> digit suffix. https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    constexpr qint32 kDosDeviceMinDigit = 1;
+    constexpr qint32 kDosDeviceMaxDigit = 9;
+
+    QSet<QString> buildReservedDosDeviceNames()
+    {
+        QSet<QString> names = {
+            QStringLiteral("CON"), QStringLiteral("PRN"),
+            QStringLiteral("AUX"), QStringLiteral("NUL"),
+            QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
+            QStringLiteral("COM\u00B9"), QStringLiteral("COM\u00B2"), QStringLiteral("COM\u00B3"),
+            QStringLiteral("LPT\u00B9"), QStringLiteral("LPT\u00B2"), QStringLiteral("LPT\u00B3"),
+        };
+        for (qint32 i = kDosDeviceMinDigit; i <= kDosDeviceMaxDigit; ++i)
+        {
+            names.insert(QStringLiteral("COM") + QString::number(i));
+            names.insert(QStringLiteral("LPT") + QString::number(i));
+        }
+        return names;
+    }
+
     bool segmentClean(const QString & seg)
     {
         static const QSet<QChar> kInvalid = {
@@ -159,16 +180,7 @@ namespace
                 return false;
             }
         }
-        static const QSet<QString> kReserved = {
-            QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
-            QStringLiteral("CONIN$"), QStringLiteral("CONOUT$"),
-            QStringLiteral("COM0"), QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
-            QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"),
-            QStringLiteral("COM8"), QStringLiteral("COM9"),
-            QStringLiteral("LPT0"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
-            QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
-            QStringLiteral("LPT8"), QStringLiteral("LPT9"),
-        };
+        static const QSet<QString> kReserved = buildReservedDosDeviceNames();
         const qint32 dotIdx = seg.indexOf(QChar('.'));
         const QString basename = (dotIdx >= 0) ? seg.left(dotIdx) : seg;
         if (kReserved.contains(basename.toUpper()))

--- a/coreengine/filesupport.cpp
+++ b/coreengine/filesupport.cpp
@@ -63,13 +63,19 @@ void Filesupport::addHash(QCryptographicHash & hash, const QString & folder, con
     }
 }
 
+namespace
+{
+    const QStringList kHashFileFilter = {QStringLiteral("*.js"), QStringLiteral("*.csv")};
+    const auto kResourceScriptsFolder = QStringLiteral("resources/scripts");
+    const auto kResourceAidataFolder = QStringLiteral("resources/aidata");
+}
+
 QByteArray Filesupport::getLegacyRuntimeHash(const QStringList & mods)
 {
     QStringList folders = mods;
-    folders.append("resources/scripts");
-    folders.append("resources/aidata");
-    QStringList filter = {"*.js", "*.csv"};
-    return getHash(filter, folders);
+    folders.append(kResourceScriptsFolder);
+    folders.append(kResourceAidataFolder);
+    return getHash(kHashFileFilter, folders);
 }
 
 QByteArray Filesupport::hashSingleFolder(const QString & folder, const QStringList & filter)
@@ -79,21 +85,19 @@ QByteArray Filesupport::hashSingleFolder(const QString & folder, const QStringLi
 
 QMap<QString, QByteArray> Filesupport::getPerModHashes(const QStringList & mods)
 {
-    const QStringList filter = {"*.js", "*.csv"};
     QMap<QString, QByteArray> result;
     for (const auto & mod : std::as_const(mods))
     {
-        result.insert(mod, hashSingleFolder(mod, filter));
+        result.insert(mod, hashSingleFolder(mod, kHashFileFilter));
     }
     return result;
 }
 
 QMap<QString, QByteArray> Filesupport::getResourceFolderHashes()
 {
-    const QStringList filter = {"*.js", "*.csv"};
     QMap<QString, QByteArray> result;
-    result.insert(QStringLiteral("resources/scripts"), hashSingleFolder(QStringLiteral("resources/scripts"), filter));
-    result.insert(QStringLiteral("resources/aidata"), hashSingleFolder(QStringLiteral("resources/aidata"), filter));
+    result.insert(kResourceScriptsFolder, hashSingleFolder(kResourceScriptsFolder, kHashFileFilter));
+    result.insert(kResourceAidataFolder, hashSingleFolder(kResourceAidataFolder, kHashFileFilter));
     return result;
 }
 
@@ -133,6 +137,17 @@ namespace
     constexpr qint64 kMaxRejoinManifestBytes = 4 * 1024;
     // Marker between mod folder name and PID during atomic swap; stageModSync, reapModSyncFolders, and the staging scanners must agree on the exact string.
     const auto kSyncStagingMarker = QStringLiteral(".sync-staging-");
+    // Marker between mod folder name and timestamp on pre-swap backups; stageModSync, reapModSyncFolders, and matchBackupShape must agree on the exact string.
+    const auto kBakMarker = QStringLiteral(".bak-");
+    const auto kModsPrefix = QStringLiteral("mods/");
+    // Pending-mod-sync and rejoin manifest JSON keys.
+    const auto kJsonKeyVersion = QStringLiteral("version");
+    const auto kJsonKeySwaps = QStringLiteral("swaps");
+    const auto kJsonKeyStaging = QStringLiteral("staging");
+    const auto kJsonKeyFinal = QStringLiteral("final");
+    const auto kJsonKeyHost = QStringLiteral("host");
+    const auto kJsonKeyPort = QStringLiteral("port");
+    const auto kJsonKeyTimestamp = QStringLiteral("timestamp");
 
     // Bounds of the documented COM<n>/LPT<n> digit suffix. https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
     constexpr qint32 kDosDeviceMinDigit = 1;
@@ -245,7 +260,7 @@ namespace
         }
         const QString prefix = name.left(idx);
         const QString suffix = name.mid(idx + kSyncStagingMarker.size());
-        if (suffix.isEmpty() || !Filesupport::validateModPath(QStringLiteral("mods/") + prefix))
+        if (suffix.isEmpty() || !Filesupport::validateModPath(kModsPrefix + prefix))
         {
             return false;
         }
@@ -262,14 +277,14 @@ namespace
 
     bool matchBackupShape(const QString & name, QString & outPrefix)
     {
-        const qint32 idx = name.lastIndexOf(QStringLiteral(".bak-"));
+        const qint32 idx = name.lastIndexOf(kBakMarker);
         if (idx <= 0)
         {
             return false;
         }
         const QString prefix = name.left(idx);
-        const QString suffix = name.mid(idx + QStringLiteral(".bak-").size());
-        if (!Filesupport::validateModPath(QStringLiteral("mods/") + prefix))
+        const QString suffix = name.mid(idx + kBakMarker.size());
+        if (!Filesupport::validateModPath(kModsPrefix + prefix))
         {
             return false;
         }
@@ -308,7 +323,7 @@ bool Filesupport::validateModPath(const QString & modPath, qint32 maxLen)
     {
         return false;
     }
-    if (!modPath.startsWith(QStringLiteral("mods/")))
+    if (!modPath.startsWith(kModsPrefix))
     {
         return false;
     }
@@ -474,7 +489,7 @@ Filesupport::ModSyncPackage Filesupport::buildModSyncPackage(const QString & ins
                 break;
             }
             const bool isDir = (si + 1 < relSegs.size());
-            if (isDir && (seg.startsWith(kSyncStagingMarker) || seg.startsWith(QStringLiteral(".bak-"))))
+            if (isDir && (seg.startsWith(kSyncStagingMarker) || seg.startsWith(kBakMarker)))
             {
                 cruft = true;
                 break;
@@ -766,13 +781,13 @@ bool Filesupport::writePendingModSyncManifest(const QString & userDataPath, cons
     for (const auto & pair : swaps)
     {
         QJsonObject entry;
-        entry.insert(QStringLiteral("staging"), pair.first);
-        entry.insert(QStringLiteral("final"), pair.second);
+        entry.insert(kJsonKeyStaging, pair.first);
+        entry.insert(kJsonKeyFinal, pair.second);
         jsonSwaps.append(entry);
     }
     QJsonObject root;
-    root.insert(QStringLiteral("version"), 1);
-    root.insert(QStringLiteral("swaps"), jsonSwaps);
+    root.insert(kJsonKeyVersion, 1);
+    root.insert(kJsonKeySwaps, jsonSwaps);
     const QString path = pendingModSyncManifestPath(userDataPath);
     QSaveFile f(path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
@@ -821,13 +836,13 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
         return applied;
     }
     const QJsonObject root = doc.object();
-    if (root.value(QStringLiteral("version")).toInt(0) != 1)
+    if (root.value(kJsonKeyVersion).toInt(0) != 1)
     {
         CONSOLE_PRINT("Pending mod-sync manifest has unknown version, discarding", GameConsole::eERROR);
         QFile::remove(path);
         return applied;
     }
-    const QJsonArray swaps = root.value(QStringLiteral("swaps")).toArray();
+    const QJsonArray swaps = root.value(kJsonKeySwaps).toArray();
     // UTC + ms keeps backup names lexically sorted across DST and avoids same-second collision on rapid retries.
     const QString isoStamp = QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMdd-HHmmsszzzZ"));
     // Read the flag once before the swap loop so settings cannot drift mid-batch. Must be called after Settings::loadSettings has run its binding loop; today the boot order at settings.cpp:1557 satisfies that.
@@ -835,8 +850,8 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
     for (const auto & v : swaps)
     {
         const QJsonObject entry = v.toObject();
-        const QString stagingRel = entry.value(QStringLiteral("staging")).toString();
-        const QString finalRel = entry.value(QStringLiteral("final")).toString();
+        const QString stagingRel = entry.value(kJsonKeyStaging).toString();
+        const QString finalRel = entry.value(kJsonKeyFinal).toString();
         if (!validateModPath(finalRel))
         {
             CONSOLE_PRINT("Manifest entry has invalid final path, skipping: " + finalRel, GameConsole::eERROR);
@@ -890,10 +905,10 @@ QStringList Filesupport::executePendingModSyncManifest(const QString & installRo
                 continue;
             }
             // Loop suffix defends against duplicate manifest entries for the same finalRel sharing one isoStamp.
-            backupAbs = finalAbs + QStringLiteral(".bak-") + isoStamp;
+            backupAbs = finalAbs + kBakMarker + isoStamp;
             for (qint32 n = 1; QFileInfo::exists(backupAbs); ++n)
             {
-                backupAbs = finalAbs + QStringLiteral(".bak-") + isoStamp + QStringLiteral("-") + QString::number(n);
+                backupAbs = finalAbs + kBakMarker + isoStamp + QStringLiteral("-") + QString::number(n);
             }
             if (!QDir().rename(finalAbs, backupAbs))
             {
@@ -938,10 +953,10 @@ bool Filesupport::writeRejoinManifest(const QString & userDataPath, const QStrin
         return false;
     }
     QJsonObject root;
-    root.insert(QStringLiteral("version"), 1);
-    root.insert(QStringLiteral("host"), host);
-    root.insert(QStringLiteral("port"), static_cast<qint32>(port));
-    root.insert(QStringLiteral("timestamp"), QDateTime::currentSecsSinceEpoch());
+    root.insert(kJsonKeyVersion, 1);
+    root.insert(kJsonKeyHost, host);
+    root.insert(kJsonKeyPort, static_cast<qint32>(port));
+    root.insert(kJsonKeyTimestamp, QDateTime::currentSecsSinceEpoch());
     const QString path = rejoinManifestPath(userDataPath);
     QSaveFile f(path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
@@ -990,14 +1005,14 @@ Filesupport::RejoinManifest Filesupport::consumeRejoinManifest(const QString & u
         return result;
     }
     const QJsonObject root = doc.object();
-    if (root.value(QStringLiteral("version")).toInt(0) != 1)
+    if (root.value(kJsonKeyVersion).toInt(0) != 1)
     {
         CONSOLE_PRINT("Rejoin manifest unknown version, discarding", GameConsole::eERROR);
         return result;
     }
-    const QString host = root.value(QStringLiteral("host")).toString();
-    const qint32 port = root.value(QStringLiteral("port")).toInt(0);
-    const qint64 timestamp = root.value(QStringLiteral("timestamp")).toVariant().toLongLong();
+    const QString host = root.value(kJsonKeyHost).toString();
+    const qint32 port = root.value(kJsonKeyPort).toInt(0);
+    const qint64 timestamp = root.value(kJsonKeyTimestamp).toVariant().toLongLong();
     if (host.isEmpty() || port <= 0 || port > kTcpPortMax)
     {
         CONSOLE_PRINT("Rejoin manifest has invalid host or port, discarding", GameConsole::eERROR);

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -63,6 +63,18 @@ public:
     static bool writePendingModSyncManifest(const QString & userDataPath, const QList<QPair<QString, QString>> & swaps);
     // Returns the list of `final` paths that were successfully swapped in; slice 3 uses this to drive settings mutation.
     static QStringList executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath);
+
+    struct RejoinManifest
+    {
+        bool valid{false};
+        QString host;
+        quint16 port{0};
+        qint64 timestamp{0};
+    };
+    static QString rejoinManifestPath(const QString & userDataPath);
+    static bool writeRejoinManifest(const QString & userDataPath, const QString & host, quint16 port);
+    // Reads .rejoin.json, deletes the file, returns parsed contents. Caller decides freshness based on RejoinManifest::timestamp.
+    static RejoinManifest consumeRejoinManifest(const QString & userDataPath);
     /**
      * @brief writeByteArray
      * @param stream

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -6,6 +6,7 @@
 #include <QDataStream>
 #include <QCryptographicHash>
 #include <QMap>
+#include <QPair>
 
 class Filesupport final
 {
@@ -14,6 +15,21 @@ public:
     {
         QString name;
         QStringList items;
+    };
+    struct ModSyncCaps
+    {
+        qint32 perModBytes{64 * 1024 * 1024};
+        qint32 fileCountMax{5000};
+        qint32 relPathMaxLen{260};
+    };
+    // rejectReason values match NetworkCommands::ModSyncRejectReason; kept as qint32 to avoid
+    // pulling networkcommands.h into coreengine.
+    struct ModSyncPackage
+    {
+        QByteArray compressedBlob;
+        qint32 declaredUncompressedSize{0};
+        qint32 fileCount{0};
+        qint32 rejectReason{0};
     };
     static const char* const LIST_FILENAME_ENDING;
     static constexpr qint32 LegacyRuntimeHashSize = 64;
@@ -37,6 +53,14 @@ public:
     static QByteArray getHash(const QStringList & filter, const QStringList & folders);
     static void addHash(QCryptographicHash & hash, const QString & folder, const QStringList & filter);
     static bool validateModPath(const QString & modPath, qint32 maxLen = ModPathDefaultMaxLen);
+    static bool validateRelativeFilePath(const QString & relPath, qint32 maxLen);
+    static ModSyncPackage buildModSyncPackage(const QString & installRoot, const QString & modPath, const ModSyncCaps & caps);
+    static QMap<QString, QByteArray> extractModSyncPackage(const QByteArray & compressedBlob, qint32 declaredUncompressedSize, const ModSyncCaps & caps, qint32 & rejectReason);
+    static QString stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, qint32 & rejectReason);
+    static void reapModSyncFolders(const QString & installRoot, qint32 backupKeep = 3);
+    static QString pendingModSyncManifestPath(const QString & userDataPath);
+    static bool writePendingModSyncManifest(const QString & userDataPath, const QList<QPair<QString, QString>> & swaps);
+    static void executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath);
     /**
      * @brief writeByteArray
      * @param stream

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -18,7 +18,16 @@ public:
     static const char* const LIST_FILENAME_ENDING;
     static constexpr qint32 LegacyRuntimeHashSize = 64;
     // Old clients read this field as a QByteArray length, so versions must stay small and never collide with 64.
-    static constexpr qint32 CurrentHashPayloadVersion = 1;
+    static constexpr qint32 LegacyHashPayloadVersion = 1;
+    static constexpr qint32 CurrentHashPayloadVersion = 2;
+    static_assert(CurrentHashPayloadVersion != LegacyRuntimeHashSize, "sentinel collision with legacy hash size");
+    static_assert(CurrentHashPayloadVersion != LegacyHashPayloadVersion, "sentinel collision with legacy payload version");
+
+    // Bit 0 = slice-1 mod-sync wire format; future schema breakages claim new bits.
+    static constexpr quint32 CapabilityModSync = 0x00000001u;
+
+    static constexpr qint32 ModPathDefaultMaxLen = 260;
+
     Filesupport() = delete;
     ~Filesupport() = delete;
     static QByteArray getLegacyRuntimeHash(const QStringList & mods);
@@ -27,6 +36,7 @@ public:
     static QByteArray hashSingleFolder(const QString & folder, const QStringList & filter);
     static QByteArray getHash(const QStringList & filter, const QStringList & folders);
     static void addHash(QCryptographicHash & hash, const QString & folder, const QStringList & filter);
+    static bool validateModPath(const QString & modPath, qint32 maxLen = ModPathDefaultMaxLen);
     /**
      * @brief writeByteArray
      * @param stream

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -16,6 +16,9 @@ public:
         QStringList items;
     };
     static const char* const LIST_FILENAME_ENDING;
+    static constexpr qint32 LegacyRuntimeHashSize = 64;
+    // Old clients read this field as a QByteArray length, so versions must stay small and never collide with 64.
+    static constexpr qint32 CurrentHashPayloadVersion = 1;
     Filesupport() = delete;
     ~Filesupport() = delete;
     static QByteArray getLegacyRuntimeHash(const QStringList & mods);

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QDataStream>
 #include <QCryptographicHash>
+#include <QMap>
 
 class Filesupport final
 {
@@ -17,24 +18,11 @@ public:
     static const char* const LIST_FILENAME_ENDING;
     Filesupport() = delete;
     ~Filesupport() = delete;
-    /**
-     * @brief getRuntimeHash
-     * @return
-     */
-    static QByteArray getRuntimeHash(const QStringList & mods);
-    /**
-     * @brief getHash
-     * @param filter
-     * @param folders
-     * @return
-     */
+    static QByteArray getLegacyRuntimeHash(const QStringList & mods);
+    static QMap<QString, QByteArray> getPerModHashes(const QStringList & mods);
+    static QMap<QString, QByteArray> getResourceFolderHashes();
+    static QByteArray hashSingleFolder(const QString & folder, const QStringList & filter);
     static QByteArray getHash(const QStringList & filter, const QStringList & folders);
-    /**
-     * @brief addHash
-     * @param hash
-     * @param folder
-     * @param filter
-     */
     static void addHash(QCryptographicHash & hash, const QString & folder, const QStringList & filter);
     /**
      * @brief writeByteArray

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -22,8 +22,7 @@ public:
         qint32 fileCountMax{5000};
         qint32 relPathMaxLen{260};
     };
-    // rejectReason values match NetworkCommands::ModSyncRejectReason; kept as qint32 to avoid
-    // pulling networkcommands.h into coreengine.
+    // rejectReason matches NetworkCommands::ModSyncRejectReason; qint32 keeps coreengine decoupled from multiplayer/.
     struct ModSyncPackage
     {
         QByteArray compressedBlob;
@@ -56,11 +55,14 @@ public:
     static bool validateRelativeFilePath(const QString & relPath, qint32 maxLen);
     static ModSyncPackage buildModSyncPackage(const QString & installRoot, const QString & modPath, const ModSyncCaps & caps);
     static QMap<QString, QByteArray> extractModSyncPackage(const QByteArray & compressedBlob, qint32 declaredUncompressedSize, const ModSyncCaps & caps, qint32 & rejectReason);
-    static QString stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, qint32 & rejectReason);
+    // Returns staging path RELATIVE to installRoot on success (e.g. "mods/foo.sync-staging-12345"); the caller writes that into the manifest.
+    // `caps` re-validates relpath, file count, per-file and total bytes here as defense in depth; callers should still run extractModSyncPackage first.
+    static QString stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, const ModSyncCaps & caps, qint32 & rejectReason);
     static void reapModSyncFolders(const QString & installRoot, qint32 backupKeep = 3);
     static QString pendingModSyncManifestPath(const QString & userDataPath);
     static bool writePendingModSyncManifest(const QString & userDataPath, const QList<QPair<QString, QString>> & swaps);
-    static void executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath);
+    // Returns the list of `final` paths that were successfully swapped in; slice 3 uses this to drive settings mutation.
+    static QStringList executePendingModSyncManifest(const QString & installRoot, const QString & userDataPath);
     /**
      * @brief writeByteArray
      * @param stream

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -16,11 +16,18 @@ public:
         QString name;
         QStringList items;
     };
+    // Mod-sync cap defaults; Settings seeds its user-overridable values from these.
+    static constexpr qint32 ModSyncDefaultPerModBytes = 64 * 1024 * 1024;
+    static constexpr qint32 ModSyncDefaultTotalBytes = 256 * 1024 * 1024;
+    static constexpr qint32 ModSyncDefaultMaxFiles = 5000;
+    // Windows MAX_PATH legacy ceiling; deeper trees need a settings override.
+    static constexpr qint32 ModSyncDefaultMaxRelativePathLength = 260;
+    static constexpr qint32 ModSyncDefaultBackupKeep = 3;
     struct ModSyncCaps
     {
-        qint32 perModBytes{64 * 1024 * 1024};
-        qint32 fileCountMax{5000};
-        qint32 relPathMaxLen{260};
+        qint32 perModBytes{ModSyncDefaultPerModBytes};
+        qint32 fileCountMax{ModSyncDefaultMaxFiles};
+        qint32 relPathMaxLen{ModSyncDefaultMaxRelativePathLength};
     };
     // rejectReason matches NetworkCommands::ModSyncRejectReason; qint32 keeps coreengine decoupled from multiplayer/.
     struct ModSyncPackage
@@ -58,7 +65,7 @@ public:
     // Returns staging path RELATIVE to installRoot on success (e.g. "mods/foo.sync-staging-12345"); the caller writes that into the manifest.
     // `caps` re-validates relpath, file count, per-file and total bytes here as defense in depth; callers should still run extractModSyncPackage first.
     static QString stageModSync(const QString & installRoot, const QString & modPath, const QMap<QString, QByteArray> & files, const ModSyncCaps & caps, qint32 & rejectReason);
-    static void reapModSyncFolders(const QString & installRoot, qint32 backupKeep = 3);
+    static void reapModSyncFolders(const QString & installRoot, qint32 backupKeep = ModSyncDefaultBackupKeep);
     static QString pendingModSyncManifestPath(const QString & userDataPath);
     static bool writePendingModSyncManifest(const QString & userDataPath, const QList<QPair<QString, QString>> & swaps);
     // Returns the list of `final` paths that were successfully swapped in; slice 3 uses this to drive settings mutation.

--- a/coreengine/filesupport.h
+++ b/coreengine/filesupport.h
@@ -60,6 +60,9 @@ public:
     static void addHash(QCryptographicHash & hash, const QString & folder, const QStringList & filter);
     static bool validateModPath(const QString & modPath, qint32 maxLen = ModPathDefaultMaxLen);
     static bool validateRelativeFilePath(const QString & relPath, qint32 maxLen);
+    // Bounded QDataStream readers; validate the length header before allocation, defending against decompression-bomb pre-allocation in operator>>.
+    static bool readBoundedBytes(QDataStream & stream, QByteArray & out, qint64 maxBytes);
+    static bool readBoundedString(QDataStream & stream, QString & out, qint32 maxChars);
     static ModSyncPackage buildModSyncPackage(const QString & installRoot, const QString & modPath, const ModSyncCaps & caps);
     static QMap<QString, QByteArray> extractModSyncPackage(const QByteArray & compressedBlob, qint32 declaredUncompressedSize, const ModSyncCaps & caps, qint32 & rejectReason);
     // Returns staging path RELATIVE to installRoot on success (e.g. "mods/foo.sync-staging-12345"); the caller writes that into the manifest.

--- a/coreengine/mainapp.cpp
+++ b/coreengine/mainapp.cpp
@@ -60,6 +60,8 @@ Mainapp* Mainapp::m_pMainapp{nullptr};
 
 bool Mainapp::m_slave{false};
 bool Mainapp::m_trainingSession{false};
+QStringList Mainapp::m_restartArgv;
+QString Mainapp::m_rejoinPassword;
 const char* const Mainapp::GAME_CONTEXT = "GAME";
 
 Mainapp::Mainapp()
@@ -739,6 +741,26 @@ bool Mainapp::getSlave()
 void Mainapp::setSlave(bool slave)
 {
     m_slave = slave;
+}
+
+QStringList Mainapp::getRestartArgv()
+{
+    return m_restartArgv;
+}
+
+void Mainapp::setRestartArgv(const QStringList & argv)
+{
+    m_restartArgv = argv;
+}
+
+QString Mainapp::getRejoinPassword()
+{
+    return m_rejoinPassword;
+}
+
+void Mainapp::setRejoinPassword(const QString & password)
+{
+    m_rejoinPassword = password;
 }
 
 void Mainapp::showCrashReport(const QString & log)

--- a/coreengine/mainapp.h
+++ b/coreengine/mainapp.h
@@ -135,6 +135,11 @@ public:
      * @param slave
      */
     static void setSlave(bool slave);
+    // Argv passed to QProcess::startDetached when main() restarts after exit(1). Set this before exit(1) to thread args (e.g. --rejoin-password=...) into the child without persisting them to disk.
+    static QStringList getRestartArgv();
+    static void setRestartArgv(const QStringList & argv);
+    static QString getRejoinPassword();
+    static void setRejoinPassword(const QString & password);
     /**
      * @brief qsTr
      * @param text
@@ -311,6 +316,8 @@ private:
     static Mainapp* m_pMainapp;
     static bool m_slave;
     static bool m_trainingSession;
+    static QStringList m_restartArgv;
+    static QString m_rejoinPassword;
     QMutex m_crashMutex;
     spQThread m_Workerthread;
     spQThread m_Networkthread;

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -1092,6 +1092,34 @@ QStringList Settings::getActiveMods()
     return m_activeMods;
 }
 
+QString Settings::stageActiveModsForRestart(const QStringList & activeMods)
+{
+    Mainapp* pApp = Mainapp::getInstance();
+    if (pApp->getSlave() || Settings::getAiSlave() || !m_updateStep.isEmpty())
+    {
+        return QString();
+    }
+    QSettings settings(m_settingFile, QSettings::IniFormat);
+    settings.beginGroup("Mods");
+    const QString prior = settings.value("Mods", QString()).toString();
+    settings.setValue("Mods", getConfigString(activeMods));
+    settings.endGroup();
+    return prior;
+}
+
+void Settings::restoreActiveModsRaw(const QString & rawValue)
+{
+    Mainapp* pApp = Mainapp::getInstance();
+    if (pApp->getSlave() || Settings::getAiSlave() || !m_updateStep.isEmpty())
+    {
+        return;
+    }
+    QSettings settings(m_settingFile, QSettings::IniFormat);
+    settings.beginGroup("Mods");
+    settings.setValue("Mods", rawValue);
+    settings.endGroup();
+}
+
 void Settings::setActiveMods(const QStringList activeMods)
 {
     m_activeMods = activeMods;

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -311,6 +311,16 @@ void Settings::setModSyncMaxRelativePathLength(qint32 newValue)
     m_modSyncMaxRelativePathLength = newValue;
 }
 
+bool Settings::getModSyncKeepBackups() const
+{
+    return m_modSyncKeepBackups;
+}
+
+void Settings::setModSyncKeepBackups(bool newValue)
+{
+    m_modSyncKeepBackups = newValue;
+}
+
 QString Settings::getMailServerSendAddress()
 {
     return m_mailServerSendAddress;
@@ -1495,6 +1505,7 @@ void Settings::setup()
             MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxTotalBytes", &m_modSyncMaxTotalBytes, 256 * 1024 * 1024, 0, std::numeric_limits<qint32>::max()),
             MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxFiles", &m_modSyncMaxFiles, 5000, 0, std::numeric_limits<qint32>::max()),
             MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxRelativePathLength", &m_modSyncMaxRelativePathLength, 260, 1, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<bool>>("Network", "ModSyncKeepBackups", &m_modSyncKeepBackups, false, false, true),
             // mailing
             MemoryManagement::create<Value<QString>>("Mailing", "MailServerAddress", &m_mailServerAddress, "", "", ""),
             MemoryManagement::create<Value<quint16>>("Mailing", "MailServerPort", &m_mailServerPort, 0, 0, std::numeric_limits<quint16>::max()),
@@ -1544,7 +1555,8 @@ void Settings::loadSettings()
     setFramesPerSecond(m_framesPerSecond);
     // Apply any pending mod-sync swaps before setActiveMods, so just-synced folders are visible to its missing-folder pruning pass.
     Filesupport::executePendingModSyncManifest(m_userPath, m_userPath);
-    Filesupport::reapModSyncFolders(m_userPath);
+    // backupKeep follows ModSyncKeepBackups so a user who opted out reaps every leftover .bak (including ones that survived a prior post-swap removeRecursively failure).
+    Filesupport::reapModSyncFolders(m_userPath, m_modSyncKeepBackups ? 3 : 0);
     setActiveMods(m_activeMods);
     GameConsole::setLogLevel(m_defaultLogLevel);
     GameConsole::setActiveModules(m_defaultLogModuls);

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -260,6 +260,56 @@ void Settings::setServerPassword(const QString newServerPassword)
     m_serverPassword = newServerPassword;
 }
 
+bool Settings::getModSyncEnabled() const
+{
+    return m_modSyncEnabled;
+}
+
+void Settings::setModSyncEnabled(bool newModSyncEnabled)
+{
+    m_modSyncEnabled = newModSyncEnabled;
+}
+
+qint32 Settings::getModSyncMaxPerModBytes() const
+{
+    return m_modSyncMaxPerModBytes;
+}
+
+void Settings::setModSyncMaxPerModBytes(qint32 newValue)
+{
+    m_modSyncMaxPerModBytes = newValue;
+}
+
+qint32 Settings::getModSyncMaxTotalBytes() const
+{
+    return m_modSyncMaxTotalBytes;
+}
+
+void Settings::setModSyncMaxTotalBytes(qint32 newValue)
+{
+    m_modSyncMaxTotalBytes = newValue;
+}
+
+qint32 Settings::getModSyncMaxFiles() const
+{
+    return m_modSyncMaxFiles;
+}
+
+void Settings::setModSyncMaxFiles(qint32 newValue)
+{
+    m_modSyncMaxFiles = newValue;
+}
+
+qint32 Settings::getModSyncMaxRelativePathLength() const
+{
+    return m_modSyncMaxRelativePathLength;
+}
+
+void Settings::setModSyncMaxRelativePathLength(qint32 newValue)
+{
+    m_modSyncMaxRelativePathLength = newValue;
+}
+
 QString Settings::getMailServerSendAddress()
 {
     return m_mailServerSendAddress;
@@ -1044,6 +1094,8 @@ QStringList Settings::getActiveMods()
 void Settings::setActiveMods(const QStringList activeMods)
 {
     m_activeMods = activeMods;
+    // Rebuild versions so repeated setActiveMods calls stay aligned.
+    m_activeModVersions.clear();
     qint32 i = 0;
     while (i < m_activeMods.size())
     {
@@ -1402,6 +1454,11 @@ void Settings::setup()
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "SlaveDespawnTime", &m_slaveDespawnTime, std::chrono::seconds(60 * 60 * 24), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "SuspendedDespawnTime", &m_suspendedDespawnTime, std::chrono::seconds(60 * 60 * 24), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "ReplayDeleteTime", &m_replayDeleteTime, std::chrono::seconds(60 * 60 * 24 * 7), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
+            MemoryManagement::create<Value<bool>>("Network", "ModSyncEnabled", &m_modSyncEnabled, false, false, true),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxPerModBytes", &m_modSyncMaxPerModBytes, 64 * 1024 * 1024, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxTotalBytes", &m_modSyncMaxTotalBytes, 256 * 1024 * 1024, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxFiles", &m_modSyncMaxFiles, 5000, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxRelativePathLength", &m_modSyncMaxRelativePathLength, 260, 1, std::numeric_limits<qint32>::max()),
             // mailing
             MemoryManagement::create<Value<QString>>("Mailing", "MailServerAddress", &m_mailServerAddress, "", "", ""),
             MemoryManagement::create<Value<quint16>>("Mailing", "MailServerPort", &m_mailServerPort, 0, 0, std::numeric_limits<quint16>::max()),

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -1508,7 +1508,6 @@ void Settings::loadSettings()
     setUserPath(m_userPath);
     setFramesPerSecond(m_framesPerSecond);
     // Apply any pending mod-sync swaps before setActiveMods, so just-synced folders are visible to its missing-folder pruning pass.
-    CONSOLE_PRINT("Checking pending mod-sync manifest", GameConsole::eDEBUG);
     Filesupport::executePendingModSyncManifest(m_userPath, m_userPath);
     Filesupport::reapModSyncFolders(m_userPath);
     setActiveMods(m_activeMods);

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -1104,6 +1104,11 @@ QString Settings::stageActiveModsForRestart(const QStringList & activeMods)
     const QString prior = settings.value("Mods", QString()).toString();
     settings.setValue("Mods", getConfigString(activeMods));
     settings.endGroup();
+    // Mirror the staged list into the in-memory active set so a saveSettings
+    // call before the manual restart cannot revert Mods/Mods to the stale list.
+    // Versions are cleared and rebuilt by setActiveMods on next boot.
+    m_activeMods = activeMods;
+    m_activeModVersions.clear();
     return prior;
 }
 
@@ -1118,6 +1123,8 @@ void Settings::restoreActiveModsRaw(const QString & rawValue)
     settings.beginGroup("Mods");
     settings.setValue("Mods", rawValue);
     settings.endGroup();
+    m_activeMods = rawValue.isEmpty() ? QStringList() : rawValue.split(QChar(','));
+    m_activeModVersions.clear();
 }
 
 void Settings::setActiveMods(const QStringList activeMods)

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -1494,7 +1494,7 @@ QString Settings::getModString()
     return getConfigString(m_activeMods);
 }
 
-void Settings::filterCosmeticMods(QStringList mods, QStringList versions, bool filter)
+void Settings::filterCosmeticMods(QStringList & mods, QStringList & versions, bool filter)
 {
     if (filter)
     {

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -19,6 +19,7 @@
 #include <QUuid>
 
 #include "coreengine/settings.h"
+#include "coreengine/filesupport.h"
 #include "coreengine/mainapp.h"
 #include "coreengine/globalutils.h"
 #include "coreengine/userdata.h"
@@ -1506,6 +1507,10 @@ void Settings::loadSettings()
     }
     setUserPath(m_userPath);
     setFramesPerSecond(m_framesPerSecond);
+    // Apply any pending mod-sync swaps before setActiveMods, so just-synced folders are visible to its missing-folder pruning pass.
+    CONSOLE_PRINT("Checking pending mod-sync manifest", GameConsole::eDEBUG);
+    Filesupport::executePendingModSyncManifest(m_userPath, m_userPath);
+    Filesupport::reapModSyncFolders(m_userPath);
     setActiveMods(m_activeMods);
     GameConsole::setLogLevel(m_defaultLogLevel);
     GameConsole::setActiveModules(m_defaultLogModuls);

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -30,16 +30,6 @@
 
 const char* const Settings::DEFAULT_AUDIODEVICE = "@@default@@";
 
-namespace
-{
-    constexpr qint32 kModSyncDefaultPerModBytes = 64 * 1024 * 1024;
-    constexpr qint32 kModSyncDefaultTotalBytes = 256 * 1024 * 1024;
-    constexpr qint32 kModSyncDefaultMaxFiles = 5000;
-    // Windows MAX_PATH legacy ceiling; deeper trees need a settings override.
-    constexpr qint32 kModSyncDefaultMaxRelativePathLength = 260;
-    constexpr qint32 kModSyncBackupKeepCount = 3;
-}
-
 // this Object
 spSettings Settings::m_pInstance;
 
@@ -1511,10 +1501,10 @@ void Settings::setup()
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "SuspendedDespawnTime", &m_suspendedDespawnTime, std::chrono::seconds(60 * 60 * 24), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "ReplayDeleteTime", &m_replayDeleteTime, std::chrono::seconds(60 * 60 * 24 * 7), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
             MemoryManagement::create<Value<bool>>("Network", "ModSyncEnabled", &m_modSyncEnabled, false, false, true),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxPerModBytes", &m_modSyncMaxPerModBytes, kModSyncDefaultPerModBytes, 0, std::numeric_limits<qint32>::max()),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxTotalBytes", &m_modSyncMaxTotalBytes, kModSyncDefaultTotalBytes, 0, std::numeric_limits<qint32>::max()),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxFiles", &m_modSyncMaxFiles, kModSyncDefaultMaxFiles, 0, std::numeric_limits<qint32>::max()),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxRelativePathLength", &m_modSyncMaxRelativePathLength, kModSyncDefaultMaxRelativePathLength, 1, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxPerModBytes", &m_modSyncMaxPerModBytes, Filesupport::ModSyncDefaultPerModBytes, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxTotalBytes", &m_modSyncMaxTotalBytes, Filesupport::ModSyncDefaultTotalBytes, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxFiles", &m_modSyncMaxFiles, Filesupport::ModSyncDefaultMaxFiles, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxRelativePathLength", &m_modSyncMaxRelativePathLength, Filesupport::ModSyncDefaultMaxRelativePathLength, 1, std::numeric_limits<qint32>::max()),
             MemoryManagement::create<Value<bool>>("Network", "ModSyncKeepBackups", &m_modSyncKeepBackups, false, false, true),
             // mailing
             MemoryManagement::create<Value<QString>>("Mailing", "MailServerAddress", &m_mailServerAddress, "", "", ""),
@@ -1569,7 +1559,7 @@ void Settings::loadSettings()
     qint32 backupKeepCount = 0;
     if (m_modSyncKeepBackups)
     {
-        backupKeepCount = kModSyncBackupKeepCount;
+        backupKeepCount = Filesupport::ModSyncDefaultBackupKeep;
     }
     Filesupport::reapModSyncFolders(m_userPath, backupKeepCount);
     setActiveMods(m_activeMods);

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -30,6 +30,12 @@
 
 const char* const Settings::DEFAULT_AUDIODEVICE = "@@default@@";
 
+namespace
+{
+    // QSettings group and key of the active mod list ([Mods]/Mods=).
+    const char* const kModsSettingsGroup = "Mods";
+}
+
 // this Object
 spSettings Settings::m_pInstance;
 
@@ -1110,9 +1116,9 @@ QString Settings::stageActiveModsForRestart(const QStringList & activeMods)
         return QString();
     }
     QSettings settings(m_settingFile, QSettings::IniFormat);
-    settings.beginGroup("Mods");
-    const QString prior = settings.value("Mods", QString()).toString();
-    settings.setValue("Mods", getConfigString(activeMods));
+    settings.beginGroup(kModsSettingsGroup);
+    const QString prior = settings.value(kModsSettingsGroup, QString()).toString();
+    settings.setValue(kModsSettingsGroup, getConfigString(activeMods));
     settings.endGroup();
     // Mirror the staged list into the in-memory active set so a saveSettings
     // call before the manual restart cannot revert Mods/Mods to the stale list.
@@ -1130,8 +1136,8 @@ void Settings::restoreActiveModsRaw(const QString & rawValue)
         return;
     }
     QSettings settings(m_settingFile, QSettings::IniFormat);
-    settings.beginGroup("Mods");
-    settings.setValue("Mods", rawValue);
+    settings.beginGroup(kModsSettingsGroup);
+    settings.setValue(kModsSettingsGroup, rawValue);
     settings.endGroup();
     m_activeMods = rawValue.isEmpty() ? QStringList() : rawValue.split(QChar(','));
     m_activeModVersions.clear();
@@ -1518,7 +1524,7 @@ void Settings::setup()
             MemoryManagement::create<Value<std::chrono::seconds>>("Autosaving", "AutoSavingTime", &m_autoSavingCylceTime, std::chrono::seconds(60 * 5), std::chrono::seconds(0), std::chrono::seconds(60 * 60 * 24)),
             MemoryManagement::create<Value<qint32>>("Autosaving", "AutoSavingCycle", &m_autoSavingCycle, 3, 0, 100),
             // mods
-            MemoryManagement::create<Value<QStringList>>("Mods", "Mods", &m_activeMods, QStringList(), QStringList(), QStringList()),
+            MemoryManagement::create<Value<QStringList>>(kModsSettingsGroup, kModsSettingsGroup, &m_activeMods, QStringList(), QStringList(), QStringList()),
             // logging
             MemoryManagement::create<Value<bool>>("Logging", "LogActions", &m_LogActions, false, false, true),
             MemoryManagement::create<Value<GameConsole::eLogLevels>>("Logging", "LogLevel", &m_defaultLogLevel, static_cast<GameConsole::eLogLevels>(DEBUG_LEVEL), GameConsole::eLogLevels::eOFF, GameConsole::eLogLevels::eFATAL),

--- a/coreengine/settings.cpp
+++ b/coreengine/settings.cpp
@@ -30,6 +30,16 @@
 
 const char* const Settings::DEFAULT_AUDIODEVICE = "@@default@@";
 
+namespace
+{
+    constexpr qint32 kModSyncDefaultPerModBytes = 64 * 1024 * 1024;
+    constexpr qint32 kModSyncDefaultTotalBytes = 256 * 1024 * 1024;
+    constexpr qint32 kModSyncDefaultMaxFiles = 5000;
+    // Windows MAX_PATH legacy ceiling; deeper trees need a settings override.
+    constexpr qint32 kModSyncDefaultMaxRelativePathLength = 260;
+    constexpr qint32 kModSyncBackupKeepCount = 3;
+}
+
 // this Object
 spSettings Settings::m_pInstance;
 
@@ -1501,10 +1511,10 @@ void Settings::setup()
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "SuspendedDespawnTime", &m_suspendedDespawnTime, std::chrono::seconds(60 * 60 * 24), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
             MemoryManagement::create<Value<std::chrono::seconds>>("Network", "ReplayDeleteTime", &m_replayDeleteTime, std::chrono::seconds(60 * 60 * 24 * 7), std::chrono::seconds(1), std::chrono::seconds(60 * 60 * 24 * 96)),
             MemoryManagement::create<Value<bool>>("Network", "ModSyncEnabled", &m_modSyncEnabled, false, false, true),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxPerModBytes", &m_modSyncMaxPerModBytes, 64 * 1024 * 1024, 0, std::numeric_limits<qint32>::max()),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxTotalBytes", &m_modSyncMaxTotalBytes, 256 * 1024 * 1024, 0, std::numeric_limits<qint32>::max()),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxFiles", &m_modSyncMaxFiles, 5000, 0, std::numeric_limits<qint32>::max()),
-            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxRelativePathLength", &m_modSyncMaxRelativePathLength, 260, 1, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxPerModBytes", &m_modSyncMaxPerModBytes, kModSyncDefaultPerModBytes, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxTotalBytes", &m_modSyncMaxTotalBytes, kModSyncDefaultTotalBytes, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxFiles", &m_modSyncMaxFiles, kModSyncDefaultMaxFiles, 0, std::numeric_limits<qint32>::max()),
+            MemoryManagement::create<Value<qint32>>("Network", "ModSyncMaxRelativePathLength", &m_modSyncMaxRelativePathLength, kModSyncDefaultMaxRelativePathLength, 1, std::numeric_limits<qint32>::max()),
             MemoryManagement::create<Value<bool>>("Network", "ModSyncKeepBackups", &m_modSyncKeepBackups, false, false, true),
             // mailing
             MemoryManagement::create<Value<QString>>("Mailing", "MailServerAddress", &m_mailServerAddress, "", "", ""),
@@ -1556,7 +1566,12 @@ void Settings::loadSettings()
     // Apply any pending mod-sync swaps before setActiveMods, so just-synced folders are visible to its missing-folder pruning pass.
     Filesupport::executePendingModSyncManifest(m_userPath, m_userPath);
     // backupKeep follows ModSyncKeepBackups so a user who opted out reaps every leftover .bak (including ones that survived a prior post-swap removeRecursively failure).
-    Filesupport::reapModSyncFolders(m_userPath, m_modSyncKeepBackups ? 3 : 0);
+    qint32 backupKeepCount = 0;
+    if (m_modSyncKeepBackups)
+    {
+        backupKeepCount = kModSyncBackupKeepCount;
+    }
+    Filesupport::reapModSyncFolders(m_userPath, backupKeepCount);
     setActiveMods(m_activeMods);
     GameConsole::setLogLevel(m_defaultLogLevel);
     GameConsole::setActiveModules(m_defaultLogModuls);

--- a/coreengine/settings.h
+++ b/coreengine/settings.h
@@ -363,6 +363,8 @@ public:
     Q_INVOKABLE void setModSyncMaxFiles(qint32 newValue);
     Q_INVOKABLE qint32 getModSyncMaxRelativePathLength() const;
     Q_INVOKABLE void setModSyncMaxRelativePathLength(qint32 newValue);
+    Q_INVOKABLE bool getModSyncKeepBackups() const;
+    Q_INVOKABLE void setModSyncKeepBackups(bool newValue);
     Q_INVOKABLE QString getMailServerSendAddress();
     Q_INVOKABLE void setMailServerSendAddress(const QString newMailServerSendAddress);
     Q_INVOKABLE qint32 getMailServerAuthMethod();
@@ -955,6 +957,8 @@ private:
     qint32 m_modSyncMaxFiles{5000};
     // Inside-package relpath cap; the modPath identifier itself uses Filesupport::ModPathDefaultMaxLen.
     qint32 m_modSyncMaxRelativePathLength{260};
+    // Disable to skip keeping the .bak-<iso> directory after a successful staging swap; saves disk for users with large mods.
+    bool m_modSyncKeepBackups{false};
 
     // mailing
     QString m_mailServerAddress;

--- a/coreengine/settings.h
+++ b/coreengine/settings.h
@@ -353,6 +353,16 @@ public:
     Q_INVOKABLE void setServerPort(const quint16 ServerPort);
     Q_INVOKABLE QString getServerPassword();
     Q_INVOKABLE void setServerPassword(const QString newServerPassword);
+    Q_INVOKABLE bool getModSyncEnabled() const;
+    Q_INVOKABLE void setModSyncEnabled(bool newModSyncEnabled);
+    Q_INVOKABLE qint32 getModSyncMaxPerModBytes() const;
+    Q_INVOKABLE void setModSyncMaxPerModBytes(qint32 newValue);
+    Q_INVOKABLE qint32 getModSyncMaxTotalBytes() const;
+    Q_INVOKABLE void setModSyncMaxTotalBytes(qint32 newValue);
+    Q_INVOKABLE qint32 getModSyncMaxFiles() const;
+    Q_INVOKABLE void setModSyncMaxFiles(qint32 newValue);
+    Q_INVOKABLE qint32 getModSyncMaxRelativePathLength() const;
+    Q_INVOKABLE void setModSyncMaxRelativePathLength(qint32 newValue);
     Q_INVOKABLE QString getMailServerSendAddress();
     Q_INVOKABLE void setMailServerSendAddress(const QString newMailServerSendAddress);
     Q_INVOKABLE qint32 getMailServerAuthMethod();
@@ -933,6 +943,15 @@ private:
     std::chrono::seconds m_slaveDespawnTime{std::chrono::minutes(0)};
     std::chrono::seconds m_suspendedDespawnTime{std::chrono::minutes(0)};
     std::chrono::seconds m_replayDeleteTime{std::chrono::minutes(0)};
+
+    // Default false until slice 4 wires the request receiver; operator opt-in.
+    bool m_modSyncEnabled{false};
+    // TODO slice 2: enforced by the package builder and receive path.
+    qint32 m_modSyncMaxPerModBytes{64 * 1024 * 1024};
+    qint32 m_modSyncMaxTotalBytes{256 * 1024 * 1024};
+    qint32 m_modSyncMaxFiles{5000};
+    // Inside-package relpath cap; the modPath identifier itself uses Filesupport::ModPathDefaultMaxLen.
+    qint32 m_modSyncMaxRelativePathLength{260};
 
     // mailing
     QString m_mailServerAddress;

--- a/coreengine/settings.h
+++ b/coreengine/settings.h
@@ -438,6 +438,9 @@ public:
     Q_INVOKABLE QStringList getActiveModVersions();
     Q_INVOKABLE QStringList getActiveMods();
     Q_INVOKABLE void setActiveMods(const QStringList activeMods);
+    // Stages Mods/Mods to ini without the missing-folder prune; returns prior raw value so the caller can restore on failure.
+    QString stageActiveModsForRestart(const QStringList & activeMods);
+    void restoreActiveModsRaw(const QString & rawValue);
     Q_INVOKABLE QString getSlaveServerName();
     Q_INVOKABLE void setSlaveServerName(const QString slaveServerName);
     Q_INVOKABLE bool getSyncAnimations();

--- a/coreengine/settings.h
+++ b/coreengine/settings.h
@@ -527,7 +527,7 @@ public:
     Q_INVOKABLE qint32 getMenuItemCount();
     Q_INVOKABLE void setMenuItemCount(const qint32 MenuItemCount);
     Q_INVOKABLE QString getModString();
-    Q_INVOKABLE void filterCosmeticMods(QStringList mods, QStringList versions, bool filter);
+    void filterCosmeticMods(QStringList & mods, QStringList & versions, bool filter);
     Q_INVOKABLE QString getConfigString(QStringList mods);
     Q_INVOKABLE quint32 getMultiTurnCounter();
     Q_INVOKABLE void setMultiTurnCounter(const quint32 value);

--- a/coreengine/settings.h
+++ b/coreengine/settings.h
@@ -13,6 +13,7 @@
 #endif
 #include <QTemporaryDir>
 
+#include "coreengine/filesupport.h"
 #include "coreengine/gameconsole.h"
 
 #include "game/GameEnums.h"
@@ -952,11 +953,11 @@ private:
     // Default false until slice 4 wires the request receiver; operator opt-in.
     bool m_modSyncEnabled{false};
     // TODO slice 2: enforced by the package builder and receive path.
-    qint32 m_modSyncMaxPerModBytes{64 * 1024 * 1024};
-    qint32 m_modSyncMaxTotalBytes{256 * 1024 * 1024};
-    qint32 m_modSyncMaxFiles{5000};
+    qint32 m_modSyncMaxPerModBytes{Filesupport::ModSyncDefaultPerModBytes};
+    qint32 m_modSyncMaxTotalBytes{Filesupport::ModSyncDefaultTotalBytes};
+    qint32 m_modSyncMaxFiles{Filesupport::ModSyncDefaultMaxFiles};
     // Inside-package relpath cap; the modPath identifier itself uses Filesupport::ModPathDefaultMaxLen.
-    qint32 m_modSyncMaxRelativePathLength{260};
+    qint32 m_modSyncMaxRelativePathLength{Filesupport::ModSyncDefaultMaxRelativePathLength};
     // Disable to skip keeping the .bak-<iso> directory after a successful staging swap; saves disk for users with large mods.
     bool m_modSyncKeepBackups{false};
 

--- a/coreengine/workerthread.cpp
+++ b/coreengine/workerthread.cpp
@@ -8,13 +8,16 @@
 
 #include "ai/aiprocesspipe.h"
 
+#include "coreengine/filesupport.h"
 #include "coreengine/mainapp.h"
 #include "coreengine/workerthread.h"
 #include "coreengine/gameconsole.h"
+#include "coreengine/settings.h"
 #include "coreengine/userdata.h"
 #include "coreengine/virtualpaths.h"
 
 #include "menue/mainwindow.h"
+#include "multiplayer/multiplayermenu.h"
 
 #include "game/gameanimation/gameanimationfactory.h"
 
@@ -228,6 +231,28 @@ void WorkerThread::showMainwindow()
 
     spLoadingScreen pLoadingScreen = LoadingScreen::getInstance();
     pLoadingScreen->hide();
+
+    // Consume before the slave guard so a leftover cannot survive into a later normal launch.
+    const Filesupport::RejoinManifest rejoin = Filesupport::consumeRejoinManifest(Settings::getInstance()->getUserPath());
+    // Clear the static slot before branching so non-rejoin paths do not retain plaintext.
+    const QString rejoinPassword = Mainapp::getRejoinPassword();
+    Mainapp::setRejoinPassword(QString());
+
+    constexpr qint64 kRejoinFreshnessSeconds = 300;
+    const bool slaveLaunch = Mainapp::getSlave() || Settings::getInstance()->getAiSlave();
+    if (!slaveLaunch && rejoin.valid)
+    {
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+        const qint64 age = now - rejoin.timestamp;
+        if (age >= 0 && age <= kRejoinFreshnessSeconds)
+        {
+            CONSOLE_PRINT("Auto-rejoining " + rejoin.host + ":" + QString::number(rejoin.port) + " from .rejoin.json", GameConsole::eINFO);
+            oxygine::Stage::getStage()->addChild(MemoryManagement::create<Multiplayermenu>(rejoin.host, "", rejoin.port, rejoinPassword, Multiplayermenu::NetworkMode::Client));
+            return;
+        }
+        CONSOLE_PRINT("Stale .rejoin.json (" + QString::number(age) + "s old), proceeding to main menu", GameConsole::eINFO);
+    }
+
     auto window = MemoryManagement::create<Mainwindow>("ui/menu/mainmenu.xml");
     oxygine::Stage::getStage()->addChild(window);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -110,7 +110,7 @@ int main(qint32 argc, char* argv[])
             CONSOLE_PRINT("No automatic restart on android", GameConsole::eDEBUG);
 #else
             CONSOLE_PRINT("Restarting application", GameConsole::eDEBUG);
-            QProcess::startDetached(QCoreApplication::applicationFilePath(), QStringList());
+            QProcess::startDetached(QCoreApplication::applicationFilePath(), Mainapp::getRestartArgv());
 #endif
         }
 #ifdef UPDATESUPPORT

--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -705,7 +705,7 @@ void GameMenue::sendVerifyGameData(quint64 socketID)
         stream << mods[i];
         stream << versions[i];
     }
-    auto hostHash = Filesupport::getRuntimeHash(mods);
+    auto hostHash = Filesupport::getLegacyRuntimeHash(mods);
     if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
     {
         QString hostString = GlobalUtils::getByteArrayString(hostHash);

--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -705,13 +705,9 @@ void GameMenue::sendVerifyGameData(quint64 socketID)
         stream << mods[i];
         stream << versions[i];
     }
-    auto hostHash = Filesupport::getLegacyRuntimeHash(mods);
-    if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
-    {
-        QString hostString = GlobalUtils::getByteArrayString(hostHash);
-        CONSOLE_PRINT("Sending host hash: " + hostString, GameConsole::eDEBUG);
-    }
-    Filesupport::writeByteArray(stream, hostHash);
+    stream << static_cast<qint32>(Filesupport::CurrentHashPayloadVersion);
+    Filesupport::writeMap(stream, Filesupport::getResourceFolderHashes());
+    Filesupport::writeMap(stream, Filesupport::getPerModHashes(mods));
     emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
 }
 

--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -705,7 +705,21 @@ void GameMenue::sendVerifyGameData(quint64 socketID)
         stream << mods[i];
         stream << versions[i];
     }
-    stream << static_cast<qint32>(Filesupport::CurrentHashPayloadVersion);
+    quint32 capabilities = 0;
+    if (Settings::getInstance()->getModSyncEnabled())
+    {
+        capabilities |= Filesupport::CapabilityModSync;
+    }
+    // Stay on parent v1 wire format when no caps advertised so v1 clients still join.
+    if (capabilities == 0)
+    {
+        stream << static_cast<qint32>(Filesupport::LegacyHashPayloadVersion);
+    }
+    else
+    {
+        stream << static_cast<qint32>(Filesupport::CurrentHashPayloadVersion);
+        stream << capabilities;
+    }
     Filesupport::writeMap(stream, Filesupport::getResourceFolderHashes());
     Filesupport::writeMap(stream, Filesupport::getPerModHashes(mods));
     emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1577,7 +1577,7 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
 
     if (fixableViaSync)
     {
-        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message, true, tr("Apply host's mod set"), tr("Leave game"));
+        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message, true, tr("Apply"), tr("Leave game"));
         // Host's advertised list is already cosmetic-filtered when the rule allows them; re-add client cosmetic-only mods so the user does not silently lose them on next boot.
         QStringList postSyncActiveMods = mods;
         if (cosmeticAllowed)

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -743,13 +743,9 @@ void Multiplayermenu::sendMapInfoUpdate(quint64 socketID)
         stream << mods[i];
         stream << versions[i];
     }
-    auto hostHash = Filesupport::getLegacyRuntimeHash(mods);
-    if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
-    {
-        QString hostString = GlobalUtils::getByteArrayString(hostHash);
-        CONSOLE_PRINT("Sending host hash: " + hostString, GameConsole::eDEBUG);
-    }
-    Filesupport::writeByteArray(stream, hostHash);
+    stream << static_cast<qint32>(Filesupport::CurrentHashPayloadVersion);
+    Filesupport::writeMap(stream, Filesupport::getResourceFolderHashes());
+    Filesupport::writeMap(stream, Filesupport::getPerModHashes(mods));
     stream << m_saveGame;
     if (m_saveGame)
     {
@@ -1165,7 +1161,9 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         QStringList versions;
         QStringList myMods;
         QStringList myVersions;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, sameMods, differentHash, sameVersion);
+        QStringList mismatchedResourceFolders;
+        QStringList mismatchedMods;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
         if (sameVersion && sameMods && !differentHash)
         {
             QString command = QString(NetworkCommands::GAMEDATAVERIFIED);
@@ -1230,10 +1228,15 @@ bool Multiplayermenu::checkMods(const QStringList & mods, const QStringList & ve
     return sameMods;
 }
 
-void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, bool & sameMods, bool & differentHash, bool & sameVersion)
+void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, bool & sameMods, bool & differentHash, bool & sameVersion)
 {
     GameVersion version;
     version.deserializeObject(stream);
+    sameVersion = (version == GameVersion());
+    if (!sameVersion)
+    {
+        return;
+    }
     bool filter = false;
     stream >> filter;
     qint32 size = 0;
@@ -1248,17 +1251,57 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
         versions.append(version);
     }
     sameMods = checkMods(mods, versions, myMods, myVersions, filter);
-    QByteArray hostRuntime = Filesupport::readByteArray(stream);
-    QByteArray ownRuntime = Filesupport::getLegacyRuntimeHash(mods);
-    if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
+    qint32 sentinel = 0;
+    stream >> sentinel;
+    if (sentinel == Filesupport::LegacyRuntimeHashSize)
     {
-        QString hostString = GlobalUtils::getByteArrayString(hostRuntime);
-        QString ownString = GlobalUtils::getByteArrayString(ownRuntime);
-        CONSOLE_PRINT("Received host hash: " + hostString, GameConsole::eDEBUG);
-        CONSOLE_PRINT("Own hash:           " + ownString, GameConsole::eDEBUG);
+        QByteArray hostRuntime;
+        for (qint32 i = 0; i < sentinel; ++i)
+        {
+            qint8 byte = 0;
+            stream >> byte;
+            hostRuntime.append(byte);
+        }
+        QByteArray ownRuntime = Filesupport::getLegacyRuntimeHash(mods);
+        if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
+        {
+            CONSOLE_PRINT("Received legacy host hash: " + GlobalUtils::getByteArrayString(hostRuntime), GameConsole::eDEBUG);
+            CONSOLE_PRINT("Own legacy hash:           " + GlobalUtils::getByteArrayString(ownRuntime), GameConsole::eDEBUG);
+        }
+        differentHash = (hostRuntime != ownRuntime);
     }
-    differentHash = (hostRuntime != ownRuntime);
-    sameVersion = version == GameVersion();
+    else if (sentinel == Filesupport::CurrentHashPayloadVersion)
+    {
+        auto hostResources = Filesupport::readMap<QString, QByteArray, QMap>(stream);
+        auto hostMods = Filesupport::readMap<QString, QByteArray, QMap>(stream);
+        auto ownResources = Filesupport::getResourceFolderHashes();
+        auto ownMods = Filesupport::getPerModHashes(myMods);
+        for (auto iter = hostResources.constBegin(); iter != hostResources.constEnd(); ++iter)
+        {
+            if (ownResources.value(iter.key()) != iter.value())
+            {
+                mismatchedResourceFolders.append(iter.key());
+            }
+        }
+        for (const auto & mod : std::as_const(mods))
+        {
+            // Mods only on one side belong in the membership-mismatch section, not here.
+            if (!myMods.contains(mod))
+            {
+                continue;
+            }
+            if (hostMods.value(mod) != ownMods.value(mod))
+            {
+                mismatchedMods.append(mod);
+            }
+        }
+        differentHash = !mismatchedResourceFolders.isEmpty() || !mismatchedMods.isEmpty();
+    }
+    else
+    {
+        CONSOLE_PRINT("Unknown hash payload sentinel " + QString::number(sentinel) + ", failing closed", GameConsole::eERROR);
+        differentHash = true;
+    }
 }
 
 void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
@@ -1273,7 +1316,9 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         QStringList versions;
         QStringList myMods;
         QStringList myVersions;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, sameMods, differentHash, sameVersion);
+        QStringList mismatchedResourceFolders;
+        QStringList mismatchedMods;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
         if (sameVersion && sameMods && !differentHash)
         {
             stream >> m_saveGame;

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1196,7 +1196,8 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         QStringList mismatchedMods;
         quint32 hostCapabilities = 0;
         bool cosmeticAllowed = false;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
+        QMap<QString, QByteArray> hostModHashes;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostModHashes, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         if (sameVersion && sameMods && !differentHash)
         {
             QString command = QString(NetworkCommands::GAMEDATAVERIFIED);
@@ -1209,7 +1210,7 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostModHashes, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         }
     }
 }
@@ -1261,10 +1262,11 @@ bool Multiplayermenu::checkMods(const QStringList & mods, const QStringList & ve
     return sameMods;
 }
 
-void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed)
+void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, QMap<QString, QByteArray> & hostModHashes, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed)
 {
     hostCapabilities = 0;
     cosmeticAllowed = false;
+    hostModHashes.clear();
     GameVersion version;
     version.deserializeObject(stream);
     sameVersion = (version == GameVersion());
@@ -1293,6 +1295,8 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
     // Call once per readHashInfo: appends to mismatch lists without clearing.
     auto compareMaps = [&](const QMap<QString, QByteArray> & hostResources, const QMap<QString, QByteArray> & hostMods)
     {
+        // Surface host's per-mod hash for the inactive-local-copy verification in handleVersionMissmatch.
+        hostModHashes = hostMods;
         auto ownResources = Filesupport::getResourceFolderHashes();
         auto ownMods = Filesupport::getPerModHashes(myMods);
         for (auto iter = hostResources.constBegin(); iter != hostResources.constEnd(); ++iter)
@@ -1371,7 +1375,8 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         QStringList mismatchedMods;
         quint32 hostCapabilities = 0;
         bool cosmeticAllowed = false;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
+        QMap<QString, QByteArray> hostModHashes;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostModHashes, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         if (sameVersion && sameMods && !differentHash)
         {
             stream >> m_saveGame;
@@ -1429,12 +1434,12 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostModHashes, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         }
     }
 }
 
-void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed)
+void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, const QMap<QString, QByteArray> & hostModHashes, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed)
 {
     // Mod/hash fields are stale on version mismatch because readHashInfo early-returns.
     if (!sameVersion)
@@ -1461,9 +1466,20 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
             if (j < 0)
             {
                 missingHere.append(settings->getModName(mod) + " " + versions[i]);
-                // Only queue a download if the mod folder is absent from disk; otherwise post-sync activation re-enables the local copy.
+                // Skip download only when local hash and version match host; disk presence alone is unsafe (stale or unrelated folder).
+                bool localSatisfies = false;
                 const QString resolvedAbs = VirtualPaths::find(mod, false);
-                if (resolvedAbs.isEmpty() || !QDir(resolvedAbs).exists())
+                if (!resolvedAbs.isEmpty() && QDir(resolvedAbs).exists())
+                {
+                    const QByteArray localHash = Filesupport::getPerModHashes(QStringList{mod}).value(mod);
+                    const QString localVersion = settings->getModVersion(mod);
+                    localSatisfies = (!localHash.isEmpty() && localHash == hostModHashes.value(mod) && localVersion == versions[i]);
+                    if (!localSatisfies)
+                    {
+                        CONSOLE_PRINT("Inactive local copy of " + mod + " differs from host (hash or version); queueing download.", GameConsole::eDEBUG);
+                    }
+                }
+                if (!localSatisfies)
                 {
                     modsToDownloadPaths.append(mod);
                 }
@@ -1532,10 +1548,10 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     appendSection(message, tr("Content mismatch:"), contentDiffs);
     appendSection(message, tr("Engine resources differ:"), mismatchedResourceFolders);
 
-    // Mod-sync is offerable when host advertised CapabilityModSync, no engine resource drift, and we have something to fix.
+    // Mod-sync is offerable when host advertised CapabilityModSync, no engine resource drift, and any mismatch class is non-empty (downloads OR settings-only activate/deactivate work).
     const bool hostSupportsModSync = (hostCapabilities & Filesupport::CapabilityModSync) != 0;
     const bool resourceDrift = !mismatchedResourceFolders.isEmpty();
-    const bool fixableViaSync = hostSupportsModSync && !resourceDrift && (!modsToDownloadPaths.isEmpty() || !extraHere.isEmpty());
+    const bool fixableViaSync = hostSupportsModSync && !resourceDrift && (!missingHere.isEmpty() || !versionDiffs.isEmpty() || !contentDiffs.isEmpty() || !extraHere.isEmpty());
 
     if (message.isEmpty())
     {

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1461,7 +1461,12 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
             if (j < 0)
             {
                 missingHere.append(settings->getModName(mod) + " " + versions[i]);
-                modsToDownloadPaths.append(mod);
+                // Only queue a download if the mod folder is absent from disk; otherwise post-sync activation re-enables the local copy.
+                const QString resolvedAbs = VirtualPaths::find(mod, false);
+                if (resolvedAbs.isEmpty() || !QDir(resolvedAbs).exists())
+                {
+                    modsToDownloadPaths.append(mod);
+                }
             }
             else if (versions[i] != myVersions[j])
             {

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -14,6 +14,7 @@
 #include "coreengine/settings.h"
 #include "coreengine/filesupport.h"
 #include "coreengine/globalutils.h"
+#include "coreengine/virtualpaths.h"
 
 #include "menue/gamemenue.h"
 #include "menue/mainwindow.h"
@@ -535,6 +536,22 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         else if (messageType == NetworkCommands::DISCONNECTINGFROMSERVER)
         {
             exitMenuToLobby();
+        }
+        else if (messageType == NetworkCommands::REQUESTMODSYNC)
+        {
+            handleModSyncRequest(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCDATA)
+        {
+            handleModSyncData(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCREJECT)
+        {
+            handleModSyncReject(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCCOMPLETE)
+        {
+            handleModSyncComplete(stream, socketID);
         }
         else
         {
@@ -2467,4 +2484,514 @@ void Multiplayermenu::countdown()
         m_GameStartTimer.stop();
         sendServerReady(false);
     }
+}
+
+// Pin reject codes to wire literals; filesupport.cpp's anonymous-namespace constants must match.
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncNoReason) == 0, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncDisabled) == 1, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncUnknownMod) == 2, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncSizeCapExceeded) == 3, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncFileCountCapExceeded) == 4, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncInvalidPath) == 5, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncInternalError) == 6, "ModSync reject code drift");
+
+namespace
+{
+    // Cap on number of mods in a single REQUESTMODSYNC; client mod count is bounded by what the user has installed.
+    constexpr qint32 MOD_SYNC_REQUEST_COUNT_MAX = 1024;
+    // Cap on reject-message char length; anything longer than this is truncated by the host or rejected.
+    constexpr qint32 MOD_SYNC_REASON_CHARS_MAX = 4096;
+
+    // QDataStream::operator>> pre-resizes to the declared length; bounded readers reject the header before allocation.
+    constexpr quint32 INT32_MAX_AS_U32 = 0x7FFFFFFFu;
+
+    bool readBoundedQByteArray(QDataStream & stream, QByteArray & out, qint64 maxBytes)
+    {
+        if (maxBytes < 0)
+        {
+            return false;
+        }
+        quint32 declared = 0;
+        stream >> declared;
+        if (stream.status() != QDataStream::Ok)
+        {
+            return false;
+        }
+        if (declared == 0xFFFFFFFFu)
+        {
+            out.clear();
+            return true;
+        }
+        if (declared > INT32_MAX_AS_U32 || static_cast<qint64>(declared) > maxBytes)
+        {
+            return false;
+        }
+        out.resize(static_cast<qint32>(declared));
+        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
+        {
+            return false;
+        }
+        return true;
+    }
+
+    bool readBoundedQString(QDataStream & stream, QString & out, qint32 maxChars)
+    {
+        if (maxChars < 0)
+        {
+            return false;
+        }
+        quint32 declared = 0;
+        stream >> declared;
+        if (stream.status() != QDataStream::Ok)
+        {
+            return false;
+        }
+        if (declared == 0xFFFFFFFFu)
+        {
+            out.clear();
+            return true;
+        }
+        const qint64 maxBytes = static_cast<qint64>(maxChars) * 2;
+        if (declared > INT32_MAX_AS_U32 || static_cast<qint64>(declared) > maxBytes || (declared % 2) != 0)
+        {
+            return false;
+        }
+        QByteArray buf;
+        buf.resize(static_cast<qint32>(declared));
+        if (buf.size() > 0 && stream.readRawData(buf.data(), buf.size()) != buf.size())
+        {
+            return false;
+        }
+        const qint32 codeUnits = buf.size() / 2;
+        out.resize(codeUnits);
+        const uchar * src = reinterpret_cast<const uchar *>(buf.constData());
+        // Wire is big-endian; build each code unit explicitly to skip platform-endian conversion in fromUtf16.
+        for (qint32 i = 0; i < codeUnits; ++i)
+        {
+            out[i] = QChar(static_cast<ushort>((src[i * 2] << 8) | src[i * 2 + 1]));
+        }
+        return true;
+    }
+}
+
+void Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+{
+    if (m_modSyncActive)
+    {
+        CONSOLE_PRINT("Mod-sync already in flight; ignoring duplicate requestModSync", GameConsole::eWARNING);
+        return;
+    }
+    // Network guard runs before the empty-request branch so a host-side caller cannot persist client-side post-sync settings.
+    if (m_pNetworkInterface == nullptr || m_pNetworkInterface->getIsServer())
+    {
+        CONSOLE_PRINT("requestModSync called without a client network interface, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (modsToDownload.size() > MOD_SYNC_REQUEST_COUNT_MAX)
+    {
+        CONSOLE_PRINT("requestModSync exceeds count cap (" + QString::number(modsToDownload.size()) + " > " + QString::number(MOD_SYNC_REQUEST_COUNT_MAX) + "), ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (modsToDownload.isEmpty())
+    {
+        // No downloads needed; persist the post-sync mod selection only. No manifest, no network round-trip.
+        Settings::getInstance()->stageActiveModsForRestart(postSyncActiveMods);
+        CONSOLE_PRINT("Mod-sync settings-only: " + QString::number(postSyncActiveMods.size()) + " mods staged for restart", GameConsole::eINFO);
+        return;
+    }
+    m_modSyncActive = true;
+    m_modSyncStagings.clear();
+    m_modSyncRequestedSet = QSet<QString>(modsToDownload.cbegin(), modsToDownload.cend());
+    m_modSyncReceivedBytes = 0;
+    m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncPostSyncActiveMods = postSyncActiveMods;
+
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Version::Qt_6_5);
+    stream << QString(NetworkCommands::REQUESTMODSYNC);
+    stream << static_cast<qint32>(1);
+    stream << modsToDownload;
+    // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
+    emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+    CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketID)
+{
+    if (m_pNetworkInterface == nullptr || !m_pNetworkInterface->getIsServer())
+    {
+        CONSOLE_PRINT("REQUESTMODSYNC received on non-server, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    if (!settings->getModSyncEnabled())
+    {
+        sendModSyncReject(socketID, NetworkCommands::ModSyncDisabled, QString(), tr("Mod sync is disabled on this host."));
+        return;
+    }
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (protocolVersion != 1)
+    {
+        sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Unsupported mod-sync protocol version."));
+        return;
+    }
+
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    qint32 modCount = 0;
+    stream >> modCount;
+    if (stream.status() != QDataStream::Ok || modCount < 0 || modCount > MOD_SYNC_REQUEST_COUNT_MAX)
+    {
+        sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Malformed mod-sync request."));
+        return;
+    }
+    QStringList requestedMods;
+    requestedMods.reserve(modCount);
+    {
+        // Dedupe at parse time so a hostile client cannot force repeated package builds and duplicate sends within the count cap.
+        QSet<QString> seen;
+        for (qint32 i = 0; i < modCount; ++i)
+        {
+            QString mod;
+            if (!readBoundedQString(stream, mod, relPathMaxLen))
+            {
+                sendModSyncReject(socketID, NetworkCommands::ModSyncInvalidPath, QString(), tr("Malformed mod path in request."));
+                return;
+            }
+            if (!seen.contains(mod))
+            {
+                seen.insert(mod);
+                requestedMods.append(mod);
+            }
+        }
+    }
+
+    QStringList hostMods = settings->getMods();
+    QStringList hostVersions = settings->getActiveModVersions();
+    bool filter = false;
+    auto pMap = m_pMapSelectionView->getCurrentMap();
+    if (pMap != nullptr && pMap->getGameRules() != nullptr)
+    {
+        filter = pMap->getGameRules()->getCosmeticModsAllowed();
+    }
+    settings->filterCosmeticMods(hostMods, hostVersions, filter);
+
+    Filesupport::ModSyncCaps caps;
+    caps.perModBytes = settings->getModSyncMaxPerModBytes();
+    caps.fileCountMax = settings->getModSyncMaxFiles();
+    caps.relPathMaxLen = relPathMaxLen;
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+    qint64 totalSent = 0;
+    qint64 totalUncompressed = 0;
+
+    for (const auto & mod : std::as_const(requestedMods))
+    {
+        if (!Filesupport::validateModPath(mod))
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncInvalidPath, mod, tr("Invalid mod path."));
+            return;
+        }
+        if (!hostMods.contains(mod))
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncUnknownMod, mod, tr("Mod not advertised by host."));
+            return;
+        }
+        // Active mods may resolve from CWD or the install/resource path, not just userPath; ask the VFS where the folder actually lives.
+        const QString resolvedAbs = VirtualPaths::find(mod, false);
+        if (resolvedAbs.isEmpty())
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncUnknownMod, mod, tr("Mod folder not found in install search paths."));
+            return;
+        }
+        QString resolvedRoot;
+        const QString suffixSlash = QStringLiteral("/") + mod;
+        if (resolvedAbs.endsWith(suffixSlash))
+        {
+            resolvedRoot = resolvedAbs.left(resolvedAbs.size() - suffixSlash.size());
+        }
+        else if (resolvedAbs == mod)
+        {
+            resolvedRoot = QString();
+        }
+        else
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, mod, tr("Mod path resolution shape unexpected."));
+            return;
+        }
+        Filesupport::ModSyncPackage pkg = Filesupport::buildModSyncPackage(resolvedRoot, mod, caps);
+        if (pkg.rejectReason != 0)
+        {
+            sendModSyncReject(socketID, pkg.rejectReason, mod, tr("Failed to build mod package."));
+            return;
+        }
+        if (totalSent + pkg.compressedBlob.size() > totalCap || totalUncompressed + pkg.declaredUncompressedSize > totalCap)
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncSizeCapExceeded, QString(), tr("Total sync size exceeds cap."));
+            return;
+        }
+        totalSent += pkg.compressedBlob.size();
+        totalUncompressed += pkg.declaredUncompressedSize;
+
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCDATA);
+        sendStream << static_cast<qint32>(1);
+        sendStream << mod;
+        sendStream << pkg.declaredUncompressedSize;
+        sendStream << pkg.fileCount;
+        sendStream << pkg.compressedBlob;
+        emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCDATA for " + mod + " (" + QString::number(pkg.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
+    }
+
+    QByteArray data;
+    QDataStream sendStream(&data, QIODevice::WriteOnly);
+    sendStream.setVersion(QDataStream::Version::Qt_6_5);
+    sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
+    sendStream << static_cast<qint32>(1);
+    emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+    CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(requestedMods.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCDATA received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 perModCap = settings->getModSyncMaxPerModBytes();
+    const qint32 fileCountMax = settings->getModSyncMaxFiles();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCDATA mod path overflow or malformed", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    qint32 declaredSize = 0;
+    qint32 fileCount = 0;
+    stream >> declaredSize;
+    stream >> fileCount;
+    if (stream.status() != QDataStream::Ok || declaredSize < 0 || fileCount < 0 || fileCount > fileCountMax)
+    {
+        CONSOLE_PRINT("MODSYNCDATA size/count out of range for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    QByteArray compressedBlob;
+    if (!readBoundedQByteArray(stream, compressedBlob, perModCap))
+    {
+        CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    if (!Filesupport::validateModPath(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCDATA invalid mod path: " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (!m_modSyncRequestedSet.contains(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCDATA for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    m_modSyncReceivedBytes += compressedBlob.size();
+    m_modSyncReceivedUncompressedBytes += declaredSize;
+    if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
+    {
+        CONSOLE_PRINT("Mod-sync exceeds total bytes cap, aborting", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    Filesupport::ModSyncCaps caps;
+    caps.perModBytes = perModCap;
+    caps.fileCountMax = fileCountMax;
+    caps.relPathMaxLen = relPathMaxLen;
+
+    qint32 rejectReason = 0;
+    auto files = Filesupport::extractModSyncPackage(compressedBlob, declaredSize, caps, rejectReason);
+    if (rejectReason != 0)
+    {
+        CONSOLE_PRINT("Mod-sync extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (files.size() != fileCount)
+    {
+        CONSOLE_PRINT("Mod-sync file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(fileCount) + ")", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    qint32 stageReason = 0;
+    QString stagingRel = Filesupport::stageModSync(settings->getUserPath(), modPath, files, caps, stageReason);
+    if (stageReason != 0 || stagingRel.isEmpty())
+    {
+        CONSOLE_PRINT("Mod-sync stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    m_modSyncStagings.append(qMakePair(stagingRel, modPath));
+    m_modSyncRequestedSet.remove(modPath);
+    CONSOLE_PRINT("Mod-sync staged " + modPath + " (" + QString::number(files.size()) + " files)", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCREJECT unsupported protocol version", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCREJECT mod path overflow or malformed", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    qint32 reasonCode = 0;
+    stream >> reasonCode;
+    QString reasonMessage;
+    if (!readBoundedQString(stream, reasonMessage, MOD_SYNC_REASON_CHARS_MAX))
+    {
+        CONSOLE_PRINT("MODSYNCREJECT reason message overflow or malformed (code=" + QString::number(reasonCode) + " mod=" + modPath + ")", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    CONSOLE_PRINT("Mod-sync rejected by host: code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + reasonMessage, GameConsole::eERROR);
+    cancelModSyncSession();
+}
+
+void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE unsupported protocol version", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (!m_modSyncRequestedSet.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE arrived with " + QString::number(m_modSyncRequestedSet.size()) + " requested mods unsent; aborting", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (m_modSyncStagings.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE received with no stagings; nothing to apply", GameConsole::eWARNING);
+        m_modSyncActive = false;
+        m_modSyncReceivedBytes = 0;
+        m_modSyncReceivedUncompressedBytes = 0;
+        m_modSyncPostSyncActiveMods.clear();
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    // Settings first; the manifest is the commit point so it must be the last thing written.
+    const QString priorActiveModsRaw = settings->stageActiveModsForRestart(m_modSyncPostSyncActiveMods);
+    QList<QPair<QString, QString>> manifestSwaps;
+    for (const auto & p : std::as_const(m_modSyncStagings))
+    {
+        manifestSwaps.append(qMakePair(p.first, p.second));
+    }
+    if (!Filesupport::writePendingModSyncManifest(settings->getUserPath(), manifestSwaps))
+    {
+        CONSOLE_PRINT("Failed to write pending mod-sync manifest; restoring prior active-mod list", GameConsole::eERROR);
+        settings->restoreActiveModsRaw(priorActiveModsRaw);
+        cancelModSyncSession();
+        return;
+    }
+    CONSOLE_PRINT("Mod-sync complete: " + QString::number(m_modSyncStagings.size()) + " mods staged. Restart the game to apply.", GameConsole::eINFO);
+    m_modSyncActive = false;
+    m_modSyncStagings.clear();
+    m_modSyncRequestedSet.clear();
+    m_modSyncReceivedBytes = 0;
+    m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncPostSyncActiveMods.clear();
+}
+
+void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
+{
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Version::Qt_6_5);
+    stream << QString(NetworkCommands::MODSYNCREJECT);
+    stream << static_cast<qint32>(1);
+    stream << modPath;
+    stream << reasonCode;
+    stream << message;
+    emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+    CONSOLE_PRINT("Sent MODSYNCREJECT code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + message, GameConsole::eINFO);
+}
+
+void Multiplayermenu::cancelModSyncSession()
+{
+    if (!m_modSyncActive)
+    {
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const QString installRoot = settings->getUserPath();
+    for (const auto & p : std::as_const(m_modSyncStagings))
+    {
+        QString stagingAbs;
+        if (installRoot.isEmpty())
+        {
+            stagingAbs = p.first;
+        }
+        else if (installRoot.endsWith(QChar('/')))
+        {
+            stagingAbs = installRoot + p.first;
+        }
+        else
+        {
+            stagingAbs = installRoot + QChar('/') + p.first;
+        }
+        QDir(stagingAbs).removeRecursively();
+    }
+    m_modSyncStagings.clear();
+    m_modSyncRequestedSet.clear();
+    m_modSyncReceivedBytes = 0;
+    m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncActive = false;
+    m_modSyncPostSyncActiveMods.clear();
 }

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1,7 +1,9 @@
-#include <QJsonObject>
+#include <QCoreApplication>
+#include <QCryptographicHash>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QCryptographicHash>
+#include <QJsonObject>
+#include <QTimer>
 
 #include "3rd_party/oxygine-framework/oxygine/actor/Stage.h"
 
@@ -42,7 +44,9 @@ Multiplayermenu::Multiplayermenu(const QString & address, const QString & second
     : MapSelectionMapsMenue(MemoryManagement::create<MapSelectionView>(QStringList({".map", ".jsm"})), Settings::getInstance()->getSmallScreenDevice() ? oxygine::Stage::getStage()->getHeight() - 80 : oxygine::Stage::getStage()->getHeight() - 230),
       m_networkMode(networkMode),
       m_local(true),
-      m_password(password)
+      m_password(password),
+      m_serverAddress(address),
+      m_serverPort(port)
 {
     init();
     if (m_networkMode != NetworkMode::Host)
@@ -68,7 +72,9 @@ Multiplayermenu::Multiplayermenu(const QString & address, quint16 port, const Pa
     : MapSelectionMapsMenue(MemoryManagement::create<MapSelectionView>(QStringList({".map", ".jsm"})), Settings::getInstance()->getSmallScreenDevice() ? oxygine::Stage::getStage()->getHeight() - 80 : oxygine::Stage::getStage()->getHeight() - 230),
       m_networkMode(networkMode),
       m_local(true),
-      m_password(*password)
+      m_password(*password),
+      m_serverAddress(address),
+      m_serverPort(port)
 {
     init();
     initClientConnection(address, "", port);
@@ -3047,14 +3053,15 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         onModSyncFailed(tr("Failed to write the pending mod-sync manifest."));
         return;
     }
-    CONSOLE_PRINT("Mod-sync complete: " + QString::number(m_modSyncStagings.size()) + " mods staged. Restart the game to apply.", GameConsole::eINFO);
+    CONSOLE_PRINT("Mod-sync complete: " + QString::number(m_modSyncStagings.size()) + " mods staged. Restarting to apply.", GameConsole::eINFO);
     m_modSyncActive = false;
     m_modSyncStagings.clear();
     m_modSyncRequestedSet.clear();
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncPostSyncActiveMods.clear();
-    onModSyncSucceeded();
+    // Hold so the progress dialog gets a frame to paint at 100% before the success+restart sequence tears it down.
+    QTimer::singleShot(500, this, &Multiplayermenu::onModSyncSucceeded);
 }
 
 void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
@@ -3166,9 +3173,43 @@ void Multiplayermenu::onModSyncSucceeded()
         m_modSyncProgressDialog->detach();
         m_modSyncProgressDialog.reset();
     }
-    spDialogMessageBox pDialog = MemoryManagement::create<DialogMessageBox>(tr("Mod sync complete. Restart the game to apply the host's mod set."));
-    connect(pDialog.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
-    addChild(pDialog);
+    auto * settings = Settings::getInstance();
+    QString rejoinHost = m_serverAddress;
+    quint16 rejoinPort = m_serverPort;
+    // Prefer the actually-connected endpoint so secondary-fallback joins rejoin to the working address.
+    if (m_pNetworkInterface != nullptr)
+    {
+        const QString connected = m_pNetworkInterface->getConnectedAdress();
+        const quint16 connectedPort = m_pNetworkInterface->getConnectedPort();
+        if (!connected.isEmpty())
+        {
+            rejoinHost = connected;
+        }
+        if (connectedPort != 0)
+        {
+            rejoinPort = connectedPort;
+        }
+    }
+    QStringList argv;
+    // Forward --userPath only when the parent had it on cmdline; passing it otherwise flips CWD-ini boot mode.
+    QString restartUserPath;
+    if (Mainapp::getInstance()->getParser().getUserPath(restartUserPath))
+    {
+        argv << QStringLiteral("--userPath=") + restartUserPath;
+    }
+    const bool haveRejoinTarget = !rejoinHost.isEmpty() && rejoinPort != 0;
+    if (haveRejoinTarget && Filesupport::writeRejoinManifest(settings->getUserPath(), rejoinHost, rejoinPort))
+    {
+        CONSOLE_PRINT("Wrote .rejoin.json for " + rejoinHost + ":" + QString::number(rejoinPort), GameConsole::eINFO);
+        // Password only after manifest succeeds; do not leak it on the no-rejoin restart.
+        argv << QStringLiteral("--rejoin-password=") + m_password.getPasswordText();
+    }
+    else if (haveRejoinTarget)
+    {
+        CONSOLE_PRINT("Failed to write .rejoin.json; user will return to main menu after restart", GameConsole::eERROR);
+    }
+    Mainapp::setRestartArgv(argv);
+    QCoreApplication::exit(1);
 }
 
 void Multiplayermenu::onModSyncFailed(const QString & reason)

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1176,7 +1176,7 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, sameMods, differentHash, sameVersion);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
         }
     }
 }
@@ -1376,41 +1376,116 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, sameMods, differentHash, sameVersion);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
         }
     }
 }
 
-void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, bool sameMods, bool differentHash, bool sameVersion)
+void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion)
 {
-    // quit game with wrong version
-    spDialogMessageBox pDialogMessageBox;
-    if (differentHash)
+    // Mod/hash fields are stale on version mismatch because readHashInfo early-returns.
+    if (!sameVersion)
     {
-        pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("Host has a different version of a mod or the game resource folder has been modified by one of the games."));
+        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("Host has a different game version. Leaving the game again."));
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+        addChild(pDialogMessageBox);
+        return;
     }
-    else  if (!sameVersion)
+
+    constexpr qint32 DISPLAY_LIMIT = 5;
+    auto * settings = Settings::getInstance();
+
+    QStringList missingHere;
+    QStringList extraHere;
+    QStringList versionDiffs;
+    if (!sameMods)
     {
-        pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("Host has a different game version. Leaving the game again."));
-    }
-    else if (!sameMods)
-    {
-        QString hostModsInfo;
         for (qint32 i = 0; i < mods.size(); ++i)
         {
-            hostModsInfo += Settings::getInstance()->getModName(mods[i]) + " " + versions[i] + "\n";
+            const QString & mod = mods[i];
+            const qint32 j = myMods.indexOf(mod);
+            if (j < 0)
+            {
+                missingHere.append(settings->getModName(mod) + " " + versions[i]);
+            }
+            else if (versions[i] != myVersions[j])
+            {
+                versionDiffs.append(tr("%1 (host: %2, you: %3)").arg(settings->getModName(mod), versions[i], myVersions[j]));
+            }
         }
-        QString myModsInfo;
         for (qint32 i = 0; i < myMods.size(); ++i)
         {
-            myModsInfo += Settings::getInstance()->getModName(myMods[i]) + " " + myVersions[i]  + "\n";
+            if (!mods.contains(myMods[i]))
+            {
+                extraHere.append(settings->getModName(myMods[i]) + " " + myVersions[i]);
+            }
         }
-        pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("Host has different mods. Leaving the game again.\nHost mods:\n") + hostModsInfo + "\nYour Mods:\n" + myModsInfo);
+    }
+
+    QStringList contentDiffs;
+    for (const auto & mod : std::as_const(mismatchedMods))
+    {
+        contentDiffs.append(settings->getModName(mod));
+    }
+
+    auto logFullList = [](const QString & label, const QStringList & list)
+    {
+        if (!list.isEmpty())
+        {
+            CONSOLE_PRINT(label + ": " + list.join(", "), GameConsole::eINFO);
+        }
+    };
+    logFullList(QStringLiteral("Mods host has that you are missing"), missingHere);
+    logFullList(QStringLiteral("Mods you have that host does not"), extraHere);
+    logFullList(QStringLiteral("Mods with version-string mismatch"), versionDiffs);
+    logFullList(QStringLiteral("Mods with different content"), contentDiffs);
+    logFullList(QStringLiteral("Engine resource folders modified"), mismatchedResourceFolders);
+
+    auto appendSection = [&](QString & dst, const QString & header, const QStringList & lines)
+    {
+        if (lines.isEmpty())
+        {
+            return;
+        }
+        dst += header + "\n";
+        const qint32 shown = std::min(static_cast<qint32>(lines.size()), DISPLAY_LIMIT);
+        for (qint32 i = 0; i < shown; ++i)
+        {
+            dst += "  " + lines[i] + "\n";
+        }
+        if (lines.size() > DISPLAY_LIMIT)
+        {
+            dst += "  " + tr("...and %1 more (see console.log)").arg(lines.size() - DISPLAY_LIMIT) + "\n";
+        }
+        dst += "\n";
+    };
+
+    QString message;
+    appendSection(message, tr("Missing mods (host has, you don't):"), missingHere);
+    appendSection(message, tr("Extra mods (you have, host doesn't):"), extraHere);
+    appendSection(message, tr("Version mismatch (mod.txt):"), versionDiffs);
+    appendSection(message, tr("Content mismatch:"), contentDiffs);
+    appendSection(message, tr("Engine resources differ:"), mismatchedResourceFolders);
+
+    if (message.isEmpty())
+    {
+        // Legacy and fail-closed payloads have no structured detail.
+        if (differentHash)
+        {
+            message = tr("Host has a different version of a mod or the game resource folder has been modified by one of the games.");
+        }
+        else
+        {
+            CONSOLE_PRINT("handleVersionMissmatch reached unreachable branch: !differentHash with no mod-set or hash diff detail. checkMods set !sameMods but our classification found nothing. Investigate.", GameConsole::eERROR);
+            message = tr("Failed to join game due to unknown verification failure.");
+        }
     }
     else
     {
-        pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("Failed to join game due to unknown verification failure."));
+        message = tr("Cannot join, your game data differs from the host:") + "\n\n" + message + tr("Leaving the game again.");
     }
+
+    spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message);
     connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
     addChild(pDialogMessageBox);
 }

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -557,6 +557,18 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         {
             handleModSyncData(stream, socketID);
         }
+        else if (messageType == NetworkCommands::MODSYNCMODBEGIN)
+        {
+            handleModSyncModBegin(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCMODCHUNK)
+        {
+            handleModSyncModChunk(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCMODEND)
+        {
+            handleModSyncModEnd(stream, socketID);
+        }
         else if (messageType == NetworkCommands::MODSYNCREJECT)
         {
             handleModSyncReject(stream, socketID);
@@ -2571,6 +2583,7 @@ static_assert(static_cast<qint32>(NetworkCommands::ModSyncSizeCapExceeded) == 3,
 static_assert(static_cast<qint32>(NetworkCommands::ModSyncFileCountCapExceeded) == 4, "ModSync reject code drift");
 static_assert(static_cast<qint32>(NetworkCommands::ModSyncInvalidPath) == 5, "ModSync reject code drift");
 static_assert(static_cast<qint32>(NetworkCommands::ModSyncInternalError) == 6, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncBusy) == 7, "ModSync reject code drift");
 
 namespace
 {
@@ -2578,6 +2591,10 @@ namespace
     constexpr qint32 MOD_SYNC_REQUEST_COUNT_MAX = 1024;
     // Cap on reject-message char length; anything longer than this is truncated by the host or rejected.
     constexpr qint32 MOD_SYNC_REASON_CHARS_MAX = 4096;
+    // Wire contract: host and client must agree on this value; chunkCount and per-chunk size are validated against it. Bump MODSYNCMODBEGIN's protocolVersion if it ever changes.
+    constexpr qint32 MOD_SYNC_CHUNK_BYTES = 1 * 1024 * 1024;
+    // Hard ceiling on chunkCount declared in MODSYNCMODBEGIN; even at perModCap = 1 GB that's only ~1024 chunks at 1 MiB.
+    constexpr qint32 MOD_SYNC_CHUNK_COUNT_MAX = 1024 * 1024;
 
     // QDataStream::operator>> pre-resizes to the declared length; bounded readers reject the header before allocation.
     constexpr quint32 INT32_MAX_AS_U32 = 0x7FFFFFFFu;
@@ -2683,6 +2700,7 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncPostSyncActiveMods = postSyncActiveMods;
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
 
     QByteArray data;
     QDataStream stream(&data, QIODevice::WriteOnly);
@@ -2690,9 +2708,11 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     stream << QString(NetworkCommands::REQUESTMODSYNC);
     stream << static_cast<qint32>(1);
     stream << modsToDownload;
+    // Trailing optional flag; older hosts read past their known fields and ignore. New hosts try-read and fall back to legacy framing if absent.
+    stream << static_cast<qint32>(NetworkCommands::ModSyncClientFlagChunked);
     // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
     emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-    CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods", GameConsole::eINFO);
+    CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods (chunked-capable)", GameConsole::eINFO);
     return true;
 }
 
@@ -2707,6 +2727,13 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     if (!settings->getModSyncEnabled())
     {
         sendModSyncReject(socketID, NetworkCommands::ModSyncDisabled, QString(), tr("Mod sync is disabled on this host."));
+        return;
+    }
+    // Host-wide pump state is single-slot; reject concurrent peers rather than clobber an in-flight transfer.
+    if (m_modSyncSendState.socketID != 0)
+    {
+        CONSOLE_PRINT("REQUESTMODSYNC arrived while another peer's send is still pumping; rejecting", GameConsole::eWARNING);
+        sendModSyncReject(socketID, NetworkCommands::ModSyncBusy, QString(), tr("Another peer is currently mod-syncing; try again shortly."));
         return;
     }
     qint32 protocolVersion = 0;
@@ -2745,6 +2772,18 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
             }
         }
     }
+    // Optional clientFlags trailer; older clients send 0 trailing bytes. Strict shape: nothing, or exactly one qint32. Anything else is malformed.
+    qint32 clientFlags = 0;
+    if (!stream.atEnd())
+    {
+        stream >> clientFlags;
+        if (stream.status() != QDataStream::Ok || !stream.atEnd())
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Malformed mod-sync request trailer."));
+            return;
+        }
+    }
+    const bool useChunked = (clientFlags & NetworkCommands::ModSyncClientFlagChunked) != 0;
 
     QStringList hostMods = settings->getMods();
     QStringList hostVersions = settings->getActiveModVersions();
@@ -2850,7 +2889,36 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         CONSOLE_PRINT("Sent MODSYNCMANIFEST; " + QString::number(builtPackages.size()) + " mods, " + QString::number(totalUncompressed) + " expected uncompressed bytes", GameConsole::eINFO);
     }
 
-    for (auto & entry : builtPackages)
+    // Hand the data send off to a singleShot-driven pump so the GUI thread isn't pinned hot-looping over chunks for a multi-hundred-MB mod.
+    m_modSyncSendState = ModSyncSendState{};
+    m_modSyncSendState.socketID = socketID;
+    m_modSyncSendState.packages = std::move(builtPackages);
+    m_modSyncSendState.useChunked = useChunked;
+    CONSOLE_PRINT("Mod-sync send queued (" + QString(useChunked ? "chunked" : "legacy") + "); " + QString::number(m_modSyncSendState.packages.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+    QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+}
+
+void Multiplayermenu::pumpModSyncSend()
+{
+    if (m_pNetworkInterface == nullptr || m_modSyncSendState.socketID == 0)
+    {
+        return;
+    }
+    auto & state = m_modSyncSendState;
+    if (state.currentMod >= state.packages.size())
+    {
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
+        sendStream << static_cast<qint32>(1);
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(state.packages.size()) + " mods", GameConsole::eINFO);
+        state = ModSyncSendState{};
+        return;
+    }
+    auto & entry = state.packages[state.currentMod];
+    if (!state.useChunked)
     {
         QByteArray data;
         QDataStream sendStream(&data, QIODevice::WriteOnly);
@@ -2861,19 +2929,67 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         sendStream << entry.second.declaredUncompressedSize;
         sendStream << entry.second.fileCount;
         sendStream << entry.second.compressedBlob;
-        emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
         CONSOLE_PRINT("Sent MODSYNCDATA for " + entry.first + " (" + QString::number(entry.second.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
-        // QByteArray COW: clearing here drops only our ref; the queued send keeps its own.
         entry.second.compressedBlob.clear();
+        ++state.currentMod;
+        QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+        return;
     }
-
-    QByteArray data;
-    QDataStream sendStream(&data, QIODevice::WriteOnly);
-    sendStream.setVersion(QDataStream::Version::Qt_6_5);
-    sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
-    sendStream << static_cast<qint32>(1);
-    emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-    CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(requestedMods.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+    const qint64 compressedTotal = entry.second.compressedBlob.size();
+    const qint32 chunkCount = compressedTotal == 0 ? 0 : static_cast<qint32>((compressedTotal + MOD_SYNC_CHUNK_BYTES - 1) / MOD_SYNC_CHUNK_BYTES);
+    if (!state.beginEmitted)
+    {
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCMODBEGIN);
+        sendStream << static_cast<qint32>(1);
+        sendStream << entry.first;
+        sendStream << entry.second.declaredUncompressedSize;
+        sendStream << entry.second.fileCount;
+        sendStream << compressedTotal;
+        sendStream << chunkCount;
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCMODBEGIN for " + entry.first + " (" + QString::number(compressedTotal) + " bytes, " + QString::number(chunkCount) + " chunks)", GameConsole::eINFO);
+        state.beginEmitted = true;
+        state.currentChunk = 0;
+        QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+        return;
+    }
+    if (state.currentChunk < chunkCount)
+    {
+        const qint64 offset = static_cast<qint64>(state.currentChunk) * MOD_SYNC_CHUNK_BYTES;
+        const qint32 sliceLen = static_cast<qint32>(std::min<qint64>(MOD_SYNC_CHUNK_BYTES, compressedTotal - offset));
+        const QByteArray chunkBytes = entry.second.compressedBlob.mid(static_cast<qint32>(offset), sliceLen);
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCMODCHUNK);
+        sendStream << static_cast<qint32>(1);
+        sendStream << entry.first;
+        sendStream << state.currentChunk;
+        sendStream << chunkBytes;
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        ++state.currentChunk;
+        QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+        return;
+    }
+    {
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCMODEND);
+        sendStream << static_cast<qint32>(1);
+        sendStream << entry.first;
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCMODEND for " + entry.first, GameConsole::eINFO);
+    }
+    entry.second.compressedBlob.clear();
+    ++state.currentMod;
+    state.beginEmitted = false;
+    state.currentChunk = 0;
+    QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
 }
 
 void Multiplayermenu::handleModSyncManifest(QDataStream & stream, quint64 socketID)
@@ -2964,6 +3080,13 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
         cancelModSyncSession();
         onModSyncFailed(uiReason);
     };
+
+    if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCDATA arrived while a chunked mod is in flight; protocol violation", GameConsole::eERROR);
+        failData(tr("Host mixed chunked and legacy mod-sync framing."));
+        return;
+    }
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
@@ -3057,6 +3180,333 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     onModSyncProgress();
 }
 
+void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 perModCap = settings->getModSyncMaxPerModBytes();
+    const qint32 fileCountMax = settings->getModSyncMaxFiles();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    auto failBegin = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
+    if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN while a chunked mod is already in flight; protocol violation", GameConsole::eERROR);
+        failBegin(tr("Host opened a second chunked mod before finishing the first."));
+        return;
+    }
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN unsupported protocol version", GameConsole::eERROR);
+        failBegin(tr("Unsupported mod-sync protocol from host."));
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN mod path overflow or malformed", GameConsole::eERROR);
+        failBegin(tr("Malformed mod-sync begin frame."));
+        return;
+    }
+    qint32 declaredUncompressedSize = 0;
+    qint32 fileCount = 0;
+    qint64 compressedTotal = 0;
+    qint32 chunkCount = 0;
+    stream >> declaredUncompressedSize;
+    stream >> fileCount;
+    stream >> compressedTotal;
+    stream >> chunkCount;
+    if (stream.status() != QDataStream::Ok)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN truncated header for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Malformed mod-sync begin frame."));
+        return;
+    }
+    if (declaredUncompressedSize < 0 || declaredUncompressedSize > perModCap)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN declaredUncompressedSize out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        return;
+    }
+    if (compressedTotal < 0 || compressedTotal > perModCap)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        return;
+    }
+    // Defensive: QByteArray and downstream offsets use qint32 sizes throughout the slice 5 pipeline. perModCap is qint32 today, but guard explicitly so a future widening cannot silently overflow the casts below.
+    if (compressedTotal > std::numeric_limits<qint32>::max())
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal exceeds qint32 range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 is too large to receive.").arg(modPath));
+        return;
+    }
+    if (fileCount < 0 || fileCount > fileCountMax)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN fileCount out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 exceeds the per-mod file-count cap.").arg(modPath));
+        return;
+    }
+    if (chunkCount < 0 || chunkCount > MOD_SYNC_CHUNK_COUNT_MAX)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN chunkCount out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 has too many chunks.").arg(modPath));
+        return;
+    }
+    const qint32 expectedChunkCount = compressedTotal == 0 ? 0 : static_cast<qint32>((compressedTotal + MOD_SYNC_CHUNK_BYTES - 1) / MOD_SYNC_CHUNK_BYTES);
+    if (chunkCount != expectedChunkCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN chunkCount inconsistent with compressedTotal for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 chunk count is inconsistent.").arg(modPath));
+        return;
+    }
+    if (m_modSyncReceivedBytes + compressedTotal > totalCap || m_modSyncReceivedUncompressedBytes + declaredUncompressedSize > totalCap)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN would exceed total cap for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod-sync exceeds the total transfer cap."));
+        return;
+    }
+    if (!Filesupport::validateModPath(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN invalid mod path: " + modPath, GameConsole::eERROR);
+        failBegin(tr("Host sent an invalid mod path."));
+        return;
+    }
+    if (!m_modSyncRequestedSet.contains(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
+        failBegin(tr("Host sent an unrequested or duplicate mod."));
+        return;
+    }
+
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
+    m_modSyncCurrentChunkMod.modPath = modPath;
+    m_modSyncCurrentChunkMod.declaredUncompressedSize = declaredUncompressedSize;
+    m_modSyncCurrentChunkMod.fileCount = fileCount;
+    m_modSyncCurrentChunkMod.compressedTotal = compressedTotal;
+    m_modSyncCurrentChunkMod.expectedChunkCount = chunkCount;
+    if (compressedTotal > 0)
+    {
+        m_modSyncCurrentChunkMod.blob.reserve(static_cast<qint32>(compressedTotal));
+    }
+    CONSOLE_PRINT("Received MODSYNCMODBEGIN for " + modPath + " (" + QString::number(compressedTotal) + " bytes, " + QString::number(chunkCount) + " chunks)", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK without prior MODSYNCMODBEGIN; protocol violation", GameConsole::eERROR);
+        cancelModSyncSession();
+        onModSyncFailed(tr("Host sent chunk without begin."));
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    auto failChunk = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK unsupported protocol version", GameConsole::eERROR);
+        failChunk(tr("Unsupported mod-sync protocol from host."));
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK mod path overflow or malformed", GameConsole::eERROR);
+        failChunk(tr("Malformed mod-sync chunk frame."));
+        return;
+    }
+    if (modPath != m_modSyncCurrentChunkMod.modPath)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK modPath mismatch; expected " + m_modSyncCurrentChunkMod.modPath + " got " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host interleaved chunks across mods."));
+        return;
+    }
+    qint32 chunkIndex = 0;
+    stream >> chunkIndex;
+    if (stream.status() != QDataStream::Ok || chunkIndex != m_modSyncCurrentChunkMod.receivedChunkCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK out-of-order chunkIndex for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host sent chunks out of order."));
+        return;
+    }
+    QByteArray chunkBytes;
+    if (!readBoundedQByteArray(stream, chunkBytes, MOD_SYNC_CHUNK_BYTES))
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK chunk overflow or malformed for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Mod-sync chunk exceeds size limit."));
+        return;
+    }
+    const qint64 newAccumulated = static_cast<qint64>(m_modSyncCurrentChunkMod.blob.size()) + chunkBytes.size();
+    if (newAccumulated > m_modSyncCurrentChunkMod.compressedTotal)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK accumulated exceeds compressedTotal for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host sent more bytes than declared for mod %1.").arg(modPath));
+        return;
+    }
+    const bool isFinalChunk = (m_modSyncCurrentChunkMod.receivedChunkCount + 1 == m_modSyncCurrentChunkMod.expectedChunkCount);
+    const qint64 expectedThisChunk = isFinalChunk
+        ? (m_modSyncCurrentChunkMod.compressedTotal - static_cast<qint64>(m_modSyncCurrentChunkMod.blob.size()))
+        : MOD_SYNC_CHUNK_BYTES;
+    if (chunkBytes.size() != expectedThisChunk)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK size " + QString::number(chunkBytes.size()) + " differs from expected " + QString::number(expectedThisChunk) + " for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host sent a chunk of unexpected size."));
+        return;
+    }
+
+    m_modSyncCurrentChunkMod.blob.append(chunkBytes);
+    ++m_modSyncCurrentChunkMod.receivedChunkCount;
+    m_modSyncReceivedBytes += chunkBytes.size();
+    // Display-side proportional uncompressed advance so the bar fraction can move during a single mod; snap-corrected at MODSYNCMODEND to absorb integer-division drift.
+    qint64 perChunkUncompressedDelta = 0;
+    if (m_modSyncCurrentChunkMod.compressedTotal > 0 && m_modSyncCurrentChunkMod.declaredUncompressedSize > 0)
+    {
+        perChunkUncompressedDelta = static_cast<qint64>(chunkBytes.size()) * m_modSyncCurrentChunkMod.declaredUncompressedSize / m_modSyncCurrentChunkMod.compressedTotal;
+    }
+    m_modSyncCurrentChunkMod.uncompressedAdvanced += perChunkUncompressedDelta;
+    m_modSyncReceivedUncompressedBytes += perChunkUncompressedDelta;
+    if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
+    {
+        CONSOLE_PRINT("Mod-sync exceeds total bytes cap mid-chunk, aborting", GameConsole::eERROR);
+        failChunk(tr("Mod-sync exceeds the total transfer cap."));
+        return;
+    }
+    onModSyncProgress();
+}
+
+void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODEND without prior MODSYNCMODBEGIN; protocol violation", GameConsole::eERROR);
+        cancelModSyncSession();
+        onModSyncFailed(tr("Host sent end without begin."));
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 perModCap = settings->getModSyncMaxPerModBytes();
+    const qint32 fileCountMax = settings->getModSyncMaxFiles();
+
+    auto failEnd = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND unsupported protocol version", GameConsole::eERROR);
+        failEnd(tr("Unsupported mod-sync protocol from host."));
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCMODEND mod path overflow or malformed", GameConsole::eERROR);
+        failEnd(tr("Malformed mod-sync end frame."));
+        return;
+    }
+    if (modPath != m_modSyncCurrentChunkMod.modPath)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND modPath mismatch; expected " + m_modSyncCurrentChunkMod.modPath + " got " + modPath, GameConsole::eERROR);
+        failEnd(tr("Host ended a different mod than the one in flight."));
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.receivedChunkCount != m_modSyncCurrentChunkMod.expectedChunkCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND chunk count mismatch for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Host ended mod %1 before delivering all chunks.").arg(modPath));
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.blob.size() != m_modSyncCurrentChunkMod.compressedTotal)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND blob size mismatch for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Host blob size for mod %1 did not match its declared total.").arg(modPath));
+        return;
+    }
+
+    Filesupport::ModSyncCaps caps;
+    caps.perModBytes = perModCap;
+    caps.fileCountMax = fileCountMax;
+    caps.relPathMaxLen = relPathMaxLen;
+
+    qint32 rejectReason = 0;
+    auto files = Filesupport::extractModSyncPackage(m_modSyncCurrentChunkMod.blob, m_modSyncCurrentChunkMod.declaredUncompressedSize, caps, rejectReason);
+    if (rejectReason != 0)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Failed to unpack mod %1.").arg(modPath));
+        return;
+    }
+    if (files.size() != m_modSyncCurrentChunkMod.fileCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(m_modSyncCurrentChunkMod.fileCount) + ")", GameConsole::eERROR);
+        failEnd(tr("Mod %1 file count did not match the host's declaration.").arg(modPath));
+        return;
+    }
+    qint32 stageReason = 0;
+    QString stagingRel = Filesupport::stageModSync(settings->getUserPath(), modPath, files, caps, stageReason);
+    if (stageReason != 0 || stagingRel.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODEND stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Failed to stage mod %1 to disk.").arg(modPath));
+        return;
+    }
+
+    // Snap-correct the proportional uncompressed advance so the global counter equals the exact sum of declaredUncompressedSize values.
+    const qint64 snapDelta = static_cast<qint64>(m_modSyncCurrentChunkMod.declaredUncompressedSize) - m_modSyncCurrentChunkMod.uncompressedAdvanced;
+    if (snapDelta != 0)
+    {
+        m_modSyncReceivedUncompressedBytes += snapDelta;
+    }
+
+    m_modSyncStagings.append(qMakePair(stagingRel, modPath));
+    m_modSyncRequestedSet.remove(modPath);
+    CONSOLE_PRINT("Mod-sync staged " + modPath + " via chunked path (" + QString::number(files.size()) + " files)", GameConsole::eINFO);
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
+    onModSyncProgress();
+}
+
 void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID)
 {
     Q_UNUSED(socketID);
@@ -3122,6 +3572,13 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
         return;
     }
+    if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE arrived with chunked mod " + m_modSyncCurrentChunkMod.modPath + " still in flight; aborting", GameConsole::eERROR);
+        cancelModSyncSession();
+        onModSyncFailed(tr("Host completed before finishing the chunked mod transfer."));
+        return;
+    }
     if (!m_modSyncRequestedSet.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE arrived with " + QString::number(m_modSyncRequestedSet.size()) + " requested mods unsent; aborting", GameConsole::eERROR);
@@ -3136,6 +3593,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         m_modSyncReceivedBytes = 0;
         m_modSyncReceivedUncompressedBytes = 0;
         m_modSyncExpectedUncompressedTotal = 0;
+        m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
         m_modSyncPostSyncActiveMods.clear();
         return;
     }
@@ -3162,6 +3620,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncExpectedUncompressedTotal = 0;
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
     m_modSyncPostSyncActiveMods.clear();
     // Hold so the progress dialog gets a frame to paint at 100% before the success+restart sequence tears it down.
     QTimer::singleShot(500, this, &Multiplayermenu::onModSyncSucceeded);
@@ -3189,6 +3648,8 @@ void Multiplayermenu::cancelModSyncSession()
         m_modSyncProgressDialog->detach();
         m_modSyncProgressDialog.reset();
     }
+    // Send-state clearing is host-side and runs even when m_modSyncActive (client-side flag) is false; the next pump tick short-circuits on socketID==0.
+    m_modSyncSendState = ModSyncSendState{};
     if (!m_modSyncActive)
     {
         return;
@@ -3218,6 +3679,7 @@ void Multiplayermenu::cancelModSyncSession()
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncActive = false;
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
     m_modSyncPostSyncActiveMods.clear();
 }
 

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -2730,6 +2730,23 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     qint64 totalSent = 0;
     qint64 totalUncompressed = 0;
 
+    auto packageRejectReason = [this](qint32 code, const QString & mod) -> QString
+    {
+        switch (code)
+        {
+            case NetworkCommands::ModSyncSizeCapExceeded:
+                return tr("Mod %1 exceeds the per-mod size cap on the host.").arg(mod);
+            case NetworkCommands::ModSyncFileCountCapExceeded:
+                return tr("Mod %1 exceeds the per-mod file-count cap on the host.").arg(mod);
+            case NetworkCommands::ModSyncInvalidPath:
+                return tr("Mod %1 has an unsafe internal file path.").arg(mod);
+            case NetworkCommands::ModSyncUnknownMod:
+                return tr("Mod %1 was not found on the host.").arg(mod);
+            default:
+                return tr("Failed to build mod package for %1.").arg(mod);
+        }
+    };
+
     for (const auto & mod : std::as_const(requestedMods))
     {
         if (!Filesupport::validateModPath(mod))
@@ -2767,12 +2784,12 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         Filesupport::ModSyncPackage pkg = Filesupport::buildModSyncPackage(resolvedRoot, mod, caps);
         if (pkg.rejectReason != 0)
         {
-            sendModSyncReject(socketID, pkg.rejectReason, mod, tr("Failed to build mod package."));
+            sendModSyncReject(socketID, pkg.rejectReason, mod, packageRejectReason(pkg.rejectReason, mod));
             return;
         }
         if (totalSent + pkg.compressedBlob.size() > totalCap || totalUncompressed + pkg.declaredUncompressedSize > totalCap)
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncSizeCapExceeded, QString(), tr("Total sync size exceeds cap."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncSizeCapExceeded, QString(), tr("Total sync size exceeds the host's cap."));
             return;
         }
         totalSent += pkg.compressedBlob.size();

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -743,7 +743,7 @@ void Multiplayermenu::sendMapInfoUpdate(quint64 socketID)
         stream << mods[i];
         stream << versions[i];
     }
-    auto hostHash = Filesupport::getRuntimeHash(mods);
+    auto hostHash = Filesupport::getLegacyRuntimeHash(mods);
     if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
     {
         QString hostString = GlobalUtils::getByteArrayString(hostHash);
@@ -1249,7 +1249,7 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
     }
     sameMods = checkMods(mods, versions, myMods, myVersions, filter);
     QByteArray hostRuntime = Filesupport::readByteArray(stream);
-    QByteArray ownRuntime = Filesupport::getRuntimeHash(mods);
+    QByteArray ownRuntime = Filesupport::getLegacyRuntimeHash(mods);
     if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
     {
         QString hostString = GlobalUtils::getByteArrayString(hostRuntime);

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -3119,10 +3119,10 @@ void Multiplayermenu::cancelModSyncSession()
 
 void Multiplayermenu::confirmModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
 {
-    const bool ok = requestModSync(modsToDownload, postSyncActiveMods);
     if (modsToDownload.isEmpty())
     {
-        // Settings-only branch already either staged Mods/Mods or refused; surface the matching prompt.
+        // Settings-only branch: no untrusted host content downloaded, skip the trust prompt.
+        const bool ok = requestModSync(modsToDownload, postSyncActiveMods);
         if (ok)
         {
             onModSyncSucceeded();
@@ -3133,6 +3133,21 @@ void Multiplayermenu::confirmModSync(const QStringList & modsToDownload, const Q
         }
         return;
     }
+    // Trust prompt before any host-supplied mod content is downloaded; mod scripts execute under the QJSEngine in this process.
+    spDialogMessageBox pTrust = MemoryManagement::create<DialogMessageBox>(
+        tr("You are about to install unverified mods from this host. These mods may include scripts that run in your game. Only continue if you trust this host."),
+        true, tr("Install"), tr("Cancel"));
+    connect(pTrust.get(), &DialogMessageBox::sigOk, this, [this, modsToDownload, postSyncActiveMods]()
+    {
+        startModSyncDownload(modsToDownload, postSyncActiveMods);
+    }, Qt::QueuedConnection);
+    connect(pTrust.get(), &DialogMessageBox::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    addChild(pTrust);
+}
+
+void Multiplayermenu::startModSyncDownload(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+{
+    const bool ok = requestModSync(modsToDownload, postSyncActiveMods);
     if (!ok)
     {
         onModSyncFailed(tr("Could not start mod sync."));

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1592,7 +1592,7 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     }
     else if (fixableViaSync)
     {
-        message = tr("Your game data differs from the host:") + "\n\n" + message + tr("Want me to download host's mod set and apply it on the next start?");
+        message = tr("Your game data differs from the host:") + "\n\n" + message + tr("Want me to download host's mod set, apply it, and restart automatically?");
     }
     else
     {

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -743,7 +743,21 @@ void Multiplayermenu::sendMapInfoUpdate(quint64 socketID)
         stream << mods[i];
         stream << versions[i];
     }
-    stream << static_cast<qint32>(Filesupport::CurrentHashPayloadVersion);
+    quint32 capabilities = 0;
+    if (Settings::getInstance()->getModSyncEnabled())
+    {
+        capabilities |= Filesupport::CapabilityModSync;
+    }
+    // Stay on parent v1 wire format when no caps advertised so v1 clients still join.
+    if (capabilities == 0)
+    {
+        stream << static_cast<qint32>(Filesupport::LegacyHashPayloadVersion);
+    }
+    else
+    {
+        stream << static_cast<qint32>(Filesupport::CurrentHashPayloadVersion);
+        stream << capabilities;
+    }
     Filesupport::writeMap(stream, Filesupport::getResourceFolderHashes());
     Filesupport::writeMap(stream, Filesupport::getPerModHashes(mods));
     stream << m_saveGame;
@@ -1163,7 +1177,9 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         QStringList myVersions;
         QStringList mismatchedResourceFolders;
         QStringList mismatchedMods;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
+        quint32 hostCapabilities = 0;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion);
+        Q_UNUSED(hostCapabilities);
         if (sameVersion && sameMods && !differentHash)
         {
             QString command = QString(NetworkCommands::GAMEDATAVERIFIED);
@@ -1228,8 +1244,9 @@ bool Multiplayermenu::checkMods(const QStringList & mods, const QStringList & ve
     return sameMods;
 }
 
-void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, bool & sameMods, bool & differentHash, bool & sameVersion)
+void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion)
 {
+    hostCapabilities = 0;
     GameVersion version;
     version.deserializeObject(stream);
     sameVersion = (version == GameVersion());
@@ -1253,27 +1270,10 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
     sameMods = checkMods(mods, versions, myMods, myVersions, filter);
     qint32 sentinel = 0;
     stream >> sentinel;
-    if (sentinel == Filesupport::LegacyRuntimeHashSize)
+
+    // Call once per readHashInfo: appends to mismatch lists without clearing.
+    auto compareMaps = [&](const QMap<QString, QByteArray> & hostResources, const QMap<QString, QByteArray> & hostMods)
     {
-        QByteArray hostRuntime;
-        for (qint32 i = 0; i < sentinel; ++i)
-        {
-            qint8 byte = 0;
-            stream >> byte;
-            hostRuntime.append(byte);
-        }
-        QByteArray ownRuntime = Filesupport::getLegacyRuntimeHash(mods);
-        if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
-        {
-            CONSOLE_PRINT("Received legacy host hash: " + GlobalUtils::getByteArrayString(hostRuntime), GameConsole::eDEBUG);
-            CONSOLE_PRINT("Own legacy hash:           " + GlobalUtils::getByteArrayString(ownRuntime), GameConsole::eDEBUG);
-        }
-        differentHash = (hostRuntime != ownRuntime);
-    }
-    else if (sentinel == Filesupport::CurrentHashPayloadVersion)
-    {
-        auto hostResources = Filesupport::readMap<QString, QByteArray, QMap>(stream);
-        auto hostMods = Filesupport::readMap<QString, QByteArray, QMap>(stream);
         auto ownResources = Filesupport::getResourceFolderHashes();
         auto ownMods = Filesupport::getPerModHashes(myMods);
         for (auto iter = hostResources.constBegin(); iter != hostResources.constEnd(); ++iter)
@@ -1296,6 +1296,38 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
             }
         }
         differentHash = !mismatchedResourceFolders.isEmpty() || !mismatchedMods.isEmpty();
+    };
+
+    if (sentinel == Filesupport::LegacyRuntimeHashSize)
+    {
+        QByteArray hostRuntime;
+        for (qint32 i = 0; i < sentinel; ++i)
+        {
+            qint8 byte = 0;
+            stream >> byte;
+            hostRuntime.append(byte);
+        }
+        QByteArray ownRuntime = Filesupport::getLegacyRuntimeHash(mods);
+        if (GameConsole::eDEBUG >= GameConsole::getLogLevel())
+        {
+            CONSOLE_PRINT("Received legacy host hash: " + GlobalUtils::getByteArrayString(hostRuntime), GameConsole::eDEBUG);
+            CONSOLE_PRINT("Own legacy hash:           " + GlobalUtils::getByteArrayString(ownRuntime), GameConsole::eDEBUG);
+        }
+        differentHash = (hostRuntime != ownRuntime);
+    }
+    else if (sentinel == Filesupport::LegacyHashPayloadVersion)
+    {
+        // parent named-mod-mismatch wire format: two maps, no capabilities advertised.
+        auto hostResources = Filesupport::readMap<QString, QByteArray, QMap>(stream);
+        auto hostMods = Filesupport::readMap<QString, QByteArray, QMap>(stream);
+        compareMaps(hostResources, hostMods);
+    }
+    else if (sentinel == Filesupport::CurrentHashPayloadVersion)
+    {
+        stream >> hostCapabilities;
+        auto hostResources = Filesupport::readMap<QString, QByteArray, QMap>(stream);
+        auto hostMods = Filesupport::readMap<QString, QByteArray, QMap>(stream);
+        compareMaps(hostResources, hostMods);
     }
     else
     {
@@ -1318,7 +1350,9 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         QStringList myVersions;
         QStringList mismatchedResourceFolders;
         QStringList mismatchedMods;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
+        quint32 hostCapabilities = 0;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion);
+        Q_UNUSED(hostCapabilities);
         if (sameVersion && sameMods && !differentHash)
         {
             stream >> m_saveGame;

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1195,8 +1195,8 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         QStringList mismatchedResourceFolders;
         QStringList mismatchedMods;
         quint32 hostCapabilities = 0;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion);
-        Q_UNUSED(hostCapabilities);
+        bool cosmeticAllowed = false;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         if (sameVersion && sameMods && !differentHash)
         {
             QString command = QString(NetworkCommands::GAMEDATAVERIFIED);
@@ -1209,7 +1209,7 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         }
     }
 }
@@ -1261,9 +1261,10 @@ bool Multiplayermenu::checkMods(const QStringList & mods, const QStringList & ve
     return sameMods;
 }
 
-void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion)
+void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed)
 {
     hostCapabilities = 0;
+    cosmeticAllowed = false;
     GameVersion version;
     version.deserializeObject(stream);
     sameVersion = (version == GameVersion());
@@ -1273,6 +1274,7 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
     }
     bool filter = false;
     stream >> filter;
+    cosmeticAllowed = filter;
     qint32 size = 0;
     stream >> size;
     for (qint32 i = 0; i < size; i++)
@@ -1368,8 +1370,8 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         QStringList mismatchedResourceFolders;
         QStringList mismatchedMods;
         quint32 hostCapabilities = 0;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion);
-        Q_UNUSED(hostCapabilities);
+        bool cosmeticAllowed = false;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         if (sameVersion && sameMods && !differentHash)
         {
             stream >> m_saveGame;
@@ -1427,12 +1429,12 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         }
     }
 }
 
-void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion)
+void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed)
 {
     // Mod/hash fields are stale on version mismatch because readHashInfo early-returns.
     if (!sameVersion)
@@ -1449,6 +1451,7 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     QStringList missingHere;
     QStringList extraHere;
     QStringList versionDiffs;
+    QStringList modsToDownloadPaths;
     if (!sameMods)
     {
         for (qint32 i = 0; i < mods.size(); ++i)
@@ -1458,10 +1461,12 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
             if (j < 0)
             {
                 missingHere.append(settings->getModName(mod) + " " + versions[i]);
+                modsToDownloadPaths.append(mod);
             }
             else if (versions[i] != myVersions[j])
             {
                 versionDiffs.append(tr("%1 (host: %2, you: %3)").arg(settings->getModName(mod), versions[i], myVersions[j]));
+                modsToDownloadPaths.append(mod);
             }
         }
         for (qint32 i = 0; i < myMods.size(); ++i)
@@ -1477,6 +1482,10 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     for (const auto & mod : std::as_const(mismatchedMods))
     {
         contentDiffs.append(settings->getModName(mod));
+        if (!modsToDownloadPaths.contains(mod))
+        {
+            modsToDownloadPaths.append(mod);
+        }
     }
 
     auto logFullList = [](const QString & label, const QStringList & list)
@@ -1518,6 +1527,11 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     appendSection(message, tr("Content mismatch:"), contentDiffs);
     appendSection(message, tr("Engine resources differ:"), mismatchedResourceFolders);
 
+    // Mod-sync is offerable when host advertised CapabilityModSync, no engine resource drift, and we have something to fix.
+    const bool hostSupportsModSync = (hostCapabilities & Filesupport::CapabilityModSync) != 0;
+    const bool resourceDrift = !mismatchedResourceFolders.isEmpty();
+    const bool fixableViaSync = hostSupportsModSync && !resourceDrift && (!modsToDownloadPaths.isEmpty() || !extraHere.isEmpty());
+
     if (message.isEmpty())
     {
         // Legacy and fail-closed payloads have no structured detail.
@@ -1531,14 +1545,44 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
             message = tr("Failed to join game due to unknown verification failure.");
         }
     }
+    else if (fixableViaSync)
+    {
+        message = tr("Your game data differs from the host:") + "\n\n" + message + tr("Want me to download host's mod set and apply it on the next start?");
+    }
     else
     {
         message = tr("Cannot join, your game data differs from the host:") + "\n\n" + message + tr("Leaving the game again.");
     }
 
-    spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message);
-    connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
-    addChild(pDialogMessageBox);
+    if (fixableViaSync)
+    {
+        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message, true, tr("Apply host's mod set"), tr("Leave game"));
+        // Host's advertised list is already cosmetic-filtered when the rule allows them; re-add client cosmetic-only mods so the user does not silently lose them on next boot.
+        QStringList postSyncActiveMods = mods;
+        if (cosmeticAllowed)
+        {
+            const QStringList clientFull = settings->getMods();
+            for (const auto & mod : std::as_const(clientFull))
+            {
+                if (!postSyncActiveMods.contains(mod) && settings->getIsCosmetic(mod))
+                {
+                    postSyncActiveMods.append(mod);
+                }
+            }
+        }
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, [this, modsToDownloadPaths, postSyncActiveMods]()
+        {
+            confirmModSync(modsToDownloadPaths, postSyncActiveMods);
+        }, Qt::QueuedConnection);
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+        addChild(pDialogMessageBox);
+    }
+    else
+    {
+        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message);
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+        addChild(pDialogMessageBox);
+    }
 }
 
 void Multiplayermenu::requestMap(quint64 socketID)
@@ -2574,30 +2618,30 @@ namespace
     }
 }
 
-void Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
 {
     if (m_modSyncActive)
     {
         CONSOLE_PRINT("Mod-sync already in flight; ignoring duplicate requestModSync", GameConsole::eWARNING);
-        return;
+        return false;
     }
     // Network guard runs before the empty-request branch so a host-side caller cannot persist client-side post-sync settings.
     if (m_pNetworkInterface == nullptr || m_pNetworkInterface->getIsServer())
     {
         CONSOLE_PRINT("requestModSync called without a client network interface, ignoring", GameConsole::eWARNING);
-        return;
+        return false;
     }
     if (modsToDownload.size() > MOD_SYNC_REQUEST_COUNT_MAX)
     {
         CONSOLE_PRINT("requestModSync exceeds count cap (" + QString::number(modsToDownload.size()) + " > " + QString::number(MOD_SYNC_REQUEST_COUNT_MAX) + "), ignoring", GameConsole::eWARNING);
-        return;
+        return false;
     }
     if (modsToDownload.isEmpty())
     {
         // No downloads needed; persist the post-sync mod selection only. No manifest, no network round-trip.
         Settings::getInstance()->stageActiveModsForRestart(postSyncActiveMods);
         CONSOLE_PRINT("Mod-sync settings-only: " + QString::number(postSyncActiveMods.size()) + " mods staged for restart", GameConsole::eINFO);
-        return;
+        return true;
     }
     m_modSyncActive = true;
     m_modSyncStagings.clear();
@@ -2615,6 +2659,7 @@ void Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
     emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
     CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods", GameConsole::eINFO);
+    return true;
 }
 
 void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketID)
@@ -2769,12 +2814,18 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     const qint32 fileCountMax = settings->getModSyncMaxFiles();
     const qint64 totalCap = settings->getModSyncMaxTotalBytes();
 
+    auto failData = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (stream.status() != QDataStream::Ok || protocolVersion != 1)
     {
         CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Unsupported mod-sync protocol from host."));
         return;
     }
 
@@ -2782,7 +2833,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!readBoundedQString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCDATA mod path overflow or malformed", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Malformed mod-sync data frame."));
         return;
     }
 
@@ -2793,7 +2844,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stream.status() != QDataStream::Ok || declaredSize < 0 || fileCount < 0 || fileCount > fileCountMax)
     {
         CONSOLE_PRINT("MODSYNCDATA size/count out of range for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod %1 exceeds the per-mod file-count cap.").arg(modPath));
         return;
     }
 
@@ -2801,20 +2852,20 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!readBoundedQByteArray(stream, compressedBlob, perModCap))
     {
         CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
         return;
     }
 
     if (!Filesupport::validateModPath(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA invalid mod path: " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Host sent an invalid mod path."));
         return;
     }
     if (!m_modSyncRequestedSet.contains(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Host sent an unrequested or duplicate mod."));
         return;
     }
 
@@ -2823,7 +2874,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
     {
         CONSOLE_PRINT("Mod-sync exceeds total bytes cap, aborting", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod-sync exceeds the total transfer cap."));
         return;
     }
 
@@ -2837,13 +2888,13 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (rejectReason != 0)
     {
         CONSOLE_PRINT("Mod-sync extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Failed to unpack mod %1.").arg(modPath));
         return;
     }
     if (files.size() != fileCount)
     {
         CONSOLE_PRINT("Mod-sync file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(fileCount) + ")", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod %1 file count did not match the host's declaration.").arg(modPath));
         return;
     }
 
@@ -2852,17 +2903,24 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stageReason != 0 || stagingRel.isEmpty())
     {
         CONSOLE_PRINT("Mod-sync stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Failed to stage mod %1 to disk.").arg(modPath));
         return;
     }
     m_modSyncStagings.append(qMakePair(stagingRel, modPath));
     m_modSyncRequestedSet.remove(modPath);
     CONSOLE_PRINT("Mod-sync staged " + modPath + " (" + QString::number(files.size()) + " files)", GameConsole::eINFO);
+    onModSyncProgress();
 }
 
 void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID)
 {
     Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        // Drop late or unsolicited rejects after cancel/success so we do not stack a second failure dialog.
+        CONSOLE_PRINT("MODSYNCREJECT received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
     auto * settings = Settings::getInstance();
     const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
 
@@ -2872,6 +2930,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
         return;
     }
     QString modPath;
@@ -2879,6 +2938,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT mod path overflow or malformed", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Malformed mod-sync reject frame."));
         return;
     }
     qint32 reasonCode = 0;
@@ -2888,32 +2948,40 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT reason message overflow or malformed (code=" + QString::number(reasonCode) + " mod=" + modPath + ")", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Malformed reject reason from host."));
         return;
     }
     CONSOLE_PRINT("Mod-sync rejected by host: code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + reasonMessage, GameConsole::eERROR);
+    const QString uiReason = reasonMessage.isEmpty()
+        ? tr("Host rejected the request (code %1).").arg(reasonCode)
+        : reasonMessage;
     cancelModSyncSession();
+    onModSyncFailed(uiReason);
 }
 
 void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socketID)
 {
     Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        // Drop late or unsolicited completes after cancel/success before parsing so a malformed stale frame does not stack a second failure dialog.
+        CONSOLE_PRINT("MODSYNCCOMPLETE received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (stream.status() != QDataStream::Ok || protocolVersion != 1)
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
-        return;
-    }
-    if (!m_modSyncActive)
-    {
-        CONSOLE_PRINT("MODSYNCCOMPLETE received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
         return;
     }
     if (!m_modSyncRequestedSet.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE arrived with " + QString::number(m_modSyncRequestedSet.size()) + " requested mods unsent; aborting", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Host did not deliver every requested mod."));
         return;
     }
     if (m_modSyncStagings.isEmpty())
@@ -2938,6 +3006,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         CONSOLE_PRINT("Failed to write pending mod-sync manifest; restoring prior active-mod list", GameConsole::eERROR);
         settings->restoreActiveModsRaw(priorActiveModsRaw);
         cancelModSyncSession();
+        onModSyncFailed(tr("Failed to write the pending mod-sync manifest."));
         return;
     }
     CONSOLE_PRINT("Mod-sync complete: " + QString::number(m_modSyncStagings.size()) + " mods staged. Restart the game to apply.", GameConsole::eINFO);
@@ -2947,6 +3016,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncPostSyncActiveMods.clear();
+    onModSyncSucceeded();
 }
 
 void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
@@ -2965,6 +3035,12 @@ void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, con
 
 void Multiplayermenu::cancelModSyncSession()
 {
+    // Dialog teardown ahead of the active-session guard so a request that bailed before arming still tears down its progress UI.
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
     if (!m_modSyncActive)
     {
         return;
@@ -2994,4 +3070,79 @@ void Multiplayermenu::cancelModSyncSession()
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncActive = false;
     m_modSyncPostSyncActiveMods.clear();
+}
+
+void Multiplayermenu::confirmModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+{
+    const bool ok = requestModSync(modsToDownload, postSyncActiveMods);
+    if (modsToDownload.isEmpty())
+    {
+        // Settings-only branch already either staged Mods/Mods or refused; surface the matching prompt.
+        if (ok)
+        {
+            onModSyncSucceeded();
+        }
+        else
+        {
+            onModSyncFailed(tr("Could not start mod sync."));
+        }
+        return;
+    }
+    if (!ok)
+    {
+        onModSyncFailed(tr("Could not start mod sync."));
+        return;
+    }
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
+    m_modSyncProgressDialog = MemoryManagement::create<DialogModSyncProgress>(static_cast<qint32>(modsToDownload.size()));
+    connect(m_modSyncProgressDialog.get(), &DialogModSyncProgress::sigCancel, this, [this]()
+    {
+        if (!m_modSyncActive)
+        {
+            return;
+        }
+        cancelModSyncSession();
+        onModSyncFailed(tr("Mod sync canceled."));
+    }, Qt::QueuedConnection);
+    addChild(m_modSyncProgressDialog);
+}
+
+void Multiplayermenu::onModSyncProgress()
+{
+    if (m_modSyncProgressDialog == nullptr)
+    {
+        return;
+    }
+    // Show declared uncompressed bytes so the user sees on-disk size, not wire-compressed size.
+    m_modSyncProgressDialog->setProgress(static_cast<qint32>(m_modSyncStagings.size()), m_modSyncReceivedUncompressedBytes);
+}
+
+void Multiplayermenu::onModSyncSucceeded()
+{
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
+    spDialogMessageBox pDialog = MemoryManagement::create<DialogMessageBox>(tr("Mod sync complete. Restart the game to apply the host's mod set."));
+    connect(pDialog.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    addChild(pDialog);
+}
+
+void Multiplayermenu::onModSyncFailed(const QString & reason)
+{
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
+    // Escape because reason can include host-supplied text and DialogMessageBox renders via setHtmlText.
+    const QString safe = reason.toHtmlEscaped();
+    spDialogMessageBox pDialog = MemoryManagement::create<DialogMessageBox>(tr("Mod sync failed: %1\n\nLeaving the game.").arg(safe));
+    connect(pDialog.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    addChild(pDialog);
 }

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -142,10 +142,12 @@ void Multiplayermenu::initClientAndWaitForConnection()
 
     connect(m_pPlayerSelection.get(), &PlayerSelection::sigDisconnect, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
     // wait 10 minutes till timeout
-    spDialogConnecting pDialogConnecting = MemoryManagement::create<DialogConnecting>(tr("Connecting"), 1000 * 60 * 5);
-    addChild(pDialogConnecting);
-    connect(pDialogConnecting.get(), &DialogConnecting::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
-    connect(this, &Multiplayermenu::sigConnected, pDialogConnecting.get(), &DialogConnecting::connected, Qt::QueuedConnection);
+    m_pJoinConnectingDialog = MemoryManagement::create<DialogConnecting>(tr("Connecting"), 1000 * 60 * 5);
+    addChild(m_pJoinConnectingDialog);
+    connect(m_pJoinConnectingDialog.get(), &DialogConnecting::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    connect(this, &Multiplayermenu::sigConnected, m_pJoinConnectingDialog.get(), &DialogConnecting::connected, Qt::QueuedConnection);
+    // Drop the smart-ptr after the dialog's own connected() slot has detached it, so a retained reference can't keep the actor alive past the lobby join.
+    connect(this, &Multiplayermenu::sigConnected, this, [this](){ m_pJoinConnectingDialog.reset(); }, Qt::QueuedConnection);
 }
 
 void Multiplayermenu::init()
@@ -546,6 +548,10 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         else if (messageType == NetworkCommands::REQUESTMODSYNC)
         {
             handleModSyncRequest(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCMANIFEST)
+        {
+            handleModSyncManifest(stream, socketID);
         }
         else if (messageType == NetworkCommands::MODSYNCDATA)
         {
@@ -2675,6 +2681,7 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     m_modSyncRequestedSet = QSet<QString>(modsToDownload.cbegin(), modsToDownload.cend());
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncPostSyncActiveMods = postSyncActiveMods;
 
     QByteArray data;
@@ -2774,6 +2781,9 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         }
     };
 
+    // Pre-build so the manifest carries exact sizes; peak ~totalCap, each blob freed after its MODSYNCDATA send.
+    QVector<QPair<QString, Filesupport::ModSyncPackage>> builtPackages;
+    builtPackages.reserve(requestedMods.size());
     for (const auto & mod : std::as_const(requestedMods))
     {
         if (!Filesupport::validateModPath(mod))
@@ -2821,18 +2831,40 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         }
         totalSent += pkg.compressedBlob.size();
         totalUncompressed += pkg.declaredUncompressedSize;
+        builtPackages.append(qMakePair(mod, std::move(pkg)));
+    }
 
+    {
+        QByteArray manifestData;
+        QDataStream manifestStream(&manifestData, QIODevice::WriteOnly);
+        manifestStream.setVersion(QDataStream::Version::Qt_6_5);
+        manifestStream << QString(NetworkCommands::MODSYNCMANIFEST);
+        manifestStream << static_cast<qint32>(1);
+        manifestStream << static_cast<qint32>(builtPackages.size());
+        for (const auto & entry : std::as_const(builtPackages))
+        {
+            manifestStream << entry.first;
+            manifestStream << entry.second.declaredUncompressedSize;
+        }
+        emit m_pNetworkInterface->sig_sendData(socketID, manifestData, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCMANIFEST; " + QString::number(builtPackages.size()) + " mods, " + QString::number(totalUncompressed) + " expected uncompressed bytes", GameConsole::eINFO);
+    }
+
+    for (auto & entry : builtPackages)
+    {
         QByteArray data;
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCDATA);
         sendStream << static_cast<qint32>(1);
-        sendStream << mod;
-        sendStream << pkg.declaredUncompressedSize;
-        sendStream << pkg.fileCount;
-        sendStream << pkg.compressedBlob;
+        sendStream << entry.first;
+        sendStream << entry.second.declaredUncompressedSize;
+        sendStream << entry.second.fileCount;
+        sendStream << entry.second.compressedBlob;
         emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-        CONSOLE_PRINT("Sent MODSYNCDATA for " + mod + " (" + QString::number(pkg.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
+        CONSOLE_PRINT("Sent MODSYNCDATA for " + entry.first + " (" + QString::number(entry.second.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
+        // QByteArray COW: clearing here drops only our ref; the queued send keeps its own.
+        entry.second.compressedBlob.clear();
     }
 
     QByteArray data;
@@ -2842,6 +2874,75 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     sendStream << static_cast<qint32>(1);
     emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
     CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(requestedMods.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncManifest(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST unsupported protocol version, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    qint32 entryCount = 0;
+    stream >> entryCount;
+    if (stream.status() != QDataStream::Ok || entryCount < 0 || entryCount > MOD_SYNC_REQUEST_COUNT_MAX)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST malformed entry count, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    qint64 expectedTotal = 0;
+    qint32 ignoredEntries = 0;
+    for (qint32 i = 0; i < entryCount; ++i)
+    {
+        QString modPath;
+        if (!readBoundedQString(stream, modPath, relPathMaxLen))
+        {
+            CONSOLE_PRINT("MODSYNCMANIFEST mod path overflow or malformed, ignoring", GameConsole::eWARNING);
+            return;
+        }
+        qint32 declaredSize = 0;
+        stream >> declaredSize;
+        if (stream.status() != QDataStream::Ok || declaredSize < 0)
+        {
+            CONSOLE_PRINT("MODSYNCMANIFEST declared size out of range for " + modPath + ", ignoring", GameConsole::eWARNING);
+            return;
+        }
+        // Only count entries the client actually asked for; a hostile or buggy host could otherwise inflate expectedTotal to drive the bar to 100% before any data lands.
+        if (!m_modSyncRequestedSet.contains(modPath))
+        {
+            ++ignoredEntries;
+            continue;
+        }
+        expectedTotal += declaredSize;
+        if (expectedTotal > totalCap)
+        {
+            CONSOLE_PRINT("MODSYNCMANIFEST expected total exceeds host total cap; clamping for display only", GameConsole::eWARNING);
+            expectedTotal = totalCap;
+            break;
+        }
+    }
+    if (ignoredEntries > 0)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST ignored " + QString::number(ignoredEntries) + " entries not in the client's request set", GameConsole::eWARNING);
+    }
+    m_modSyncExpectedUncompressedTotal = expectedTotal;
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->setExpectedTotalBytes(expectedTotal);
+    }
+    CONSOLE_PRINT("Received MODSYNCMANIFEST; expected uncompressed total " + QString::number(expectedTotal) + " bytes across " + QString::number(entryCount) + " mods", GameConsole::eINFO);
 }
 
 void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
@@ -3034,6 +3135,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         m_modSyncActive = false;
         m_modSyncReceivedBytes = 0;
         m_modSyncReceivedUncompressedBytes = 0;
+        m_modSyncExpectedUncompressedTotal = 0;
         m_modSyncPostSyncActiveMods.clear();
         return;
     }
@@ -3059,6 +3161,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncRequestedSet.clear();
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncPostSyncActiveMods.clear();
     // Hold so the progress dialog gets a frame to paint at 100% before the success+restart sequence tears it down.
     QTimer::singleShot(500, this, &Multiplayermenu::onModSyncSucceeded);
@@ -3113,6 +3216,7 @@ void Multiplayermenu::cancelModSyncSession()
     m_modSyncRequestedSet.clear();
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncActive = false;
     m_modSyncPostSyncActiveMods.clear();
 }
@@ -3153,12 +3257,19 @@ void Multiplayermenu::startModSyncDownload(const QStringList & modsToDownload, c
         onModSyncFailed(tr("Could not start mod sync."));
         return;
     }
+    if (m_pJoinConnectingDialog != nullptr)
+    {
+        m_pJoinConnectingDialog->detach();
+        m_pJoinConnectingDialog.reset();
+    }
     if (m_modSyncProgressDialog != nullptr)
     {
         m_modSyncProgressDialog->detach();
         m_modSyncProgressDialog.reset();
     }
     m_modSyncProgressDialog = MemoryManagement::create<DialogModSyncProgress>(static_cast<qint32>(modsToDownload.size()));
+    // Defensive seed in case MODSYNCMANIFEST raced ahead of dialog construction.
+    m_modSyncProgressDialog->setExpectedTotalBytes(m_modSyncExpectedUncompressedTotal);
     connect(m_modSyncProgressDialog.get(), &DialogModSyncProgress::sigCancel, this, [this]()
     {
         if (!m_modSyncActive)
@@ -3177,8 +3288,8 @@ void Multiplayermenu::onModSyncProgress()
     {
         return;
     }
-    // Show declared uncompressed bytes so the user sees on-disk size, not wire-compressed size.
-    m_modSyncProgressDialog->setProgress(static_cast<qint32>(m_modSyncStagings.size()), m_modSyncReceivedUncompressedBytes);
+    // Compressed drives the EMA network-rate display; uncompressed drives bar fraction and ETA.
+    m_modSyncProgressDialog->setProgress(static_cast<qint32>(m_modSyncStagings.size()), m_modSyncReceivedBytes, m_modSyncReceivedUncompressedBytes);
 }
 
 void Multiplayermenu::onModSyncSucceeded()

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -557,6 +557,18 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         {
             handleModSyncData(stream, socketID);
         }
+        else if (messageType == NetworkCommands::MODSYNCMODBEGIN)
+        {
+            handleModSyncModBegin(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCMODCHUNK)
+        {
+            handleModSyncModChunk(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCMODEND)
+        {
+            handleModSyncModEnd(stream, socketID);
+        }
         else if (messageType == NetworkCommands::MODSYNCREJECT)
         {
             handleModSyncReject(stream, socketID);
@@ -2571,6 +2583,7 @@ static_assert(static_cast<qint32>(NetworkCommands::ModSyncSizeCapExceeded) == 3,
 static_assert(static_cast<qint32>(NetworkCommands::ModSyncFileCountCapExceeded) == 4, "ModSync reject code drift");
 static_assert(static_cast<qint32>(NetworkCommands::ModSyncInvalidPath) == 5, "ModSync reject code drift");
 static_assert(static_cast<qint32>(NetworkCommands::ModSyncInternalError) == 6, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncBusy) == 7, "ModSync reject code drift");
 
 namespace
 {
@@ -2578,6 +2591,10 @@ namespace
     constexpr qint32 kModSyncRequestCountMax = 1024;
     // Cap on reject-message char length; anything longer than this is truncated by the host or rejected.
     constexpr qint32 kModSyncReasonCharsMax = 4096;
+    // Wire contract: host and client must agree on this value; chunkCount and per-chunk size are validated against it. Bump MODSYNCMODBEGIN's protocolVersion if it ever changes.
+    constexpr qint32 kModSyncChunkBytes = 1 * 1024 * 1024;
+    // Hard ceiling on chunkCount declared in MODSYNCMODBEGIN; even at perModCap = 1 GB that's only ~1024 chunks at 1 MiB.
+    constexpr qint32 kModSyncChunkCountMax = 1024 * 1024;
 
     // QDataStream::operator>> pre-resizes to the declared length; bounded readers reject the header before allocation.
     constexpr quint32 kInt32MaxAsU32 = 0x7FFFFFFFu;
@@ -2683,6 +2700,7 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncPostSyncActiveMods = postSyncActiveMods;
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
 
     QByteArray data;
     QDataStream stream(&data, QIODevice::WriteOnly);
@@ -2690,9 +2708,11 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     stream << QString(NetworkCommands::REQUESTMODSYNC);
     stream << static_cast<qint32>(1);
     stream << modsToDownload;
+    // Trailing optional flag; older hosts read past their known fields and ignore. New hosts try-read and fall back to legacy framing if absent.
+    stream << static_cast<qint32>(NetworkCommands::ModSyncClientFlagChunked);
     // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
     emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-    CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods", GameConsole::eINFO);
+    CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods (chunked-capable)", GameConsole::eINFO);
     return true;
 }
 
@@ -2707,6 +2727,13 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     if (!settings->getModSyncEnabled())
     {
         sendModSyncReject(socketID, NetworkCommands::ModSyncDisabled, QString(), tr("Mod sync is disabled on this host."));
+        return;
+    }
+    // Host-wide pump state is single-slot; reject concurrent peers rather than clobber an in-flight transfer.
+    if (m_modSyncSendState.socketID != 0)
+    {
+        CONSOLE_PRINT("REQUESTMODSYNC arrived while another peer's send is still pumping; rejecting", GameConsole::eWARNING);
+        sendModSyncReject(socketID, NetworkCommands::ModSyncBusy, QString(), tr("Another peer is currently mod-syncing; try again shortly."));
         return;
     }
     qint32 protocolVersion = 0;
@@ -2745,6 +2772,18 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
             }
         }
     }
+    // Optional clientFlags trailer; older clients send 0 trailing bytes. Strict shape: nothing, or exactly one qint32. Anything else is malformed.
+    qint32 clientFlags = 0;
+    if (!stream.atEnd())
+    {
+        stream >> clientFlags;
+        if (stream.status() != QDataStream::Ok || !stream.atEnd())
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Malformed mod-sync request trailer."));
+            return;
+        }
+    }
+    const bool useChunked = (clientFlags & NetworkCommands::ModSyncClientFlagChunked) != 0;
 
     QStringList hostMods = settings->getMods();
     QStringList hostVersions = settings->getActiveModVersions();
@@ -2850,7 +2889,36 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         CONSOLE_PRINT("Sent MODSYNCMANIFEST; " + QString::number(builtPackages.size()) + " mods, " + QString::number(totalUncompressed) + " expected uncompressed bytes", GameConsole::eINFO);
     }
 
-    for (auto & entry : builtPackages)
+    // Hand the data send off to a singleShot-driven pump so the GUI thread isn't pinned hot-looping over chunks for a multi-hundred-MB mod.
+    m_modSyncSendState = ModSyncSendState{};
+    m_modSyncSendState.socketID = socketID;
+    m_modSyncSendState.packages = std::move(builtPackages);
+    m_modSyncSendState.useChunked = useChunked;
+    CONSOLE_PRINT("Mod-sync send queued (" + QString(useChunked ? "chunked" : "legacy") + "); " + QString::number(m_modSyncSendState.packages.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+    QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+}
+
+void Multiplayermenu::pumpModSyncSend()
+{
+    if (m_pNetworkInterface == nullptr || m_modSyncSendState.socketID == 0)
+    {
+        return;
+    }
+    auto & state = m_modSyncSendState;
+    if (state.currentMod >= state.packages.size())
+    {
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
+        sendStream << static_cast<qint32>(1);
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(state.packages.size()) + " mods", GameConsole::eINFO);
+        state = ModSyncSendState{};
+        return;
+    }
+    auto & entry = state.packages[state.currentMod];
+    if (!state.useChunked)
     {
         QByteArray data;
         QDataStream sendStream(&data, QIODevice::WriteOnly);
@@ -2861,19 +2929,67 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         sendStream << entry.second.declaredUncompressedSize;
         sendStream << entry.second.fileCount;
         sendStream << entry.second.compressedBlob;
-        emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
         CONSOLE_PRINT("Sent MODSYNCDATA for " + entry.first + " (" + QString::number(entry.second.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
-        // QByteArray COW: clearing here drops only our ref; the queued send keeps its own.
         entry.second.compressedBlob.clear();
+        ++state.currentMod;
+        QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+        return;
     }
-
-    QByteArray data;
-    QDataStream sendStream(&data, QIODevice::WriteOnly);
-    sendStream.setVersion(QDataStream::Version::Qt_6_5);
-    sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
-    sendStream << static_cast<qint32>(1);
-    emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-    CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(requestedMods.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+    const qint64 compressedTotal = entry.second.compressedBlob.size();
+    const qint32 chunkCount = compressedTotal == 0 ? 0 : static_cast<qint32>((compressedTotal + kModSyncChunkBytes - 1) / kModSyncChunkBytes);
+    if (!state.beginEmitted)
+    {
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCMODBEGIN);
+        sendStream << static_cast<qint32>(1);
+        sendStream << entry.first;
+        sendStream << entry.second.declaredUncompressedSize;
+        sendStream << entry.second.fileCount;
+        sendStream << compressedTotal;
+        sendStream << chunkCount;
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCMODBEGIN for " + entry.first + " (" + QString::number(compressedTotal) + " bytes, " + QString::number(chunkCount) + " chunks)", GameConsole::eINFO);
+        state.beginEmitted = true;
+        state.currentChunk = 0;
+        QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+        return;
+    }
+    if (state.currentChunk < chunkCount)
+    {
+        const qint64 offset = static_cast<qint64>(state.currentChunk) * kModSyncChunkBytes;
+        const qint32 sliceLen = static_cast<qint32>(std::min<qint64>(kModSyncChunkBytes, compressedTotal - offset));
+        const QByteArray chunkBytes = entry.second.compressedBlob.mid(static_cast<qint32>(offset), sliceLen);
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCMODCHUNK);
+        sendStream << static_cast<qint32>(1);
+        sendStream << entry.first;
+        sendStream << state.currentChunk;
+        sendStream << chunkBytes;
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        ++state.currentChunk;
+        QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
+        return;
+    }
+    {
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCMODEND);
+        sendStream << static_cast<qint32>(1);
+        sendStream << entry.first;
+        emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCMODEND for " + entry.first, GameConsole::eINFO);
+    }
+    entry.second.compressedBlob.clear();
+    ++state.currentMod;
+    state.beginEmitted = false;
+    state.currentChunk = 0;
+    QTimer::singleShot(0, this, &Multiplayermenu::pumpModSyncSend);
 }
 
 void Multiplayermenu::handleModSyncManifest(QDataStream & stream, quint64 socketID)
@@ -2964,6 +3080,13 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
         cancelModSyncSession();
         onModSyncFailed(uiReason);
     };
+
+    if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCDATA arrived while a chunked mod is in flight; protocol violation", GameConsole::eERROR);
+        failData(tr("Host mixed chunked and legacy mod-sync framing."));
+        return;
+    }
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
@@ -3057,6 +3180,333 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     onModSyncProgress();
 }
 
+void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 perModCap = settings->getModSyncMaxPerModBytes();
+    const qint32 fileCountMax = settings->getModSyncMaxFiles();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    auto failBegin = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
+    if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN while a chunked mod is already in flight; protocol violation", GameConsole::eERROR);
+        failBegin(tr("Host opened a second chunked mod before finishing the first."));
+        return;
+    }
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN unsupported protocol version", GameConsole::eERROR);
+        failBegin(tr("Unsupported mod-sync protocol from host."));
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN mod path overflow or malformed", GameConsole::eERROR);
+        failBegin(tr("Malformed mod-sync begin frame."));
+        return;
+    }
+    qint32 declaredUncompressedSize = 0;
+    qint32 fileCount = 0;
+    qint64 compressedTotal = 0;
+    qint32 chunkCount = 0;
+    stream >> declaredUncompressedSize;
+    stream >> fileCount;
+    stream >> compressedTotal;
+    stream >> chunkCount;
+    if (stream.status() != QDataStream::Ok)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN truncated header for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Malformed mod-sync begin frame."));
+        return;
+    }
+    if (declaredUncompressedSize < 0 || declaredUncompressedSize > perModCap)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN declaredUncompressedSize out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        return;
+    }
+    if (compressedTotal < 0 || compressedTotal > perModCap)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        return;
+    }
+    // Defensive: QByteArray and downstream offsets use qint32 sizes throughout the slice 5 pipeline. perModCap is qint32 today, but guard explicitly so a future widening cannot silently overflow the casts below.
+    if (compressedTotal > std::numeric_limits<qint32>::max())
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal exceeds qint32 range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 is too large to receive.").arg(modPath));
+        return;
+    }
+    if (fileCount < 0 || fileCount > fileCountMax)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN fileCount out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 exceeds the per-mod file-count cap.").arg(modPath));
+        return;
+    }
+    if (chunkCount < 0 || chunkCount > kModSyncChunkCountMax)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN chunkCount out of range for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 has too many chunks.").arg(modPath));
+        return;
+    }
+    const qint32 expectedChunkCount = compressedTotal == 0 ? 0 : static_cast<qint32>((compressedTotal + kModSyncChunkBytes - 1) / kModSyncChunkBytes);
+    if (chunkCount != expectedChunkCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN chunkCount inconsistent with compressedTotal for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod %1 chunk count is inconsistent.").arg(modPath));
+        return;
+    }
+    if (m_modSyncReceivedBytes + compressedTotal > totalCap || m_modSyncReceivedUncompressedBytes + declaredUncompressedSize > totalCap)
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN would exceed total cap for " + modPath, GameConsole::eERROR);
+        failBegin(tr("Mod-sync exceeds the total transfer cap."));
+        return;
+    }
+    if (!Filesupport::validateModPath(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN invalid mod path: " + modPath, GameConsole::eERROR);
+        failBegin(tr("Host sent an invalid mod path."));
+        return;
+    }
+    if (!m_modSyncRequestedSet.contains(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCMODBEGIN for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
+        failBegin(tr("Host sent an unrequested or duplicate mod."));
+        return;
+    }
+
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
+    m_modSyncCurrentChunkMod.modPath = modPath;
+    m_modSyncCurrentChunkMod.declaredUncompressedSize = declaredUncompressedSize;
+    m_modSyncCurrentChunkMod.fileCount = fileCount;
+    m_modSyncCurrentChunkMod.compressedTotal = compressedTotal;
+    m_modSyncCurrentChunkMod.expectedChunkCount = chunkCount;
+    if (compressedTotal > 0)
+    {
+        m_modSyncCurrentChunkMod.blob.reserve(static_cast<qint32>(compressedTotal));
+    }
+    CONSOLE_PRINT("Received MODSYNCMODBEGIN for " + modPath + " (" + QString::number(compressedTotal) + " bytes, " + QString::number(chunkCount) + " chunks)", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK without prior MODSYNCMODBEGIN; protocol violation", GameConsole::eERROR);
+        cancelModSyncSession();
+        onModSyncFailed(tr("Host sent chunk without begin."));
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    auto failChunk = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK unsupported protocol version", GameConsole::eERROR);
+        failChunk(tr("Unsupported mod-sync protocol from host."));
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK mod path overflow or malformed", GameConsole::eERROR);
+        failChunk(tr("Malformed mod-sync chunk frame."));
+        return;
+    }
+    if (modPath != m_modSyncCurrentChunkMod.modPath)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK modPath mismatch; expected " + m_modSyncCurrentChunkMod.modPath + " got " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host interleaved chunks across mods."));
+        return;
+    }
+    qint32 chunkIndex = 0;
+    stream >> chunkIndex;
+    if (stream.status() != QDataStream::Ok || chunkIndex != m_modSyncCurrentChunkMod.receivedChunkCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK out-of-order chunkIndex for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host sent chunks out of order."));
+        return;
+    }
+    QByteArray chunkBytes;
+    if (!readBoundedQByteArray(stream, chunkBytes, kModSyncChunkBytes))
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK chunk overflow or malformed for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Mod-sync chunk exceeds size limit."));
+        return;
+    }
+    const qint64 newAccumulated = static_cast<qint64>(m_modSyncCurrentChunkMod.blob.size()) + chunkBytes.size();
+    if (newAccumulated > m_modSyncCurrentChunkMod.compressedTotal)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK accumulated exceeds compressedTotal for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host sent more bytes than declared for mod %1.").arg(modPath));
+        return;
+    }
+    const bool isFinalChunk = (m_modSyncCurrentChunkMod.receivedChunkCount + 1 == m_modSyncCurrentChunkMod.expectedChunkCount);
+    const qint64 expectedThisChunk = isFinalChunk
+        ? (m_modSyncCurrentChunkMod.compressedTotal - static_cast<qint64>(m_modSyncCurrentChunkMod.blob.size()))
+        : kModSyncChunkBytes;
+    if (chunkBytes.size() != expectedThisChunk)
+    {
+        CONSOLE_PRINT("MODSYNCMODCHUNK size " + QString::number(chunkBytes.size()) + " differs from expected " + QString::number(expectedThisChunk) + " for " + modPath, GameConsole::eERROR);
+        failChunk(tr("Host sent a chunk of unexpected size."));
+        return;
+    }
+
+    m_modSyncCurrentChunkMod.blob.append(chunkBytes);
+    ++m_modSyncCurrentChunkMod.receivedChunkCount;
+    m_modSyncReceivedBytes += chunkBytes.size();
+    // Display-side proportional uncompressed advance so the bar fraction can move during a single mod; snap-corrected at MODSYNCMODEND to absorb integer-division drift.
+    qint64 perChunkUncompressedDelta = 0;
+    if (m_modSyncCurrentChunkMod.compressedTotal > 0 && m_modSyncCurrentChunkMod.declaredUncompressedSize > 0)
+    {
+        perChunkUncompressedDelta = static_cast<qint64>(chunkBytes.size()) * m_modSyncCurrentChunkMod.declaredUncompressedSize / m_modSyncCurrentChunkMod.compressedTotal;
+    }
+    m_modSyncCurrentChunkMod.uncompressedAdvanced += perChunkUncompressedDelta;
+    m_modSyncReceivedUncompressedBytes += perChunkUncompressedDelta;
+    if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
+    {
+        CONSOLE_PRINT("Mod-sync exceeds total bytes cap mid-chunk, aborting", GameConsole::eERROR);
+        failChunk(tr("Mod-sync exceeds the total transfer cap."));
+        return;
+    }
+    onModSyncProgress();
+}
+
+void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODEND without prior MODSYNCMODBEGIN; protocol violation", GameConsole::eERROR);
+        cancelModSyncSession();
+        onModSyncFailed(tr("Host sent end without begin."));
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 perModCap = settings->getModSyncMaxPerModBytes();
+    const qint32 fileCountMax = settings->getModSyncMaxFiles();
+
+    auto failEnd = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND unsupported protocol version", GameConsole::eERROR);
+        failEnd(tr("Unsupported mod-sync protocol from host."));
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCMODEND mod path overflow or malformed", GameConsole::eERROR);
+        failEnd(tr("Malformed mod-sync end frame."));
+        return;
+    }
+    if (modPath != m_modSyncCurrentChunkMod.modPath)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND modPath mismatch; expected " + m_modSyncCurrentChunkMod.modPath + " got " + modPath, GameConsole::eERROR);
+        failEnd(tr("Host ended a different mod than the one in flight."));
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.receivedChunkCount != m_modSyncCurrentChunkMod.expectedChunkCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND chunk count mismatch for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Host ended mod %1 before delivering all chunks.").arg(modPath));
+        return;
+    }
+    if (m_modSyncCurrentChunkMod.blob.size() != m_modSyncCurrentChunkMod.compressedTotal)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND blob size mismatch for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Host blob size for mod %1 did not match its declared total.").arg(modPath));
+        return;
+    }
+
+    Filesupport::ModSyncCaps caps;
+    caps.perModBytes = perModCap;
+    caps.fileCountMax = fileCountMax;
+    caps.relPathMaxLen = relPathMaxLen;
+
+    qint32 rejectReason = 0;
+    auto files = Filesupport::extractModSyncPackage(m_modSyncCurrentChunkMod.blob, m_modSyncCurrentChunkMod.declaredUncompressedSize, caps, rejectReason);
+    if (rejectReason != 0)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Failed to unpack mod %1.").arg(modPath));
+        return;
+    }
+    if (files.size() != m_modSyncCurrentChunkMod.fileCount)
+    {
+        CONSOLE_PRINT("MODSYNCMODEND file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(m_modSyncCurrentChunkMod.fileCount) + ")", GameConsole::eERROR);
+        failEnd(tr("Mod %1 file count did not match the host's declaration.").arg(modPath));
+        return;
+    }
+    qint32 stageReason = 0;
+    QString stagingRel = Filesupport::stageModSync(settings->getUserPath(), modPath, files, caps, stageReason);
+    if (stageReason != 0 || stagingRel.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCMODEND stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
+        failEnd(tr("Failed to stage mod %1 to disk.").arg(modPath));
+        return;
+    }
+
+    // Snap-correct the proportional uncompressed advance so the global counter equals the exact sum of declaredUncompressedSize values.
+    const qint64 snapDelta = static_cast<qint64>(m_modSyncCurrentChunkMod.declaredUncompressedSize) - m_modSyncCurrentChunkMod.uncompressedAdvanced;
+    if (snapDelta != 0)
+    {
+        m_modSyncReceivedUncompressedBytes += snapDelta;
+    }
+
+    m_modSyncStagings.append(qMakePair(stagingRel, modPath));
+    m_modSyncRequestedSet.remove(modPath);
+    CONSOLE_PRINT("Mod-sync staged " + modPath + " via chunked path (" + QString::number(files.size()) + " files)", GameConsole::eINFO);
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
+    onModSyncProgress();
+}
+
 void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID)
 {
     Q_UNUSED(socketID);
@@ -3122,6 +3572,13 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
         return;
     }
+    if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE arrived with chunked mod " + m_modSyncCurrentChunkMod.modPath + " still in flight; aborting", GameConsole::eERROR);
+        cancelModSyncSession();
+        onModSyncFailed(tr("Host completed before finishing the chunked mod transfer."));
+        return;
+    }
     if (!m_modSyncRequestedSet.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE arrived with " + QString::number(m_modSyncRequestedSet.size()) + " requested mods unsent; aborting", GameConsole::eERROR);
@@ -3136,6 +3593,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         m_modSyncReceivedBytes = 0;
         m_modSyncReceivedUncompressedBytes = 0;
         m_modSyncExpectedUncompressedTotal = 0;
+        m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
         m_modSyncPostSyncActiveMods.clear();
         return;
     }
@@ -3162,6 +3620,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncExpectedUncompressedTotal = 0;
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
     m_modSyncPostSyncActiveMods.clear();
     // Hold so the progress dialog gets a frame to paint at 100% before the success+restart sequence tears it down.
     QTimer::singleShot(500, this, &Multiplayermenu::onModSyncSucceeded);
@@ -3189,6 +3648,8 @@ void Multiplayermenu::cancelModSyncSession()
         m_modSyncProgressDialog->detach();
         m_modSyncProgressDialog.reset();
     }
+    // Send-state clearing is host-side and runs even when m_modSyncActive (client-side flag) is false; the next pump tick short-circuits on socketID==0.
+    m_modSyncSendState = ModSyncSendState{};
     if (!m_modSyncActive)
     {
         return;
@@ -3218,6 +3679,7 @@ void Multiplayermenu::cancelModSyncSession()
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncActive = false;
+    m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
     m_modSyncPostSyncActiveMods.clear();
 }
 

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -2605,6 +2605,19 @@ namespace
     // Version prefix on every mod-sync wire frame; bump on schema breakage.
     constexpr qint32 kModSyncProtocolVersion = 1;
 
+    // Repeated mod-sync failure texts; QT_TRANSLATE_NOOP keeps lupdate extraction working with the context tr() resolves at runtime.
+    constexpr const char* const kMsgUnsupportedModSyncProtocol = QT_TRANSLATE_NOOP("Multiplayermenu", "Unsupported mod-sync protocol from host.");
+    constexpr const char* const kMsgModSyncPerModSizeCap = QT_TRANSLATE_NOOP("Multiplayermenu", "Mod %1 exceeds the per-mod size cap.");
+    constexpr const char* const kMsgModSyncTotalCap = QT_TRANSLATE_NOOP("Multiplayermenu", "Mod-sync exceeds the total transfer cap.");
+    constexpr const char* const kMsgModSyncFileCountCap = QT_TRANSLATE_NOOP("Multiplayermenu", "Mod %1 exceeds the per-mod file-count cap.");
+    constexpr const char* const kMsgModSyncInvalidModPath = QT_TRANSLATE_NOOP("Multiplayermenu", "Host sent an invalid mod path.");
+    constexpr const char* const kMsgModSyncUnrequestedMod = QT_TRANSLATE_NOOP("Multiplayermenu", "Host sent an unrequested or duplicate mod.");
+    constexpr const char* const kMsgModSyncUnpackFailed = QT_TRANSLATE_NOOP("Multiplayermenu", "Failed to unpack mod %1.");
+    constexpr const char* const kMsgModSyncFileCountMismatch = QT_TRANSLATE_NOOP("Multiplayermenu", "Mod %1 file count did not match the host's declaration.");
+    constexpr const char* const kMsgModSyncStageFailed = QT_TRANSLATE_NOOP("Multiplayermenu", "Failed to stage mod %1 to disk.");
+    constexpr const char* const kMsgModSyncMalformedBegin = QT_TRANSLATE_NOOP("Multiplayermenu", "Malformed mod-sync begin frame.");
+    constexpr const char* const kMsgModSyncStartFailed = QT_TRANSLATE_NOOP("Multiplayermenu", "Could not start mod sync.");
+
     bool readBoundedQByteArray(QDataStream & stream, QByteArray & out, qint64 maxBytes)
     {
         if (maxBytes < 0)
@@ -3099,7 +3112,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
-        failData(tr("Unsupported mod-sync protocol from host."));
+        failData(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
 
@@ -3118,7 +3131,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stream.status() != QDataStream::Ok || declaredSize < 0 || fileCount < 0 || fileCount > fileCountMax)
     {
         CONSOLE_PRINT("MODSYNCDATA size/count out of range for " + modPath, GameConsole::eERROR);
-        failData(tr("Mod %1 exceeds the per-mod file-count cap.").arg(modPath));
+        failData(tr(kMsgModSyncFileCountCap).arg(modPath));
         return;
     }
 
@@ -3126,20 +3139,20 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!readBoundedQByteArray(stream, compressedBlob, perModCap))
     {
         CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
-        failData(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        failData(tr(kMsgModSyncPerModSizeCap).arg(modPath));
         return;
     }
 
     if (!Filesupport::validateModPath(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA invalid mod path: " + modPath, GameConsole::eERROR);
-        failData(tr("Host sent an invalid mod path."));
+        failData(tr(kMsgModSyncInvalidModPath));
         return;
     }
     if (!m_modSyncRequestedSet.contains(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
-        failData(tr("Host sent an unrequested or duplicate mod."));
+        failData(tr(kMsgModSyncUnrequestedMod));
         return;
     }
 
@@ -3148,7 +3161,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
     {
         CONSOLE_PRINT("Mod-sync exceeds total bytes cap, aborting", GameConsole::eERROR);
-        failData(tr("Mod-sync exceeds the total transfer cap."));
+        failData(tr(kMsgModSyncTotalCap));
         return;
     }
 
@@ -3162,13 +3175,13 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (rejectReason != 0)
     {
         CONSOLE_PRINT("Mod-sync extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
-        failData(tr("Failed to unpack mod %1.").arg(modPath));
+        failData(tr(kMsgModSyncUnpackFailed).arg(modPath));
         return;
     }
     if (files.size() != fileCount)
     {
         CONSOLE_PRINT("Mod-sync file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(fileCount) + ")", GameConsole::eERROR);
-        failData(tr("Mod %1 file count did not match the host's declaration.").arg(modPath));
+        failData(tr(kMsgModSyncFileCountMismatch).arg(modPath));
         return;
     }
 
@@ -3177,7 +3190,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stageReason != 0 || stagingRel.isEmpty())
     {
         CONSOLE_PRINT("Mod-sync stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
-        failData(tr("Failed to stage mod %1 to disk.").arg(modPath));
+        failData(tr(kMsgModSyncStageFailed).arg(modPath));
         return;
     }
     m_modSyncStagings.append(qMakePair(stagingRel, modPath));
@@ -3218,14 +3231,14 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN unsupported protocol version", GameConsole::eERROR);
-        failBegin(tr("Unsupported mod-sync protocol from host."));
+        failBegin(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
     if (!readBoundedQString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN mod path overflow or malformed", GameConsole::eERROR);
-        failBegin(tr("Malformed mod-sync begin frame."));
+        failBegin(tr(kMsgModSyncMalformedBegin));
         return;
     }
     qint32 declaredUncompressedSize = 0;
@@ -3239,19 +3252,19 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     if (stream.status() != QDataStream::Ok)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN truncated header for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Malformed mod-sync begin frame."));
+        failBegin(tr(kMsgModSyncMalformedBegin));
         return;
     }
     if (declaredUncompressedSize < 0 || declaredUncompressedSize > perModCap)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN declaredUncompressedSize out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        failBegin(tr(kMsgModSyncPerModSizeCap).arg(modPath));
         return;
     }
     if (compressedTotal < 0 || compressedTotal > perModCap)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
+        failBegin(tr(kMsgModSyncPerModSizeCap).arg(modPath));
         return;
     }
     // Defensive: QByteArray and downstream offsets use qint32 sizes throughout the slice 5 pipeline. perModCap is qint32 today, but guard explicitly so a future widening cannot silently overflow the casts below.
@@ -3264,7 +3277,7 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     if (fileCount < 0 || fileCount > fileCountMax)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN fileCount out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod %1 exceeds the per-mod file-count cap.").arg(modPath));
+        failBegin(tr(kMsgModSyncFileCountCap).arg(modPath));
         return;
     }
     if (chunkCount < 0 || chunkCount > kModSyncChunkCountMax)
@@ -3283,19 +3296,19 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     if (m_modSyncReceivedBytes + compressedTotal > totalCap || m_modSyncReceivedUncompressedBytes + declaredUncompressedSize > totalCap)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN would exceed total cap for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod-sync exceeds the total transfer cap."));
+        failBegin(tr(kMsgModSyncTotalCap));
         return;
     }
     if (!Filesupport::validateModPath(modPath))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN invalid mod path: " + modPath, GameConsole::eERROR);
-        failBegin(tr("Host sent an invalid mod path."));
+        failBegin(tr(kMsgModSyncInvalidModPath));
         return;
     }
     if (!m_modSyncRequestedSet.contains(modPath))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
-        failBegin(tr("Host sent an unrequested or duplicate mod."));
+        failBegin(tr(kMsgModSyncUnrequestedMod));
         return;
     }
 
@@ -3342,7 +3355,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK unsupported protocol version", GameConsole::eERROR);
-        failChunk(tr("Unsupported mod-sync protocol from host."));
+        failChunk(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
@@ -3405,7 +3418,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
     if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
     {
         CONSOLE_PRINT("Mod-sync exceeds total bytes cap mid-chunk, aborting", GameConsole::eERROR);
-        failChunk(tr("Mod-sync exceeds the total transfer cap."));
+        failChunk(tr(kMsgModSyncTotalCap));
         return;
     }
     onModSyncProgress();
@@ -3442,7 +3455,7 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODEND unsupported protocol version", GameConsole::eERROR);
-        failEnd(tr("Unsupported mod-sync protocol from host."));
+        failEnd(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
@@ -3481,13 +3494,13 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
     if (rejectReason != 0)
     {
         CONSOLE_PRINT("MODSYNCMODEND extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
-        failEnd(tr("Failed to unpack mod %1.").arg(modPath));
+        failEnd(tr(kMsgModSyncUnpackFailed).arg(modPath));
         return;
     }
     if (files.size() != m_modSyncCurrentChunkMod.fileCount)
     {
         CONSOLE_PRINT("MODSYNCMODEND file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(m_modSyncCurrentChunkMod.fileCount) + ")", GameConsole::eERROR);
-        failEnd(tr("Mod %1 file count did not match the host's declaration.").arg(modPath));
+        failEnd(tr(kMsgModSyncFileCountMismatch).arg(modPath));
         return;
     }
     qint32 stageReason = 0;
@@ -3495,7 +3508,7 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
     if (stageReason != 0 || stagingRel.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCMODEND stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
-        failEnd(tr("Failed to stage mod %1 to disk.").arg(modPath));
+        failEnd(tr(kMsgModSyncStageFailed).arg(modPath));
         return;
     }
 
@@ -3531,7 +3544,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
-        onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
+        onModSyncFailed(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
@@ -3575,7 +3588,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
-        onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
+        onModSyncFailed(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
@@ -3702,7 +3715,7 @@ void Multiplayermenu::confirmModSync(const QStringList & modsToDownload, const Q
         }
         else
         {
-            onModSyncFailed(tr("Could not start mod sync."));
+            onModSyncFailed(tr(kMsgModSyncStartFailed));
         }
         return;
     }
@@ -3723,7 +3736,7 @@ void Multiplayermenu::startModSyncDownload(const QStringList & modsToDownload, c
     const bool ok = requestModSync(modsToDownload, postSyncActiveMods);
     if (!ok)
     {
-        onModSyncFailed(tr("Could not start mod sync."));
+        onModSyncFailed(tr(kMsgModSyncStartFailed));
         return;
     }
     if (m_pJoinConnectingDialog != nullptr)

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -2596,12 +2596,6 @@ namespace
     // Hard ceiling on chunkCount declared in MODSYNCMODBEGIN; even at perModCap = 1 GB that's only ~1024 chunks at 1 MiB.
     constexpr qint32 kModSyncChunkCountMax = 1024 * 1024;
 
-    // QDataStream::operator>> pre-resizes to the declared length; bounded readers reject the header before allocation.
-    constexpr quint32 kInt32MaxAsU32 = 0x7FFFFFFFu;
-    // QDataStream encodes a null QByteArray or QString length as 0xFFFFFFFFu; mirrors filesupport.cpp.
-    constexpr quint32 kQDataStreamNullSentinel = 0xFFFFFFFFu;
-    constexpr qint32 kBytesPerUtf16CodeUnit = 2;
-    constexpr qint32 kBitsPerByte = 8;
     // Version prefix on every mod-sync wire frame; bump on schema breakage.
     constexpr qint32 kModSyncProtocolVersion = 1;
 
@@ -2618,73 +2612,6 @@ namespace
     constexpr const char* const kMsgModSyncMalformedBegin = QT_TRANSLATE_NOOP("Multiplayermenu", "Malformed mod-sync begin frame.");
     constexpr const char* const kMsgModSyncStartFailed = QT_TRANSLATE_NOOP("Multiplayermenu", "Could not start mod sync.");
 
-    bool readBoundedQByteArray(QDataStream & stream, QByteArray & out, qint64 maxBytes)
-    {
-        if (maxBytes < 0)
-        {
-            return false;
-        }
-        quint32 declared = 0;
-        stream >> declared;
-        if (stream.status() != QDataStream::Ok)
-        {
-            return false;
-        }
-        if (declared == kQDataStreamNullSentinel)
-        {
-            out.clear();
-            return true;
-        }
-        if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes)
-        {
-            return false;
-        }
-        out.resize(static_cast<qint32>(declared));
-        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
-        {
-            return false;
-        }
-        return true;
-    }
-
-    bool readBoundedQString(QDataStream & stream, QString & out, qint32 maxChars)
-    {
-        if (maxChars < 0)
-        {
-            return false;
-        }
-        quint32 declared = 0;
-        stream >> declared;
-        if (stream.status() != QDataStream::Ok)
-        {
-            return false;
-        }
-        if (declared == kQDataStreamNullSentinel)
-        {
-            out.clear();
-            return true;
-        }
-        const qint64 maxBytes = static_cast<qint64>(maxChars) * kBytesPerUtf16CodeUnit;
-        if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes || (declared % kBytesPerUtf16CodeUnit) != 0)
-        {
-            return false;
-        }
-        QByteArray buf;
-        buf.resize(static_cast<qint32>(declared));
-        if (buf.size() > 0 && stream.readRawData(buf.data(), buf.size()) != buf.size())
-        {
-            return false;
-        }
-        const qint32 codeUnits = buf.size() / kBytesPerUtf16CodeUnit;
-        out.resize(codeUnits);
-        const uchar * src = reinterpret_cast<const uchar *>(buf.constData());
-        // Wire is big-endian; build each code unit explicitly to skip platform-endian conversion in fromUtf16.
-        for (qint32 i = 0; i < codeUnits; ++i)
-        {
-            out[i] = QChar(static_cast<ushort>((src[i * kBytesPerUtf16CodeUnit] << kBitsPerByte) | src[i * kBytesPerUtf16CodeUnit + 1]));
-        }
-        return true;
-    }
 }
 
 bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
@@ -2779,7 +2706,7 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         for (qint32 i = 0; i < modCount; ++i)
         {
             QString mod;
-            if (!readBoundedQString(stream, mod, relPathMaxLen))
+            if (!Filesupport::readBoundedString(stream, mod, relPathMaxLen))
             {
                 sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath, QString(), tr("Malformed mod path in request."));
                 return;
@@ -3044,7 +2971,7 @@ void Multiplayermenu::handleModSyncManifest(QDataStream & stream, quint64 socket
     for (qint32 i = 0; i < entryCount; ++i)
     {
         QString modPath;
-        if (!readBoundedQString(stream, modPath, relPathMaxLen))
+        if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
         {
             CONSOLE_PRINT("MODSYNCMANIFEST mod path overflow or malformed, ignoring", GameConsole::eWARNING);
             return;
@@ -3119,7 +3046,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     }
 
     QString modPath;
-    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCDATA mod path overflow or malformed", GameConsole::eERROR);
         failData(tr("Malformed mod-sync data frame."));
@@ -3138,7 +3065,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     }
 
     QByteArray compressedBlob;
-    if (!readBoundedQByteArray(stream, compressedBlob, perModCap))
+    if (!Filesupport::readBoundedBytes(stream, compressedBlob, perModCap))
     {
         CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
         failData(tr(kMsgModSyncPerModSizeCap).arg(modPath));
@@ -3237,7 +3164,7 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
         return;
     }
     QString modPath;
-    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN mod path overflow or malformed", GameConsole::eERROR);
         failBegin(tr(kMsgModSyncMalformedBegin));
@@ -3361,7 +3288,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
         return;
     }
     QString modPath;
-    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK mod path overflow or malformed", GameConsole::eERROR);
         failChunk(tr("Malformed mod-sync chunk frame."));
@@ -3382,7 +3309,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
         return;
     }
     QByteArray chunkBytes;
-    if (!readBoundedQByteArray(stream, chunkBytes, kModSyncChunkBytes))
+    if (!Filesupport::readBoundedBytes(stream, chunkBytes, kModSyncChunkBytes))
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK chunk overflow or malformed for " + modPath, GameConsole::eERROR);
         failChunk(tr("Mod-sync chunk exceeds size limit."));
@@ -3461,7 +3388,7 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
         return;
     }
     QString modPath;
-    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODEND mod path overflow or malformed", GameConsole::eERROR);
         failEnd(tr("Malformed mod-sync end frame."));
@@ -3550,7 +3477,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
         return;
     }
     QString modPath;
-    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCREJECT mod path overflow or malformed", GameConsole::eERROR);
         cancelModSyncSession();
@@ -3560,7 +3487,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     qint32 reasonCode = 0;
     stream >> reasonCode;
     QString reasonMessage;
-    if (!readBoundedQString(stream, reasonMessage, kModSyncReasonCharsMax))
+    if (!Filesupport::readBoundedString(stream, reasonMessage, kModSyncReasonCharsMax))
     {
         CONSOLE_PRINT("MODSYNCREJECT reason message overflow or malformed (code=" + QString::number(reasonCode) + " mod=" + modPath + ")", GameConsole::eERROR);
         cancelModSyncSession();

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1463,6 +1463,39 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
     }
 }
 
+namespace
+{
+    // Cap per mismatch section in the dialog; the full lists go to the console log.
+    constexpr qint32 kMismatchDisplayLimit = 5;
+
+    void logFullList(const QString & label, const QStringList & list)
+    {
+        if (!list.isEmpty())
+        {
+            CONSOLE_PRINT(label + ": " + list.join(", "), GameConsole::eINFO);
+        }
+    }
+
+    void appendSection(QString & dst, const QString & header, const QStringList & lines)
+    {
+        if (lines.isEmpty())
+        {
+            return;
+        }
+        dst += header + "\n";
+        const qint32 shown = std::min(static_cast<qint32>(lines.size()), kMismatchDisplayLimit);
+        for (qint32 i = 0; i < shown; ++i)
+        {
+            dst += "  " + lines[i] + "\n";
+        }
+        if (lines.size() > kMismatchDisplayLimit)
+        {
+            dst += "  " + Multiplayermenu::tr("...and %1 more (see console.log)").arg(lines.size() - kMismatchDisplayLimit) + "\n";
+        }
+        dst += "\n";
+    }
+}
+
 void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, const QMap<QString, QByteArray> & hostModHashes, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed)
 {
     // Mod/hash fields are stale on version mismatch because readHashInfo early-returns.
@@ -1474,7 +1507,6 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
         return;
     }
 
-    constexpr qint32 DISPLAY_LIMIT = 5;
     auto * settings = Settings::getInstance();
 
     QStringList missingHere;
@@ -1533,37 +1565,11 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
         }
     }
 
-    auto logFullList = [](const QString & label, const QStringList & list)
-    {
-        if (!list.isEmpty())
-        {
-            CONSOLE_PRINT(label + ": " + list.join(", "), GameConsole::eINFO);
-        }
-    };
     logFullList(QStringLiteral("Mods host has that you are missing"), missingHere);
     logFullList(QStringLiteral("Mods you have that host does not"), extraHere);
     logFullList(QStringLiteral("Mods with version-string mismatch"), versionDiffs);
     logFullList(QStringLiteral("Mods with different content"), contentDiffs);
     logFullList(QStringLiteral("Engine resource folders modified"), mismatchedResourceFolders);
-
-    auto appendSection = [&](QString & dst, const QString & header, const QStringList & lines)
-    {
-        if (lines.isEmpty())
-        {
-            return;
-        }
-        dst += header + "\n";
-        const qint32 shown = std::min(static_cast<qint32>(lines.size()), DISPLAY_LIMIT);
-        for (qint32 i = 0; i < shown; ++i)
-        {
-            dst += "  " + lines[i] + "\n";
-        }
-        if (lines.size() > DISPLAY_LIMIT)
-        {
-            dst += "  " + tr("...and %1 more (see console.log)").arg(lines.size() - DISPLAY_LIMIT) + "\n";
-        }
-        dst += "\n";
-    };
 
     QString message;
     appendSection(message, tr("Missing mods (host has, you don't):"), missingHere);
@@ -2612,6 +2618,23 @@ namespace
     constexpr const char* const kMsgModSyncMalformedBegin = QT_TRANSLATE_NOOP("Multiplayermenu", "Malformed mod-sync begin frame.");
     constexpr const char* const kMsgModSyncStartFailed = QT_TRANSLATE_NOOP("Multiplayermenu", "Could not start mod sync.");
 
+    QString packageRejectReason(NetworkCommands::ModSyncRejectReason code, const QString & mod)
+    {
+        switch (code)
+        {
+            case NetworkCommands::ModSyncRejectReason::ModSyncSizeCapExceeded:
+                return Multiplayermenu::tr("Mod %1 exceeds the per-mod size cap on the host.").arg(mod);
+            case NetworkCommands::ModSyncRejectReason::ModSyncFileCountCapExceeded:
+                return Multiplayermenu::tr("Mod %1 exceeds the per-mod file-count cap on the host.").arg(mod);
+            case NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath:
+                return Multiplayermenu::tr("Mod %1 has an unsafe internal file path.").arg(mod);
+            case NetworkCommands::ModSyncRejectReason::ModSyncUnknownMod:
+                return Multiplayermenu::tr("Mod %1 was not found on the host.").arg(mod);
+            default:
+                return Multiplayermenu::tr("Failed to build mod package for %1.").arg(mod);
+        }
+    }
+
 }
 
 bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
@@ -2748,23 +2771,6 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     const qint64 totalCap = settings->getModSyncMaxTotalBytes();
     qint64 totalSent = 0;
     qint64 totalUncompressed = 0;
-
-    auto packageRejectReason = [this](NetworkCommands::ModSyncRejectReason code, const QString & mod) -> QString
-    {
-        switch (code)
-        {
-            case NetworkCommands::ModSyncRejectReason::ModSyncSizeCapExceeded:
-                return tr("Mod %1 exceeds the per-mod size cap on the host.").arg(mod);
-            case NetworkCommands::ModSyncRejectReason::ModSyncFileCountCapExceeded:
-                return tr("Mod %1 exceeds the per-mod file-count cap on the host.").arg(mod);
-            case NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath:
-                return tr("Mod %1 has an unsafe internal file path.").arg(mod);
-            case NetworkCommands::ModSyncRejectReason::ModSyncUnknownMod:
-                return tr("Mod %1 was not found on the host.").arg(mod);
-            default:
-                return tr("Failed to build mod package for %1.").arg(mod);
-        }
-    };
 
     // Pre-build so the manifest carries exact sizes; peak ~totalCap, each blob freed after its MODSYNCDATA send.
     QVector<QPair<QString, Filesupport::ModSyncPackage>> builtPackages;
@@ -3023,16 +3029,10 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     const qint32 fileCountMax = settings->getModSyncMaxFiles();
     const qint64 totalCap = settings->getModSyncMaxTotalBytes();
 
-    auto failData = [this](const QString & uiReason)
-    {
-        cancelModSyncSession();
-        onModSyncFailed(uiReason);
-    };
-
     if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCDATA arrived while a chunked mod is in flight; protocol violation", GameConsole::eERROR);
-        failData(tr("Host mixed chunked and legacy mod-sync framing."));
+        failModSync(tr("Host mixed chunked and legacy mod-sync framing."));
         return;
     }
 
@@ -3041,7 +3041,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
-        failData(tr(kMsgUnsupportedModSyncProtocol));
+        failModSync(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
 
@@ -3049,7 +3049,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCDATA mod path overflow or malformed", GameConsole::eERROR);
-        failData(tr("Malformed mod-sync data frame."));
+        failModSync(tr("Malformed mod-sync data frame."));
         return;
     }
 
@@ -3060,7 +3060,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stream.status() != QDataStream::Ok || declaredSize < 0 || fileCount < 0 || fileCount > fileCountMax)
     {
         CONSOLE_PRINT("MODSYNCDATA size/count out of range for " + modPath, GameConsole::eERROR);
-        failData(tr(kMsgModSyncFileCountCap).arg(modPath));
+        failModSync(tr(kMsgModSyncFileCountCap).arg(modPath));
         return;
     }
 
@@ -3068,20 +3068,20 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!Filesupport::readBoundedBytes(stream, compressedBlob, perModCap))
     {
         CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
-        failData(tr(kMsgModSyncPerModSizeCap).arg(modPath));
+        failModSync(tr(kMsgModSyncPerModSizeCap).arg(modPath));
         return;
     }
 
     if (!Filesupport::validateModPath(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA invalid mod path: " + modPath, GameConsole::eERROR);
-        failData(tr(kMsgModSyncInvalidModPath));
+        failModSync(tr(kMsgModSyncInvalidModPath));
         return;
     }
     if (!m_modSyncRequestedSet.contains(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
-        failData(tr(kMsgModSyncUnrequestedMod));
+        failModSync(tr(kMsgModSyncUnrequestedMod));
         return;
     }
 
@@ -3090,7 +3090,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
     {
         CONSOLE_PRINT("Mod-sync exceeds total bytes cap, aborting", GameConsole::eERROR);
-        failData(tr(kMsgModSyncTotalCap));
+        failModSync(tr(kMsgModSyncTotalCap));
         return;
     }
 
@@ -3104,13 +3104,13 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (rejectReason != 0)
     {
         CONSOLE_PRINT("Mod-sync extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
-        failData(tr(kMsgModSyncUnpackFailed).arg(modPath));
+        failModSync(tr(kMsgModSyncUnpackFailed).arg(modPath));
         return;
     }
     if (files.size() != fileCount)
     {
         CONSOLE_PRINT("Mod-sync file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(fileCount) + ")", GameConsole::eERROR);
-        failData(tr(kMsgModSyncFileCountMismatch).arg(modPath));
+        failModSync(tr(kMsgModSyncFileCountMismatch).arg(modPath));
         return;
     }
 
@@ -3119,7 +3119,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stageReason != 0 || stagingRel.isEmpty())
     {
         CONSOLE_PRINT("Mod-sync stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
-        failData(tr(kMsgModSyncStageFailed).arg(modPath));
+        failModSync(tr(kMsgModSyncStageFailed).arg(modPath));
         return;
     }
     m_modSyncStagings.append(qMakePair(stagingRel, modPath));
@@ -3142,16 +3142,10 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     const qint32 fileCountMax = settings->getModSyncMaxFiles();
     const qint64 totalCap = settings->getModSyncMaxTotalBytes();
 
-    auto failBegin = [this](const QString & uiReason)
-    {
-        cancelModSyncSession();
-        onModSyncFailed(uiReason);
-    };
-
     if (!m_modSyncCurrentChunkMod.modPath.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN while a chunked mod is already in flight; protocol violation", GameConsole::eERROR);
-        failBegin(tr("Host opened a second chunked mod before finishing the first."));
+        failModSync(tr("Host opened a second chunked mod before finishing the first."));
         return;
     }
 
@@ -3160,14 +3154,14 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN unsupported protocol version", GameConsole::eERROR);
-        failBegin(tr(kMsgUnsupportedModSyncProtocol));
+        failModSync(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
     if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN mod path overflow or malformed", GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncMalformedBegin));
+        failModSync(tr(kMsgModSyncMalformedBegin));
         return;
     }
     qint32 declaredUncompressedSize = 0;
@@ -3181,63 +3175,63 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
     if (stream.status() != QDataStream::Ok)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN truncated header for " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncMalformedBegin));
+        failModSync(tr(kMsgModSyncMalformedBegin));
         return;
     }
     if (declaredUncompressedSize < 0 || declaredUncompressedSize > perModCap)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN declaredUncompressedSize out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncPerModSizeCap).arg(modPath));
+        failModSync(tr(kMsgModSyncPerModSizeCap).arg(modPath));
         return;
     }
     if (compressedTotal < 0 || compressedTotal > perModCap)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncPerModSizeCap).arg(modPath));
+        failModSync(tr(kMsgModSyncPerModSizeCap).arg(modPath));
         return;
     }
     // Defensive: QByteArray and downstream offsets use qint32 sizes throughout the slice 5 pipeline. perModCap is qint32 today, but guard explicitly so a future widening cannot silently overflow the casts below.
     if (compressedTotal > std::numeric_limits<qint32>::max())
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN compressedTotal exceeds qint32 range for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod %1 is too large to receive.").arg(modPath));
+        failModSync(tr("Mod %1 is too large to receive.").arg(modPath));
         return;
     }
     if (fileCount < 0 || fileCount > fileCountMax)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN fileCount out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncFileCountCap).arg(modPath));
+        failModSync(tr(kMsgModSyncFileCountCap).arg(modPath));
         return;
     }
     if (chunkCount < 0 || chunkCount > kModSyncChunkCountMax)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN chunkCount out of range for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod %1 has too many chunks.").arg(modPath));
+        failModSync(tr("Mod %1 has too many chunks.").arg(modPath));
         return;
     }
     const qint32 expectedChunkCount = compressedTotal == 0 ? 0 : static_cast<qint32>((compressedTotal + kModSyncChunkBytes - 1) / kModSyncChunkBytes);
     if (chunkCount != expectedChunkCount)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN chunkCount inconsistent with compressedTotal for " + modPath, GameConsole::eERROR);
-        failBegin(tr("Mod %1 chunk count is inconsistent.").arg(modPath));
+        failModSync(tr("Mod %1 chunk count is inconsistent.").arg(modPath));
         return;
     }
     if (m_modSyncReceivedBytes + compressedTotal > totalCap || m_modSyncReceivedUncompressedBytes + declaredUncompressedSize > totalCap)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN would exceed total cap for " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncTotalCap));
+        failModSync(tr(kMsgModSyncTotalCap));
         return;
     }
     if (!Filesupport::validateModPath(modPath))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN invalid mod path: " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncInvalidModPath));
+        failModSync(tr(kMsgModSyncInvalidModPath));
         return;
     }
     if (!m_modSyncRequestedSet.contains(modPath))
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
-        failBegin(tr(kMsgModSyncUnrequestedMod));
+        failModSync(tr(kMsgModSyncUnrequestedMod));
         return;
     }
 
@@ -3273,31 +3267,25 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
     const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
     const qint64 totalCap = settings->getModSyncMaxTotalBytes();
 
-    auto failChunk = [this](const QString & uiReason)
-    {
-        cancelModSyncSession();
-        onModSyncFailed(uiReason);
-    };
-
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK unsupported protocol version", GameConsole::eERROR);
-        failChunk(tr(kMsgUnsupportedModSyncProtocol));
+        failModSync(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
     if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK mod path overflow or malformed", GameConsole::eERROR);
-        failChunk(tr("Malformed mod-sync chunk frame."));
+        failModSync(tr("Malformed mod-sync chunk frame."));
         return;
     }
     if (modPath != m_modSyncCurrentChunkMod.modPath)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK modPath mismatch; expected " + m_modSyncCurrentChunkMod.modPath + " got " + modPath, GameConsole::eERROR);
-        failChunk(tr("Host interleaved chunks across mods."));
+        failModSync(tr("Host interleaved chunks across mods."));
         return;
     }
     qint32 chunkIndex = 0;
@@ -3305,21 +3293,21 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
     if (stream.status() != QDataStream::Ok || chunkIndex != m_modSyncCurrentChunkMod.receivedChunkCount)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK out-of-order chunkIndex for " + modPath, GameConsole::eERROR);
-        failChunk(tr("Host sent chunks out of order."));
+        failModSync(tr("Host sent chunks out of order."));
         return;
     }
     QByteArray chunkBytes;
     if (!Filesupport::readBoundedBytes(stream, chunkBytes, kModSyncChunkBytes))
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK chunk overflow or malformed for " + modPath, GameConsole::eERROR);
-        failChunk(tr("Mod-sync chunk exceeds size limit."));
+        failModSync(tr("Mod-sync chunk exceeds size limit."));
         return;
     }
     const qint64 newAccumulated = static_cast<qint64>(m_modSyncCurrentChunkMod.blob.size()) + chunkBytes.size();
     if (newAccumulated > m_modSyncCurrentChunkMod.compressedTotal)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK accumulated exceeds compressedTotal for " + modPath, GameConsole::eERROR);
-        failChunk(tr("Host sent more bytes than declared for mod %1.").arg(modPath));
+        failModSync(tr("Host sent more bytes than declared for mod %1.").arg(modPath));
         return;
     }
     const bool isFinalChunk = (m_modSyncCurrentChunkMod.receivedChunkCount + 1 == m_modSyncCurrentChunkMod.expectedChunkCount);
@@ -3329,7 +3317,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
     if (chunkBytes.size() != expectedThisChunk)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK size " + QString::number(chunkBytes.size()) + " differs from expected " + QString::number(expectedThisChunk) + " for " + modPath, GameConsole::eERROR);
-        failChunk(tr("Host sent a chunk of unexpected size."));
+        failModSync(tr("Host sent a chunk of unexpected size."));
         return;
     }
 
@@ -3347,7 +3335,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
     if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
     {
         CONSOLE_PRINT("Mod-sync exceeds total bytes cap mid-chunk, aborting", GameConsole::eERROR);
-        failChunk(tr(kMsgModSyncTotalCap));
+        failModSync(tr(kMsgModSyncTotalCap));
         return;
     }
     onModSyncProgress();
@@ -3373,43 +3361,37 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
     const qint64 perModCap = settings->getModSyncMaxPerModBytes();
     const qint32 fileCountMax = settings->getModSyncMaxFiles();
 
-    auto failEnd = [this](const QString & uiReason)
-    {
-        cancelModSyncSession();
-        onModSyncFailed(uiReason);
-    };
-
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODEND unsupported protocol version", GameConsole::eERROR);
-        failEnd(tr(kMsgUnsupportedModSyncProtocol));
+        failModSync(tr(kMsgUnsupportedModSyncProtocol));
         return;
     }
     QString modPath;
     if (!Filesupport::readBoundedString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCMODEND mod path overflow or malformed", GameConsole::eERROR);
-        failEnd(tr("Malformed mod-sync end frame."));
+        failModSync(tr("Malformed mod-sync end frame."));
         return;
     }
     if (modPath != m_modSyncCurrentChunkMod.modPath)
     {
         CONSOLE_PRINT("MODSYNCMODEND modPath mismatch; expected " + m_modSyncCurrentChunkMod.modPath + " got " + modPath, GameConsole::eERROR);
-        failEnd(tr("Host ended a different mod than the one in flight."));
+        failModSync(tr("Host ended a different mod than the one in flight."));
         return;
     }
     if (m_modSyncCurrentChunkMod.receivedChunkCount != m_modSyncCurrentChunkMod.expectedChunkCount)
     {
         CONSOLE_PRINT("MODSYNCMODEND chunk count mismatch for " + modPath, GameConsole::eERROR);
-        failEnd(tr("Host ended mod %1 before delivering all chunks.").arg(modPath));
+        failModSync(tr("Host ended mod %1 before delivering all chunks.").arg(modPath));
         return;
     }
     if (m_modSyncCurrentChunkMod.blob.size() != m_modSyncCurrentChunkMod.compressedTotal)
     {
         CONSOLE_PRINT("MODSYNCMODEND blob size mismatch for " + modPath, GameConsole::eERROR);
-        failEnd(tr("Host blob size for mod %1 did not match its declared total.").arg(modPath));
+        failModSync(tr("Host blob size for mod %1 did not match its declared total.").arg(modPath));
         return;
     }
 
@@ -3423,13 +3405,13 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
     if (rejectReason != 0)
     {
         CONSOLE_PRINT("MODSYNCMODEND extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
-        failEnd(tr(kMsgModSyncUnpackFailed).arg(modPath));
+        failModSync(tr(kMsgModSyncUnpackFailed).arg(modPath));
         return;
     }
     if (files.size() != m_modSyncCurrentChunkMod.fileCount)
     {
         CONSOLE_PRINT("MODSYNCMODEND file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(m_modSyncCurrentChunkMod.fileCount) + ")", GameConsole::eERROR);
-        failEnd(tr(kMsgModSyncFileCountMismatch).arg(modPath));
+        failModSync(tr(kMsgModSyncFileCountMismatch).arg(modPath));
         return;
     }
     qint32 stageReason = 0;
@@ -3437,7 +3419,7 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
     if (stageReason != 0 || stagingRel.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCMODEND stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
-        failEnd(tr(kMsgModSyncStageFailed).arg(modPath));
+        failModSync(tr(kMsgModSyncStageFailed).arg(modPath));
         return;
     }
 
@@ -3588,6 +3570,12 @@ void Multiplayermenu::sendModSyncReject(quint64 socketID, NetworkCommands::ModSy
     stream << message;
     emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
     CONSOLE_PRINT("Sent MODSYNCREJECT code=" + QString::number(static_cast<qint32>(reasonCode)) + " mod=" + modPath + " msg=" + message, GameConsole::eINFO);
+}
+
+void Multiplayermenu::failModSync(const QString & uiReason)
+{
+    cancelModSyncSession();
+    onModSyncFailed(uiReason);
 }
 
 void Multiplayermenu::cancelModSyncSession()

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -142,10 +142,12 @@ void Multiplayermenu::initClientAndWaitForConnection()
 
     connect(m_pPlayerSelection.get(), &PlayerSelection::sigDisconnect, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
     // wait 10 minutes till timeout
-    spDialogConnecting pDialogConnecting = MemoryManagement::create<DialogConnecting>(tr("Connecting"), 1000 * 60 * 5);
-    addChild(pDialogConnecting);
-    connect(pDialogConnecting.get(), &DialogConnecting::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
-    connect(this, &Multiplayermenu::sigConnected, pDialogConnecting.get(), &DialogConnecting::connected, Qt::QueuedConnection);
+    m_pJoinConnectingDialog = MemoryManagement::create<DialogConnecting>(tr("Connecting"), 1000 * 60 * 5);
+    addChild(m_pJoinConnectingDialog);
+    connect(m_pJoinConnectingDialog.get(), &DialogConnecting::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    connect(this, &Multiplayermenu::sigConnected, m_pJoinConnectingDialog.get(), &DialogConnecting::connected, Qt::QueuedConnection);
+    // Drop the smart-ptr after the dialog's own connected() slot has detached it, so a retained reference can't keep the actor alive past the lobby join.
+    connect(this, &Multiplayermenu::sigConnected, this, [this](){ m_pJoinConnectingDialog.reset(); }, Qt::QueuedConnection);
 }
 
 void Multiplayermenu::init()
@@ -546,6 +548,10 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         else if (messageType == NetworkCommands::REQUESTMODSYNC)
         {
             handleModSyncRequest(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCMANIFEST)
+        {
+            handleModSyncManifest(stream, socketID);
         }
         else if (messageType == NetworkCommands::MODSYNCDATA)
         {
@@ -2675,6 +2681,7 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     m_modSyncRequestedSet = QSet<QString>(modsToDownload.cbegin(), modsToDownload.cend());
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncPostSyncActiveMods = postSyncActiveMods;
 
     QByteArray data;
@@ -2774,6 +2781,9 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         }
     };
 
+    // Pre-build so the manifest carries exact sizes; peak ~totalCap, each blob freed after its MODSYNCDATA send.
+    QVector<QPair<QString, Filesupport::ModSyncPackage>> builtPackages;
+    builtPackages.reserve(requestedMods.size());
     for (const auto & mod : std::as_const(requestedMods))
     {
         if (!Filesupport::validateModPath(mod))
@@ -2821,18 +2831,40 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         }
         totalSent += pkg.compressedBlob.size();
         totalUncompressed += pkg.declaredUncompressedSize;
+        builtPackages.append(qMakePair(mod, std::move(pkg)));
+    }
 
+    {
+        QByteArray manifestData;
+        QDataStream manifestStream(&manifestData, QIODevice::WriteOnly);
+        manifestStream.setVersion(QDataStream::Version::Qt_6_5);
+        manifestStream << QString(NetworkCommands::MODSYNCMANIFEST);
+        manifestStream << static_cast<qint32>(1);
+        manifestStream << static_cast<qint32>(builtPackages.size());
+        for (const auto & entry : std::as_const(builtPackages))
+        {
+            manifestStream << entry.first;
+            manifestStream << entry.second.declaredUncompressedSize;
+        }
+        emit m_pNetworkInterface->sig_sendData(socketID, manifestData, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCMANIFEST; " + QString::number(builtPackages.size()) + " mods, " + QString::number(totalUncompressed) + " expected uncompressed bytes", GameConsole::eINFO);
+    }
+
+    for (auto & entry : builtPackages)
+    {
         QByteArray data;
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCDATA);
         sendStream << static_cast<qint32>(1);
-        sendStream << mod;
-        sendStream << pkg.declaredUncompressedSize;
-        sendStream << pkg.fileCount;
-        sendStream << pkg.compressedBlob;
+        sendStream << entry.first;
+        sendStream << entry.second.declaredUncompressedSize;
+        sendStream << entry.second.fileCount;
+        sendStream << entry.second.compressedBlob;
         emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-        CONSOLE_PRINT("Sent MODSYNCDATA for " + mod + " (" + QString::number(pkg.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
+        CONSOLE_PRINT("Sent MODSYNCDATA for " + entry.first + " (" + QString::number(entry.second.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
+        // QByteArray COW: clearing here drops only our ref; the queued send keeps its own.
+        entry.second.compressedBlob.clear();
     }
 
     QByteArray data;
@@ -2842,6 +2874,75 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     sendStream << static_cast<qint32>(1);
     emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
     CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(requestedMods.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncManifest(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST unsupported protocol version, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    qint32 entryCount = 0;
+    stream >> entryCount;
+    if (stream.status() != QDataStream::Ok || entryCount < 0 || entryCount > kModSyncRequestCountMax)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST malformed entry count, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    qint64 expectedTotal = 0;
+    qint32 ignoredEntries = 0;
+    for (qint32 i = 0; i < entryCount; ++i)
+    {
+        QString modPath;
+        if (!readBoundedQString(stream, modPath, relPathMaxLen))
+        {
+            CONSOLE_PRINT("MODSYNCMANIFEST mod path overflow or malformed, ignoring", GameConsole::eWARNING);
+            return;
+        }
+        qint32 declaredSize = 0;
+        stream >> declaredSize;
+        if (stream.status() != QDataStream::Ok || declaredSize < 0)
+        {
+            CONSOLE_PRINT("MODSYNCMANIFEST declared size out of range for " + modPath + ", ignoring", GameConsole::eWARNING);
+            return;
+        }
+        // Only count entries the client actually asked for; a hostile or buggy host could otherwise inflate expectedTotal to drive the bar to 100% before any data lands.
+        if (!m_modSyncRequestedSet.contains(modPath))
+        {
+            ++ignoredEntries;
+            continue;
+        }
+        expectedTotal += declaredSize;
+        if (expectedTotal > totalCap)
+        {
+            CONSOLE_PRINT("MODSYNCMANIFEST expected total exceeds host total cap; clamping for display only", GameConsole::eWARNING);
+            expectedTotal = totalCap;
+            break;
+        }
+    }
+    if (ignoredEntries > 0)
+    {
+        CONSOLE_PRINT("MODSYNCMANIFEST ignored " + QString::number(ignoredEntries) + " entries not in the client's request set", GameConsole::eWARNING);
+    }
+    m_modSyncExpectedUncompressedTotal = expectedTotal;
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->setExpectedTotalBytes(expectedTotal);
+    }
+    CONSOLE_PRINT("Received MODSYNCMANIFEST; expected uncompressed total " + QString::number(expectedTotal) + " bytes across " + QString::number(entryCount) + " mods", GameConsole::eINFO);
 }
 
 void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
@@ -3034,6 +3135,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         m_modSyncActive = false;
         m_modSyncReceivedBytes = 0;
         m_modSyncReceivedUncompressedBytes = 0;
+        m_modSyncExpectedUncompressedTotal = 0;
         m_modSyncPostSyncActiveMods.clear();
         return;
     }
@@ -3059,6 +3161,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncRequestedSet.clear();
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncPostSyncActiveMods.clear();
     // Hold so the progress dialog gets a frame to paint at 100% before the success+restart sequence tears it down.
     QTimer::singleShot(500, this, &Multiplayermenu::onModSyncSucceeded);
@@ -3113,6 +3216,7 @@ void Multiplayermenu::cancelModSyncSession()
     m_modSyncRequestedSet.clear();
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncExpectedUncompressedTotal = 0;
     m_modSyncActive = false;
     m_modSyncPostSyncActiveMods.clear();
 }
@@ -3153,12 +3257,19 @@ void Multiplayermenu::startModSyncDownload(const QStringList & modsToDownload, c
         onModSyncFailed(tr("Could not start mod sync."));
         return;
     }
+    if (m_pJoinConnectingDialog != nullptr)
+    {
+        m_pJoinConnectingDialog->detach();
+        m_pJoinConnectingDialog.reset();
+    }
     if (m_modSyncProgressDialog != nullptr)
     {
         m_modSyncProgressDialog->detach();
         m_modSyncProgressDialog.reset();
     }
     m_modSyncProgressDialog = MemoryManagement::create<DialogModSyncProgress>(static_cast<qint32>(modsToDownload.size()));
+    // Defensive seed in case MODSYNCMANIFEST raced ahead of dialog construction.
+    m_modSyncProgressDialog->setExpectedTotalBytes(m_modSyncExpectedUncompressedTotal);
     connect(m_modSyncProgressDialog.get(), &DialogModSyncProgress::sigCancel, this, [this]()
     {
         if (!m_modSyncActive)
@@ -3177,8 +3288,8 @@ void Multiplayermenu::onModSyncProgress()
     {
         return;
     }
-    // Show declared uncompressed bytes so the user sees on-disk size, not wire-compressed size.
-    m_modSyncProgressDialog->setProgress(static_cast<qint32>(m_modSyncStagings.size()), m_modSyncReceivedUncompressedBytes);
+    // Compressed drives the EMA network-rate display; uncompressed drives bar fraction and ETA.
+    m_modSyncProgressDialog->setProgress(static_cast<qint32>(m_modSyncStagings.size()), m_modSyncReceivedBytes, m_modSyncReceivedUncompressedBytes);
 }
 
 void Multiplayermenu::onModSyncSucceeded()

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -14,6 +14,7 @@
 #include "coreengine/settings.h"
 #include "coreengine/filesupport.h"
 #include "coreengine/globalutils.h"
+#include "coreengine/virtualpaths.h"
 
 #include "menue/gamemenue.h"
 #include "menue/mainwindow.h"
@@ -535,6 +536,22 @@ void Multiplayermenu::recieveData(quint64 socketID, QByteArray data, NetworkInte
         else if (messageType == NetworkCommands::DISCONNECTINGFROMSERVER)
         {
             exitMenuToLobby();
+        }
+        else if (messageType == NetworkCommands::REQUESTMODSYNC)
+        {
+            handleModSyncRequest(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCDATA)
+        {
+            handleModSyncData(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCREJECT)
+        {
+            handleModSyncReject(stream, socketID);
+        }
+        else if (messageType == NetworkCommands::MODSYNCCOMPLETE)
+        {
+            handleModSyncComplete(stream, socketID);
         }
         else
         {
@@ -2467,4 +2484,514 @@ void Multiplayermenu::countdown()
         m_GameStartTimer.stop();
         sendServerReady(false);
     }
+}
+
+// Pin reject codes to wire literals; filesupport.cpp's anonymous-namespace constants must match.
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncNoReason) == 0, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncDisabled) == 1, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncUnknownMod) == 2, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncSizeCapExceeded) == 3, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncFileCountCapExceeded) == 4, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncInvalidPath) == 5, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncInternalError) == 6, "ModSync reject code drift");
+
+namespace
+{
+    // Cap on number of mods in a single REQUESTMODSYNC; client mod count is bounded by what the user has installed.
+    constexpr qint32 kModSyncRequestCountMax = 1024;
+    // Cap on reject-message char length; anything longer than this is truncated by the host or rejected.
+    constexpr qint32 kModSyncReasonCharsMax = 4096;
+
+    // QDataStream::operator>> pre-resizes to the declared length; bounded readers reject the header before allocation.
+    constexpr quint32 kInt32MaxAsU32 = 0x7FFFFFFFu;
+
+    bool readBoundedQByteArray(QDataStream & stream, QByteArray & out, qint64 maxBytes)
+    {
+        if (maxBytes < 0)
+        {
+            return false;
+        }
+        quint32 declared = 0;
+        stream >> declared;
+        if (stream.status() != QDataStream::Ok)
+        {
+            return false;
+        }
+        if (declared == 0xFFFFFFFFu)
+        {
+            out.clear();
+            return true;
+        }
+        if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes)
+        {
+            return false;
+        }
+        out.resize(static_cast<qint32>(declared));
+        if (out.size() > 0 && stream.readRawData(out.data(), out.size()) != out.size())
+        {
+            return false;
+        }
+        return true;
+    }
+
+    bool readBoundedQString(QDataStream & stream, QString & out, qint32 maxChars)
+    {
+        if (maxChars < 0)
+        {
+            return false;
+        }
+        quint32 declared = 0;
+        stream >> declared;
+        if (stream.status() != QDataStream::Ok)
+        {
+            return false;
+        }
+        if (declared == 0xFFFFFFFFu)
+        {
+            out.clear();
+            return true;
+        }
+        const qint64 maxBytes = static_cast<qint64>(maxChars) * 2;
+        if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes || (declared % 2) != 0)
+        {
+            return false;
+        }
+        QByteArray buf;
+        buf.resize(static_cast<qint32>(declared));
+        if (buf.size() > 0 && stream.readRawData(buf.data(), buf.size()) != buf.size())
+        {
+            return false;
+        }
+        const qint32 codeUnits = buf.size() / 2;
+        out.resize(codeUnits);
+        const uchar * src = reinterpret_cast<const uchar *>(buf.constData());
+        // Wire is big-endian; build each code unit explicitly to skip platform-endian conversion in fromUtf16.
+        for (qint32 i = 0; i < codeUnits; ++i)
+        {
+            out[i] = QChar(static_cast<ushort>((src[i * 2] << 8) | src[i * 2 + 1]));
+        }
+        return true;
+    }
+}
+
+void Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+{
+    if (m_modSyncActive)
+    {
+        CONSOLE_PRINT("Mod-sync already in flight; ignoring duplicate requestModSync", GameConsole::eWARNING);
+        return;
+    }
+    // Network guard runs before the empty-request branch so a host-side caller cannot persist client-side post-sync settings.
+    if (m_pNetworkInterface == nullptr || m_pNetworkInterface->getIsServer())
+    {
+        CONSOLE_PRINT("requestModSync called without a client network interface, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (modsToDownload.size() > kModSyncRequestCountMax)
+    {
+        CONSOLE_PRINT("requestModSync exceeds count cap (" + QString::number(modsToDownload.size()) + " > " + QString::number(kModSyncRequestCountMax) + "), ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (modsToDownload.isEmpty())
+    {
+        // No downloads needed; persist the post-sync mod selection only. No manifest, no network round-trip.
+        Settings::getInstance()->stageActiveModsForRestart(postSyncActiveMods);
+        CONSOLE_PRINT("Mod-sync settings-only: " + QString::number(postSyncActiveMods.size()) + " mods staged for restart", GameConsole::eINFO);
+        return;
+    }
+    m_modSyncActive = true;
+    m_modSyncStagings.clear();
+    m_modSyncRequestedSet = QSet<QString>(modsToDownload.cbegin(), modsToDownload.cend());
+    m_modSyncReceivedBytes = 0;
+    m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncPostSyncActiveMods = postSyncActiveMods;
+
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Version::Qt_6_5);
+    stream << QString(NetworkCommands::REQUESTMODSYNC);
+    stream << static_cast<qint32>(1);
+    stream << modsToDownload;
+    // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
+    emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+    CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketID)
+{
+    if (m_pNetworkInterface == nullptr || !m_pNetworkInterface->getIsServer())
+    {
+        CONSOLE_PRINT("REQUESTMODSYNC received on non-server, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    if (!settings->getModSyncEnabled())
+    {
+        sendModSyncReject(socketID, NetworkCommands::ModSyncDisabled, QString(), tr("Mod sync is disabled on this host."));
+        return;
+    }
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (protocolVersion != 1)
+    {
+        sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Unsupported mod-sync protocol version."));
+        return;
+    }
+
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    qint32 modCount = 0;
+    stream >> modCount;
+    if (stream.status() != QDataStream::Ok || modCount < 0 || modCount > kModSyncRequestCountMax)
+    {
+        sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Malformed mod-sync request."));
+        return;
+    }
+    QStringList requestedMods;
+    requestedMods.reserve(modCount);
+    {
+        // Dedupe at parse time so a hostile client cannot force repeated package builds and duplicate sends within the count cap.
+        QSet<QString> seen;
+        for (qint32 i = 0; i < modCount; ++i)
+        {
+            QString mod;
+            if (!readBoundedQString(stream, mod, relPathMaxLen))
+            {
+                sendModSyncReject(socketID, NetworkCommands::ModSyncInvalidPath, QString(), tr("Malformed mod path in request."));
+                return;
+            }
+            if (!seen.contains(mod))
+            {
+                seen.insert(mod);
+                requestedMods.append(mod);
+            }
+        }
+    }
+
+    QStringList hostMods = settings->getMods();
+    QStringList hostVersions = settings->getActiveModVersions();
+    bool filter = false;
+    auto pMap = m_pMapSelectionView->getCurrentMap();
+    if (pMap != nullptr && pMap->getGameRules() != nullptr)
+    {
+        filter = pMap->getGameRules()->getCosmeticModsAllowed();
+    }
+    settings->filterCosmeticMods(hostMods, hostVersions, filter);
+
+    Filesupport::ModSyncCaps caps;
+    caps.perModBytes = settings->getModSyncMaxPerModBytes();
+    caps.fileCountMax = settings->getModSyncMaxFiles();
+    caps.relPathMaxLen = relPathMaxLen;
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+    qint64 totalSent = 0;
+    qint64 totalUncompressed = 0;
+
+    for (const auto & mod : std::as_const(requestedMods))
+    {
+        if (!Filesupport::validateModPath(mod))
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncInvalidPath, mod, tr("Invalid mod path."));
+            return;
+        }
+        if (!hostMods.contains(mod))
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncUnknownMod, mod, tr("Mod not advertised by host."));
+            return;
+        }
+        // Active mods may resolve from CWD or the install/resource path, not just userPath; ask the VFS where the folder actually lives.
+        const QString resolvedAbs = VirtualPaths::find(mod, false);
+        if (resolvedAbs.isEmpty())
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncUnknownMod, mod, tr("Mod folder not found in install search paths."));
+            return;
+        }
+        QString resolvedRoot;
+        const QString suffixSlash = QStringLiteral("/") + mod;
+        if (resolvedAbs.endsWith(suffixSlash))
+        {
+            resolvedRoot = resolvedAbs.left(resolvedAbs.size() - suffixSlash.size());
+        }
+        else if (resolvedAbs == mod)
+        {
+            resolvedRoot = QString();
+        }
+        else
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, mod, tr("Mod path resolution shape unexpected."));
+            return;
+        }
+        Filesupport::ModSyncPackage pkg = Filesupport::buildModSyncPackage(resolvedRoot, mod, caps);
+        if (pkg.rejectReason != 0)
+        {
+            sendModSyncReject(socketID, pkg.rejectReason, mod, tr("Failed to build mod package."));
+            return;
+        }
+        if (totalSent + pkg.compressedBlob.size() > totalCap || totalUncompressed + pkg.declaredUncompressedSize > totalCap)
+        {
+            sendModSyncReject(socketID, NetworkCommands::ModSyncSizeCapExceeded, QString(), tr("Total sync size exceeds cap."));
+            return;
+        }
+        totalSent += pkg.compressedBlob.size();
+        totalUncompressed += pkg.declaredUncompressedSize;
+
+        QByteArray data;
+        QDataStream sendStream(&data, QIODevice::WriteOnly);
+        sendStream.setVersion(QDataStream::Version::Qt_6_5);
+        sendStream << QString(NetworkCommands::MODSYNCDATA);
+        sendStream << static_cast<qint32>(1);
+        sendStream << mod;
+        sendStream << pkg.declaredUncompressedSize;
+        sendStream << pkg.fileCount;
+        sendStream << pkg.compressedBlob;
+        emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+        CONSOLE_PRINT("Sent MODSYNCDATA for " + mod + " (" + QString::number(pkg.compressedBlob.size()) + " bytes)", GameConsole::eINFO);
+    }
+
+    QByteArray data;
+    QDataStream sendStream(&data, QIODevice::WriteOnly);
+    sendStream.setVersion(QDataStream::Version::Qt_6_5);
+    sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
+    sendStream << static_cast<qint32>(1);
+    emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+    CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(requestedMods.size()) + " mods, " + QString::number(totalSent) + " compressed bytes, " + QString::number(totalUncompressed) + " uncompressed bytes", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCDATA received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+    const qint64 perModCap = settings->getModSyncMaxPerModBytes();
+    const qint32 fileCountMax = settings->getModSyncMaxFiles();
+    const qint64 totalCap = settings->getModSyncMaxTotalBytes();
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCDATA mod path overflow or malformed", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    qint32 declaredSize = 0;
+    qint32 fileCount = 0;
+    stream >> declaredSize;
+    stream >> fileCount;
+    if (stream.status() != QDataStream::Ok || declaredSize < 0 || fileCount < 0 || fileCount > fileCountMax)
+    {
+        CONSOLE_PRINT("MODSYNCDATA size/count out of range for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    QByteArray compressedBlob;
+    if (!readBoundedQByteArray(stream, compressedBlob, perModCap))
+    {
+        CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    if (!Filesupport::validateModPath(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCDATA invalid mod path: " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (!m_modSyncRequestedSet.contains(modPath))
+    {
+        CONSOLE_PRINT("MODSYNCDATA for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    m_modSyncReceivedBytes += compressedBlob.size();
+    m_modSyncReceivedUncompressedBytes += declaredSize;
+    if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
+    {
+        CONSOLE_PRINT("Mod-sync exceeds total bytes cap, aborting", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    Filesupport::ModSyncCaps caps;
+    caps.perModBytes = perModCap;
+    caps.fileCountMax = fileCountMax;
+    caps.relPathMaxLen = relPathMaxLen;
+
+    qint32 rejectReason = 0;
+    auto files = Filesupport::extractModSyncPackage(compressedBlob, declaredSize, caps, rejectReason);
+    if (rejectReason != 0)
+    {
+        CONSOLE_PRINT("Mod-sync extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (files.size() != fileCount)
+    {
+        CONSOLE_PRINT("Mod-sync file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(fileCount) + ")", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+
+    qint32 stageReason = 0;
+    QString stagingRel = Filesupport::stageModSync(settings->getUserPath(), modPath, files, caps, stageReason);
+    if (stageReason != 0 || stagingRel.isEmpty())
+    {
+        CONSOLE_PRINT("Mod-sync stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    m_modSyncStagings.append(qMakePair(stagingRel, modPath));
+    m_modSyncRequestedSet.remove(modPath);
+    CONSOLE_PRINT("Mod-sync staged " + modPath + " (" + QString::number(files.size()) + " files)", GameConsole::eINFO);
+}
+
+void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    auto * settings = Settings::getInstance();
+    const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
+
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCREJECT unsupported protocol version", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    QString modPath;
+    if (!readBoundedQString(stream, modPath, relPathMaxLen))
+    {
+        CONSOLE_PRINT("MODSYNCREJECT mod path overflow or malformed", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    qint32 reasonCode = 0;
+    stream >> reasonCode;
+    QString reasonMessage;
+    if (!readBoundedQString(stream, reasonMessage, kModSyncReasonCharsMax))
+    {
+        CONSOLE_PRINT("MODSYNCREJECT reason message overflow or malformed (code=" + QString::number(reasonCode) + " mod=" + modPath + ")", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    CONSOLE_PRINT("Mod-sync rejected by host: code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + reasonMessage, GameConsole::eERROR);
+    cancelModSyncSession();
+}
+
+void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socketID)
+{
+    Q_UNUSED(socketID);
+    qint32 protocolVersion = 0;
+    stream >> protocolVersion;
+    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE unsupported protocol version", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (!m_modSyncActive)
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
+    if (!m_modSyncRequestedSet.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE arrived with " + QString::number(m_modSyncRequestedSet.size()) + " requested mods unsent; aborting", GameConsole::eERROR);
+        cancelModSyncSession();
+        return;
+    }
+    if (m_modSyncStagings.isEmpty())
+    {
+        CONSOLE_PRINT("MODSYNCCOMPLETE received with no stagings; nothing to apply", GameConsole::eWARNING);
+        m_modSyncActive = false;
+        m_modSyncReceivedBytes = 0;
+        m_modSyncReceivedUncompressedBytes = 0;
+        m_modSyncPostSyncActiveMods.clear();
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    // Settings first; the manifest is the commit point so it must be the last thing written.
+    const QString priorActiveModsRaw = settings->stageActiveModsForRestart(m_modSyncPostSyncActiveMods);
+    QList<QPair<QString, QString>> manifestSwaps;
+    for (const auto & p : std::as_const(m_modSyncStagings))
+    {
+        manifestSwaps.append(qMakePair(p.first, p.second));
+    }
+    if (!Filesupport::writePendingModSyncManifest(settings->getUserPath(), manifestSwaps))
+    {
+        CONSOLE_PRINT("Failed to write pending mod-sync manifest; restoring prior active-mod list", GameConsole::eERROR);
+        settings->restoreActiveModsRaw(priorActiveModsRaw);
+        cancelModSyncSession();
+        return;
+    }
+    CONSOLE_PRINT("Mod-sync complete: " + QString::number(m_modSyncStagings.size()) + " mods staged. Restart the game to apply.", GameConsole::eINFO);
+    m_modSyncActive = false;
+    m_modSyncStagings.clear();
+    m_modSyncRequestedSet.clear();
+    m_modSyncReceivedBytes = 0;
+    m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncPostSyncActiveMods.clear();
+}
+
+void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
+{
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Version::Qt_6_5);
+    stream << QString(NetworkCommands::MODSYNCREJECT);
+    stream << static_cast<qint32>(1);
+    stream << modPath;
+    stream << reasonCode;
+    stream << message;
+    emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
+    CONSOLE_PRINT("Sent MODSYNCREJECT code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + message, GameConsole::eINFO);
+}
+
+void Multiplayermenu::cancelModSyncSession()
+{
+    if (!m_modSyncActive)
+    {
+        return;
+    }
+    auto * settings = Settings::getInstance();
+    const QString installRoot = settings->getUserPath();
+    for (const auto & p : std::as_const(m_modSyncStagings))
+    {
+        QString stagingAbs;
+        if (installRoot.isEmpty())
+        {
+            stagingAbs = p.first;
+        }
+        else if (installRoot.endsWith(QChar('/')))
+        {
+            stagingAbs = installRoot + p.first;
+        }
+        else
+        {
+            stagingAbs = installRoot + QChar('/') + p.first;
+        }
+        QDir(stagingAbs).removeRecursively();
+    }
+    m_modSyncStagings.clear();
+    m_modSyncRequestedSet.clear();
+    m_modSyncReceivedBytes = 0;
+    m_modSyncReceivedUncompressedBytes = 0;
+    m_modSyncActive = false;
+    m_modSyncPostSyncActiveMods.clear();
 }

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -1195,8 +1195,8 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         QStringList mismatchedResourceFolders;
         QStringList mismatchedMods;
         quint32 hostCapabilities = 0;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion);
-        Q_UNUSED(hostCapabilities);
+        bool cosmeticAllowed = false;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         if (sameVersion && sameMods && !differentHash)
         {
             QString command = QString(NetworkCommands::GAMEDATAVERIFIED);
@@ -1209,7 +1209,7 @@ void Multiplayermenu::verifyGameData(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         }
     }
 }
@@ -1261,9 +1261,10 @@ bool Multiplayermenu::checkMods(const QStringList & mods, const QStringList & ve
     return sameMods;
 }
 
-void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion)
+void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed)
 {
     hostCapabilities = 0;
+    cosmeticAllowed = false;
     GameVersion version;
     version.deserializeObject(stream);
     sameVersion = (version == GameVersion());
@@ -1273,6 +1274,7 @@ void Multiplayermenu::readHashInfo(QDataStream & stream, quint64 socketID, QStri
     }
     bool filter = false;
     stream >> filter;
+    cosmeticAllowed = filter;
     qint32 size = 0;
     stream >> size;
     for (qint32 i = 0; i < size; i++)
@@ -1368,8 +1370,8 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         QStringList mismatchedResourceFolders;
         QStringList mismatchedMods;
         quint32 hostCapabilities = 0;
-        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion);
-        Q_UNUSED(hostCapabilities);
+        bool cosmeticAllowed = false;
+        readHashInfo(stream, socketID, mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         if (sameVersion && sameMods && !differentHash)
         {
             stream >> m_saveGame;
@@ -1427,12 +1429,12 @@ void Multiplayermenu::clientMapInfo(QDataStream & stream, quint64 socketID)
         }
         else
         {
-            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, sameMods, differentHash, sameVersion);
+            handleVersionMissmatch(mods, versions, myMods, myVersions, mismatchedResourceFolders, mismatchedMods, hostCapabilities, sameMods, differentHash, sameVersion, cosmeticAllowed);
         }
     }
 }
 
-void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion)
+void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed)
 {
     // Mod/hash fields are stale on version mismatch because readHashInfo early-returns.
     if (!sameVersion)
@@ -1449,6 +1451,7 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     QStringList missingHere;
     QStringList extraHere;
     QStringList versionDiffs;
+    QStringList modsToDownloadPaths;
     if (!sameMods)
     {
         for (qint32 i = 0; i < mods.size(); ++i)
@@ -1458,10 +1461,12 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
             if (j < 0)
             {
                 missingHere.append(settings->getModName(mod) + " " + versions[i]);
+                modsToDownloadPaths.append(mod);
             }
             else if (versions[i] != myVersions[j])
             {
                 versionDiffs.append(tr("%1 (host: %2, you: %3)").arg(settings->getModName(mod), versions[i], myVersions[j]));
+                modsToDownloadPaths.append(mod);
             }
         }
         for (qint32 i = 0; i < myMods.size(); ++i)
@@ -1477,6 +1482,10 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     for (const auto & mod : std::as_const(mismatchedMods))
     {
         contentDiffs.append(settings->getModName(mod));
+        if (!modsToDownloadPaths.contains(mod))
+        {
+            modsToDownloadPaths.append(mod);
+        }
     }
 
     auto logFullList = [](const QString & label, const QStringList & list)
@@ -1518,6 +1527,11 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
     appendSection(message, tr("Content mismatch:"), contentDiffs);
     appendSection(message, tr("Engine resources differ:"), mismatchedResourceFolders);
 
+    // Mod-sync is offerable when host advertised CapabilityModSync, no engine resource drift, and we have something to fix.
+    const bool hostSupportsModSync = (hostCapabilities & Filesupport::CapabilityModSync) != 0;
+    const bool resourceDrift = !mismatchedResourceFolders.isEmpty();
+    const bool fixableViaSync = hostSupportsModSync && !resourceDrift && (!modsToDownloadPaths.isEmpty() || !extraHere.isEmpty());
+
     if (message.isEmpty())
     {
         // Legacy and fail-closed payloads have no structured detail.
@@ -1531,14 +1545,44 @@ void Multiplayermenu::handleVersionMissmatch(const QStringList & mods, const QSt
             message = tr("Failed to join game due to unknown verification failure.");
         }
     }
+    else if (fixableViaSync)
+    {
+        message = tr("Your game data differs from the host:") + "\n\n" + message + tr("Want me to download host's mod set and apply it on the next start?");
+    }
     else
     {
         message = tr("Cannot join, your game data differs from the host:") + "\n\n" + message + tr("Leaving the game again.");
     }
 
-    spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message);
-    connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
-    addChild(pDialogMessageBox);
+    if (fixableViaSync)
+    {
+        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message, true, tr("Apply host's mod set"), tr("Leave game"));
+        // Host's advertised list is already cosmetic-filtered when the rule allows them; re-add client cosmetic-only mods so the user does not silently lose them on next boot.
+        QStringList postSyncActiveMods = mods;
+        if (cosmeticAllowed)
+        {
+            const QStringList clientFull = settings->getMods();
+            for (const auto & mod : std::as_const(clientFull))
+            {
+                if (!postSyncActiveMods.contains(mod) && settings->getIsCosmetic(mod))
+                {
+                    postSyncActiveMods.append(mod);
+                }
+            }
+        }
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, [this, modsToDownloadPaths, postSyncActiveMods]()
+        {
+            confirmModSync(modsToDownloadPaths, postSyncActiveMods);
+        }, Qt::QueuedConnection);
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+        addChild(pDialogMessageBox);
+    }
+    else
+    {
+        spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(message);
+        connect(pDialogMessageBox.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+        addChild(pDialogMessageBox);
+    }
 }
 
 void Multiplayermenu::requestMap(quint64 socketID)
@@ -2574,30 +2618,30 @@ namespace
     }
 }
 
-void Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
 {
     if (m_modSyncActive)
     {
         CONSOLE_PRINT("Mod-sync already in flight; ignoring duplicate requestModSync", GameConsole::eWARNING);
-        return;
+        return false;
     }
     // Network guard runs before the empty-request branch so a host-side caller cannot persist client-side post-sync settings.
     if (m_pNetworkInterface == nullptr || m_pNetworkInterface->getIsServer())
     {
         CONSOLE_PRINT("requestModSync called without a client network interface, ignoring", GameConsole::eWARNING);
-        return;
+        return false;
     }
     if (modsToDownload.size() > kModSyncRequestCountMax)
     {
         CONSOLE_PRINT("requestModSync exceeds count cap (" + QString::number(modsToDownload.size()) + " > " + QString::number(kModSyncRequestCountMax) + "), ignoring", GameConsole::eWARNING);
-        return;
+        return false;
     }
     if (modsToDownload.isEmpty())
     {
         // No downloads needed; persist the post-sync mod selection only. No manifest, no network round-trip.
         Settings::getInstance()->stageActiveModsForRestart(postSyncActiveMods);
         CONSOLE_PRINT("Mod-sync settings-only: " + QString::number(postSyncActiveMods.size()) + " mods staged for restart", GameConsole::eINFO);
-        return;
+        return true;
     }
     m_modSyncActive = true;
     m_modSyncStagings.clear();
@@ -2615,6 +2659,7 @@ void Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
     emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
     CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods", GameConsole::eINFO);
+    return true;
 }
 
 void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketID)
@@ -2769,12 +2814,18 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     const qint32 fileCountMax = settings->getModSyncMaxFiles();
     const qint64 totalCap = settings->getModSyncMaxTotalBytes();
 
+    auto failData = [this](const QString & uiReason)
+    {
+        cancelModSyncSession();
+        onModSyncFailed(uiReason);
+    };
+
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (stream.status() != QDataStream::Ok || protocolVersion != 1)
     {
         CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Unsupported mod-sync protocol from host."));
         return;
     }
 
@@ -2782,7 +2833,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!readBoundedQString(stream, modPath, relPathMaxLen))
     {
         CONSOLE_PRINT("MODSYNCDATA mod path overflow or malformed", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Malformed mod-sync data frame."));
         return;
     }
 
@@ -2793,7 +2844,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stream.status() != QDataStream::Ok || declaredSize < 0 || fileCount < 0 || fileCount > fileCountMax)
     {
         CONSOLE_PRINT("MODSYNCDATA size/count out of range for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod %1 exceeds the per-mod file-count cap.").arg(modPath));
         return;
     }
 
@@ -2801,20 +2852,20 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (!readBoundedQByteArray(stream, compressedBlob, perModCap))
     {
         CONSOLE_PRINT("MODSYNCDATA blob overflow or malformed for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod %1 exceeds the per-mod size cap.").arg(modPath));
         return;
     }
 
     if (!Filesupport::validateModPath(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA invalid mod path: " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Host sent an invalid mod path."));
         return;
     }
     if (!m_modSyncRequestedSet.contains(modPath))
     {
         CONSOLE_PRINT("MODSYNCDATA for unrequested or duplicate mod: " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Host sent an unrequested or duplicate mod."));
         return;
     }
 
@@ -2823,7 +2874,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (m_modSyncReceivedBytes > totalCap || m_modSyncReceivedUncompressedBytes > totalCap)
     {
         CONSOLE_PRINT("Mod-sync exceeds total bytes cap, aborting", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod-sync exceeds the total transfer cap."));
         return;
     }
 
@@ -2837,13 +2888,13 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (rejectReason != 0)
     {
         CONSOLE_PRINT("Mod-sync extract rejected (" + QString::number(rejectReason) + ") for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Failed to unpack mod %1.").arg(modPath));
         return;
     }
     if (files.size() != fileCount)
     {
         CONSOLE_PRINT("Mod-sync file count mismatch for " + modPath + " (got " + QString::number(files.size()) + ", expected " + QString::number(fileCount) + ")", GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Mod %1 file count did not match the host's declaration.").arg(modPath));
         return;
     }
 
@@ -2852,17 +2903,24 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
     if (stageReason != 0 || stagingRel.isEmpty())
     {
         CONSOLE_PRINT("Mod-sync stage rejected (" + QString::number(stageReason) + ") for " + modPath, GameConsole::eERROR);
-        cancelModSyncSession();
+        failData(tr("Failed to stage mod %1 to disk.").arg(modPath));
         return;
     }
     m_modSyncStagings.append(qMakePair(stagingRel, modPath));
     m_modSyncRequestedSet.remove(modPath);
     CONSOLE_PRINT("Mod-sync staged " + modPath + " (" + QString::number(files.size()) + " files)", GameConsole::eINFO);
+    onModSyncProgress();
 }
 
 void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID)
 {
     Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        // Drop late or unsolicited rejects after cancel/success so we do not stack a second failure dialog.
+        CONSOLE_PRINT("MODSYNCREJECT received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
     auto * settings = Settings::getInstance();
     const qint32 relPathMaxLen = settings->getModSyncMaxRelativePathLength();
 
@@ -2872,6 +2930,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
         return;
     }
     QString modPath;
@@ -2879,6 +2938,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT mod path overflow or malformed", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Malformed mod-sync reject frame."));
         return;
     }
     qint32 reasonCode = 0;
@@ -2888,32 +2948,40 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
     {
         CONSOLE_PRINT("MODSYNCREJECT reason message overflow or malformed (code=" + QString::number(reasonCode) + " mod=" + modPath + ")", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Malformed reject reason from host."));
         return;
     }
     CONSOLE_PRINT("Mod-sync rejected by host: code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + reasonMessage, GameConsole::eERROR);
+    const QString uiReason = reasonMessage.isEmpty()
+        ? tr("Host rejected the request (code %1).").arg(reasonCode)
+        : reasonMessage;
     cancelModSyncSession();
+    onModSyncFailed(uiReason);
 }
 
 void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socketID)
 {
     Q_UNUSED(socketID);
+    if (!m_modSyncActive)
+    {
+        // Drop late or unsolicited completes after cancel/success before parsing so a malformed stale frame does not stack a second failure dialog.
+        CONSOLE_PRINT("MODSYNCCOMPLETE received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        return;
+    }
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (stream.status() != QDataStream::Ok || protocolVersion != 1)
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
-        return;
-    }
-    if (!m_modSyncActive)
-    {
-        CONSOLE_PRINT("MODSYNCCOMPLETE received with no active mod-sync session, ignoring", GameConsole::eWARNING);
+        onModSyncFailed(tr("Unsupported mod-sync protocol from host."));
         return;
     }
     if (!m_modSyncRequestedSet.isEmpty())
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE arrived with " + QString::number(m_modSyncRequestedSet.size()) + " requested mods unsent; aborting", GameConsole::eERROR);
         cancelModSyncSession();
+        onModSyncFailed(tr("Host did not deliver every requested mod."));
         return;
     }
     if (m_modSyncStagings.isEmpty())
@@ -2938,6 +3006,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
         CONSOLE_PRINT("Failed to write pending mod-sync manifest; restoring prior active-mod list", GameConsole::eERROR);
         settings->restoreActiveModsRaw(priorActiveModsRaw);
         cancelModSyncSession();
+        onModSyncFailed(tr("Failed to write the pending mod-sync manifest."));
         return;
     }
     CONSOLE_PRINT("Mod-sync complete: " + QString::number(m_modSyncStagings.size()) + " mods staged. Restart the game to apply.", GameConsole::eINFO);
@@ -2947,6 +3016,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncReceivedBytes = 0;
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncPostSyncActiveMods.clear();
+    onModSyncSucceeded();
 }
 
 void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
@@ -2965,6 +3035,12 @@ void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, con
 
 void Multiplayermenu::cancelModSyncSession()
 {
+    // Dialog teardown ahead of the active-session guard so a request that bailed before arming still tears down its progress UI.
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
     if (!m_modSyncActive)
     {
         return;
@@ -2994,4 +3070,79 @@ void Multiplayermenu::cancelModSyncSession()
     m_modSyncReceivedUncompressedBytes = 0;
     m_modSyncActive = false;
     m_modSyncPostSyncActiveMods.clear();
+}
+
+void Multiplayermenu::confirmModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods)
+{
+    const bool ok = requestModSync(modsToDownload, postSyncActiveMods);
+    if (modsToDownload.isEmpty())
+    {
+        // Settings-only branch already either staged Mods/Mods or refused; surface the matching prompt.
+        if (ok)
+        {
+            onModSyncSucceeded();
+        }
+        else
+        {
+            onModSyncFailed(tr("Could not start mod sync."));
+        }
+        return;
+    }
+    if (!ok)
+    {
+        onModSyncFailed(tr("Could not start mod sync."));
+        return;
+    }
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
+    m_modSyncProgressDialog = MemoryManagement::create<DialogModSyncProgress>(static_cast<qint32>(modsToDownload.size()));
+    connect(m_modSyncProgressDialog.get(), &DialogModSyncProgress::sigCancel, this, [this]()
+    {
+        if (!m_modSyncActive)
+        {
+            return;
+        }
+        cancelModSyncSession();
+        onModSyncFailed(tr("Mod sync canceled."));
+    }, Qt::QueuedConnection);
+    addChild(m_modSyncProgressDialog);
+}
+
+void Multiplayermenu::onModSyncProgress()
+{
+    if (m_modSyncProgressDialog == nullptr)
+    {
+        return;
+    }
+    // Show declared uncompressed bytes so the user sees on-disk size, not wire-compressed size.
+    m_modSyncProgressDialog->setProgress(static_cast<qint32>(m_modSyncStagings.size()), m_modSyncReceivedUncompressedBytes);
+}
+
+void Multiplayermenu::onModSyncSucceeded()
+{
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
+    spDialogMessageBox pDialog = MemoryManagement::create<DialogMessageBox>(tr("Mod sync complete. Restart the game to apply the host's mod set."));
+    connect(pDialog.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    addChild(pDialog);
+}
+
+void Multiplayermenu::onModSyncFailed(const QString & reason)
+{
+    if (m_modSyncProgressDialog != nullptr)
+    {
+        m_modSyncProgressDialog->detach();
+        m_modSyncProgressDialog.reset();
+    }
+    // Escape because reason can include host-supplied text and DialogMessageBox renders via setHtmlText.
+    const QString safe = reason.toHtmlEscaped();
+    spDialogMessageBox pDialog = MemoryManagement::create<DialogMessageBox>(tr("Mod sync failed: %1\n\nLeaving the game.").arg(safe));
+    connect(pDialog.get(), &DialogMessageBox::sigOk, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
+    addChild(pDialog);
 }

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -2576,14 +2576,14 @@ void Multiplayermenu::countdown()
 }
 
 // Pin reject codes to wire literals; filesupport.cpp's anonymous-namespace constants must match.
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncNoReason) == 0, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncDisabled) == 1, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncUnknownMod) == 2, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncSizeCapExceeded) == 3, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncFileCountCapExceeded) == 4, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncInvalidPath) == 5, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncInternalError) == 6, "ModSync reject code drift");
-static_assert(static_cast<qint32>(NetworkCommands::ModSyncBusy) == 7, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncNoReason) == 0, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncDisabled) == 1, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncUnknownMod) == 2, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncSizeCapExceeded) == 3, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncFileCountCapExceeded) == 4, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath) == 5, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncInternalError) == 6, "ModSync reject code drift");
+static_assert(static_cast<qint32>(NetworkCommands::ModSyncRejectReason::ModSyncBusy) == 7, "ModSync reject code drift");
 
 namespace
 {
@@ -2728,7 +2728,7 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     stream << kModSyncProtocolVersion;
     stream << modsToDownload;
     // Trailing optional flag; older hosts read past their known fields and ignore. New hosts try-read and fall back to legacy framing if absent.
-    stream << static_cast<qint32>(NetworkCommands::ModSyncClientFlagChunked);
+    stream << static_cast<qint32>(NetworkCommands::ModSyncClientFlag::ModSyncClientFlagChunked);
     // socketID=0 routes to the server on a TCP client interface; same convention as other client-originated sends.
     emit m_pNetworkInterface->sig_sendData(0, data, NetworkInterface::NetworkSerives::Multiplayer, false);
     CONSOLE_PRINT("Requested mod-sync for " + QString::number(modsToDownload.size()) + " mods (chunked-capable)", GameConsole::eINFO);
@@ -2745,21 +2745,21 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     auto * settings = Settings::getInstance();
     if (!settings->getModSyncEnabled())
     {
-        sendModSyncReject(socketID, NetworkCommands::ModSyncDisabled, QString(), tr("Mod sync is disabled on this host."));
+        sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncDisabled, QString(), tr("Mod sync is disabled on this host."));
         return;
     }
     // Host-wide pump state is single-slot; reject concurrent peers rather than clobber an in-flight transfer.
     if (m_modSyncSendState.socketID != 0)
     {
         CONSOLE_PRINT("REQUESTMODSYNC arrived while another peer's send is still pumping; rejecting", GameConsole::eWARNING);
-        sendModSyncReject(socketID, NetworkCommands::ModSyncBusy, QString(), tr("Another peer is currently mod-syncing; try again shortly."));
+        sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncBusy, QString(), tr("Another peer is currently mod-syncing; try again shortly."));
         return;
     }
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
     if (protocolVersion != kModSyncProtocolVersion)
     {
-        sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Unsupported mod-sync protocol version."));
+        sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInternalError, QString(), tr("Unsupported mod-sync protocol version."));
         return;
     }
 
@@ -2768,7 +2768,7 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     stream >> modCount;
     if (stream.status() != QDataStream::Ok || modCount < 0 || modCount > kModSyncRequestCountMax)
     {
-        sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Malformed mod-sync request."));
+        sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInternalError, QString(), tr("Malformed mod-sync request."));
         return;
     }
     QStringList requestedMods;
@@ -2781,7 +2781,7 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
             QString mod;
             if (!readBoundedQString(stream, mod, relPathMaxLen))
             {
-                sendModSyncReject(socketID, NetworkCommands::ModSyncInvalidPath, QString(), tr("Malformed mod path in request."));
+                sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath, QString(), tr("Malformed mod path in request."));
                 return;
             }
             if (!seen.contains(mod))
@@ -2798,11 +2798,11 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         stream >> clientFlags;
         if (stream.status() != QDataStream::Ok || !stream.atEnd())
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Malformed mod-sync request trailer."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInternalError, QString(), tr("Malformed mod-sync request trailer."));
             return;
         }
     }
-    const bool useChunked = (clientFlags & NetworkCommands::ModSyncClientFlagChunked) != 0;
+    const bool useChunked = (clientFlags & static_cast<qint32>(NetworkCommands::ModSyncClientFlag::ModSyncClientFlagChunked)) != 0;
 
     QStringList hostMods = settings->getMods();
     QStringList hostVersions = settings->getActiveModVersions();
@@ -2822,17 +2822,17 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     qint64 totalSent = 0;
     qint64 totalUncompressed = 0;
 
-    auto packageRejectReason = [this](qint32 code, const QString & mod) -> QString
+    auto packageRejectReason = [this](NetworkCommands::ModSyncRejectReason code, const QString & mod) -> QString
     {
         switch (code)
         {
-            case NetworkCommands::ModSyncSizeCapExceeded:
+            case NetworkCommands::ModSyncRejectReason::ModSyncSizeCapExceeded:
                 return tr("Mod %1 exceeds the per-mod size cap on the host.").arg(mod);
-            case NetworkCommands::ModSyncFileCountCapExceeded:
+            case NetworkCommands::ModSyncRejectReason::ModSyncFileCountCapExceeded:
                 return tr("Mod %1 exceeds the per-mod file-count cap on the host.").arg(mod);
-            case NetworkCommands::ModSyncInvalidPath:
+            case NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath:
                 return tr("Mod %1 has an unsafe internal file path.").arg(mod);
-            case NetworkCommands::ModSyncUnknownMod:
+            case NetworkCommands::ModSyncRejectReason::ModSyncUnknownMod:
                 return tr("Mod %1 was not found on the host.").arg(mod);
             default:
                 return tr("Failed to build mod package for %1.").arg(mod);
@@ -2846,19 +2846,19 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     {
         if (!Filesupport::validateModPath(mod))
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncInvalidPath, mod, tr("Invalid mod path."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInvalidPath, mod, tr("Invalid mod path."));
             return;
         }
         if (!hostMods.contains(mod))
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncUnknownMod, mod, tr("Mod not advertised by host."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncUnknownMod, mod, tr("Mod not advertised by host."));
             return;
         }
         // Active mods may resolve from CWD or the install/resource path, not just userPath; ask the VFS where the folder actually lives.
         const QString resolvedAbs = VirtualPaths::find(mod, false);
         if (resolvedAbs.isEmpty())
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncUnknownMod, mod, tr("Mod folder not found in install search paths."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncUnknownMod, mod, tr("Mod folder not found in install search paths."));
             return;
         }
         QString resolvedRoot;
@@ -2873,18 +2873,20 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         }
         else
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, mod, tr("Mod path resolution shape unexpected."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncInternalError, mod, tr("Mod path resolution shape unexpected."));
             return;
         }
         Filesupport::ModSyncPackage pkg = Filesupport::buildModSyncPackage(resolvedRoot, mod, caps);
         if (pkg.rejectReason != 0)
         {
-            sendModSyncReject(socketID, pkg.rejectReason, mod, packageRejectReason(pkg.rejectReason, mod));
+            // Single coreengine boundary cast; Filesupport reports reject codes as qint32 to stay decoupled from multiplayer/.
+            const auto reason = static_cast<NetworkCommands::ModSyncRejectReason>(pkg.rejectReason);
+            sendModSyncReject(socketID, reason, mod, packageRejectReason(reason, mod));
             return;
         }
         if (totalSent + pkg.compressedBlob.size() > totalCap || totalUncompressed + pkg.declaredUncompressedSize > totalCap)
         {
-            sendModSyncReject(socketID, NetworkCommands::ModSyncSizeCapExceeded, QString(), tr("Total sync size exceeds the host's cap."));
+            sendModSyncReject(socketID, NetworkCommands::ModSyncRejectReason::ModSyncSizeCapExceeded, QString(), tr("Total sync size exceeds the host's cap."));
             return;
         }
         totalSent += pkg.compressedBlob.size();
@@ -3646,7 +3648,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     QTimer::singleShot(kModSyncSuccessUiHoldMs, this, &Multiplayermenu::onModSyncSucceeded);
 }
 
-void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
+void Multiplayermenu::sendModSyncReject(quint64 socketID, NetworkCommands::ModSyncRejectReason reasonCode, const QString & modPath, const QString & message)
 {
     QByteArray data;
     QDataStream stream(&data, QIODevice::WriteOnly);
@@ -3654,10 +3656,11 @@ void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, con
     stream << QString(NetworkCommands::MODSYNCREJECT);
     stream << kModSyncProtocolVersion;
     stream << modPath;
-    stream << reasonCode;
+    // Explicit qint32 per the wire contract in networkcommands.h; never stream the enum directly.
+    stream << static_cast<qint32>(reasonCode);
     stream << message;
     emit m_pNetworkInterface->sig_sendData(socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
-    CONSOLE_PRINT("Sent MODSYNCREJECT code=" + QString::number(reasonCode) + " mod=" + modPath + " msg=" + message, GameConsole::eINFO);
+    CONSOLE_PRINT("Sent MODSYNCREJECT code=" + QString::number(static_cast<qint32>(reasonCode)) + " mod=" + modPath + " msg=" + message, GameConsole::eINFO);
 }
 
 void Multiplayermenu::cancelModSyncSession()

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -141,8 +141,8 @@ void Multiplayermenu::initClientAndWaitForConnection()
     connectNetworkSlots();
 
     connect(m_pPlayerSelection.get(), &PlayerSelection::sigDisconnect, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
-    // wait 10 minutes till timeout
-    m_pJoinConnectingDialog = MemoryManagement::create<DialogConnecting>(tr("Connecting"), 1000 * 60 * 5);
+    constexpr qint32 kJoinConnectTimeoutMs = 1000 * 60 * 5;
+    m_pJoinConnectingDialog = MemoryManagement::create<DialogConnecting>(tr("Connecting"), kJoinConnectTimeoutMs);
     addChild(m_pJoinConnectingDialog);
     connect(m_pJoinConnectingDialog.get(), &DialogConnecting::sigCancel, this, &Multiplayermenu::buttonBack, Qt::QueuedConnection);
     connect(this, &Multiplayermenu::sigConnected, m_pJoinConnectingDialog.get(), &DialogConnecting::connected, Qt::QueuedConnection);
@@ -2598,6 +2598,12 @@ namespace
 
     // QDataStream::operator>> pre-resizes to the declared length; bounded readers reject the header before allocation.
     constexpr quint32 kInt32MaxAsU32 = 0x7FFFFFFFu;
+    // QDataStream encodes a null QByteArray or QString length as 0xFFFFFFFFu; mirrors filesupport.cpp.
+    constexpr quint32 kQDataStreamNullSentinel = 0xFFFFFFFFu;
+    constexpr qint32 kBytesPerUtf16CodeUnit = 2;
+    constexpr qint32 kBitsPerByte = 8;
+    // Version prefix on every mod-sync wire frame; bump on schema breakage.
+    constexpr qint32 kModSyncProtocolVersion = 1;
 
     bool readBoundedQByteArray(QDataStream & stream, QByteArray & out, qint64 maxBytes)
     {
@@ -2611,7 +2617,7 @@ namespace
         {
             return false;
         }
-        if (declared == 0xFFFFFFFFu)
+        if (declared == kQDataStreamNullSentinel)
         {
             out.clear();
             return true;
@@ -2640,13 +2646,13 @@ namespace
         {
             return false;
         }
-        if (declared == 0xFFFFFFFFu)
+        if (declared == kQDataStreamNullSentinel)
         {
             out.clear();
             return true;
         }
-        const qint64 maxBytes = static_cast<qint64>(maxChars) * 2;
-        if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes || (declared % 2) != 0)
+        const qint64 maxBytes = static_cast<qint64>(maxChars) * kBytesPerUtf16CodeUnit;
+        if (declared > kInt32MaxAsU32 || static_cast<qint64>(declared) > maxBytes || (declared % kBytesPerUtf16CodeUnit) != 0)
         {
             return false;
         }
@@ -2656,13 +2662,13 @@ namespace
         {
             return false;
         }
-        const qint32 codeUnits = buf.size() / 2;
+        const qint32 codeUnits = buf.size() / kBytesPerUtf16CodeUnit;
         out.resize(codeUnits);
         const uchar * src = reinterpret_cast<const uchar *>(buf.constData());
         // Wire is big-endian; build each code unit explicitly to skip platform-endian conversion in fromUtf16.
         for (qint32 i = 0; i < codeUnits; ++i)
         {
-            out[i] = QChar(static_cast<ushort>((src[i * 2] << 8) | src[i * 2 + 1]));
+            out[i] = QChar(static_cast<ushort>((src[i * kBytesPerUtf16CodeUnit] << kBitsPerByte) | src[i * kBytesPerUtf16CodeUnit + 1]));
         }
         return true;
     }
@@ -2706,7 +2712,7 @@ bool Multiplayermenu::requestModSync(const QStringList & modsToDownload, const Q
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream.setVersion(QDataStream::Version::Qt_6_5);
     stream << QString(NetworkCommands::REQUESTMODSYNC);
-    stream << static_cast<qint32>(1);
+    stream << kModSyncProtocolVersion;
     stream << modsToDownload;
     // Trailing optional flag; older hosts read past their known fields and ignore. New hosts try-read and fall back to legacy framing if absent.
     stream << static_cast<qint32>(NetworkCommands::ModSyncClientFlagChunked);
@@ -2738,7 +2744,7 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
     }
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (protocolVersion != 1)
+    if (protocolVersion != kModSyncProtocolVersion)
     {
         sendModSyncReject(socketID, NetworkCommands::ModSyncInternalError, QString(), tr("Unsupported mod-sync protocol version."));
         return;
@@ -2878,7 +2884,7 @@ void Multiplayermenu::handleModSyncRequest(QDataStream & stream, quint64 socketI
         QDataStream manifestStream(&manifestData, QIODevice::WriteOnly);
         manifestStream.setVersion(QDataStream::Version::Qt_6_5);
         manifestStream << QString(NetworkCommands::MODSYNCMANIFEST);
-        manifestStream << static_cast<qint32>(1);
+        manifestStream << kModSyncProtocolVersion;
         manifestStream << static_cast<qint32>(builtPackages.size());
         for (const auto & entry : std::as_const(builtPackages))
         {
@@ -2911,7 +2917,7 @@ void Multiplayermenu::pumpModSyncSend()
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCCOMPLETE);
-        sendStream << static_cast<qint32>(1);
+        sendStream << kModSyncProtocolVersion;
         emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
         CONSOLE_PRINT("Sent MODSYNCCOMPLETE; " + QString::number(state.packages.size()) + " mods", GameConsole::eINFO);
         state = ModSyncSendState{};
@@ -2924,7 +2930,7 @@ void Multiplayermenu::pumpModSyncSend()
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCDATA);
-        sendStream << static_cast<qint32>(1);
+        sendStream << kModSyncProtocolVersion;
         sendStream << entry.first;
         sendStream << entry.second.declaredUncompressedSize;
         sendStream << entry.second.fileCount;
@@ -2944,7 +2950,7 @@ void Multiplayermenu::pumpModSyncSend()
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCMODBEGIN);
-        sendStream << static_cast<qint32>(1);
+        sendStream << kModSyncProtocolVersion;
         sendStream << entry.first;
         sendStream << entry.second.declaredUncompressedSize;
         sendStream << entry.second.fileCount;
@@ -2966,7 +2972,7 @@ void Multiplayermenu::pumpModSyncSend()
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCMODCHUNK);
-        sendStream << static_cast<qint32>(1);
+        sendStream << kModSyncProtocolVersion;
         sendStream << entry.first;
         sendStream << state.currentChunk;
         sendStream << chunkBytes;
@@ -2980,7 +2986,7 @@ void Multiplayermenu::pumpModSyncSend()
         QDataStream sendStream(&data, QIODevice::WriteOnly);
         sendStream.setVersion(QDataStream::Version::Qt_6_5);
         sendStream << QString(NetworkCommands::MODSYNCMODEND);
-        sendStream << static_cast<qint32>(1);
+        sendStream << kModSyncProtocolVersion;
         sendStream << entry.first;
         emit m_pNetworkInterface->sig_sendData(state.socketID, data, NetworkInterface::NetworkSerives::Multiplayer, false);
         CONSOLE_PRINT("Sent MODSYNCMODEND for " + entry.first, GameConsole::eINFO);
@@ -3006,7 +3012,7 @@ void Multiplayermenu::handleModSyncManifest(QDataStream & stream, quint64 socket
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMANIFEST unsupported protocol version, ignoring", GameConsole::eWARNING);
         return;
@@ -3090,7 +3096,7 @@ void Multiplayermenu::handleModSyncData(QDataStream & stream, quint64 socketID)
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCDATA unsupported protocol version", GameConsole::eERROR);
         failData(tr("Unsupported mod-sync protocol from host."));
@@ -3209,7 +3215,7 @@ void Multiplayermenu::handleModSyncModBegin(QDataStream & stream, quint64 socket
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODBEGIN unsupported protocol version", GameConsole::eERROR);
         failBegin(tr("Unsupported mod-sync protocol from host."));
@@ -3333,7 +3339,7 @@ void Multiplayermenu::handleModSyncModChunk(QDataStream & stream, quint64 socket
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODCHUNK unsupported protocol version", GameConsole::eERROR);
         failChunk(tr("Unsupported mod-sync protocol from host."));
@@ -3433,7 +3439,7 @@ void Multiplayermenu::handleModSyncModEnd(QDataStream & stream, quint64 socketID
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCMODEND unsupported protocol version", GameConsole::eERROR);
         failEnd(tr("Unsupported mod-sync protocol from host."));
@@ -3521,7 +3527,7 @@ void Multiplayermenu::handleModSyncReject(QDataStream & stream, quint64 socketID
 
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCREJECT unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
@@ -3565,7 +3571,7 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     }
     qint32 protocolVersion = 0;
     stream >> protocolVersion;
-    if (stream.status() != QDataStream::Ok || protocolVersion != 1)
+    if (stream.status() != QDataStream::Ok || protocolVersion != kModSyncProtocolVersion)
     {
         CONSOLE_PRINT("MODSYNCCOMPLETE unsupported protocol version", GameConsole::eERROR);
         cancelModSyncSession();
@@ -3623,7 +3629,8 @@ void Multiplayermenu::handleModSyncComplete(QDataStream & stream, quint64 socket
     m_modSyncCurrentChunkMod = ModSyncChunkAccumulator{};
     m_modSyncPostSyncActiveMods.clear();
     // Hold so the progress dialog gets a frame to paint at 100% before the success+restart sequence tears it down.
-    QTimer::singleShot(500, this, &Multiplayermenu::onModSyncSucceeded);
+    constexpr qint32 kModSyncSuccessUiHoldMs = 500;
+    QTimer::singleShot(kModSyncSuccessUiHoldMs, this, &Multiplayermenu::onModSyncSucceeded);
 }
 
 void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message)
@@ -3632,7 +3639,7 @@ void Multiplayermenu::sendModSyncReject(quint64 socketID, qint32 reasonCode, con
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream.setVersion(QDataStream::Version::Qt_6_5);
     stream << QString(NetworkCommands::MODSYNCREJECT);
-    stream << static_cast<qint32>(1);
+    stream << kModSyncProtocolVersion;
     stream << modPath;
     stream << reasonCode;
     stream << message;

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -184,7 +184,7 @@ protected:
     spGameMap createMapFromStream(QString mapFile, QString scriptFile, QDataStream &stream);
     QString getNewFileName(QString filename);    
     void clientMapInfo(QDataStream & stream, quint64 socketID);
-    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, bool & sameMods, bool & differentHash, bool & sameVersion);
+    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion);
     void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion);
     bool checkMods(const QStringList & mods, const QStringList & versions, QStringList & myMods, QStringList & myVersions, bool filter);
     void verifyGameData(QDataStream & stream, quint64 socketID);

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -185,7 +185,7 @@ protected:
     QString getNewFileName(QString filename);    
     void clientMapInfo(QDataStream & stream, quint64 socketID);
     void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, bool & sameMods, bool & differentHash, bool & sameVersion);
-    void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, bool sameMods, bool differentHash, bool sameVersion);
+    void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion);
     bool checkMods(const QStringList & mods, const QStringList & versions, QStringList & myMods, QStringList & myVersions, bool filter);
     void verifyGameData(QDataStream & stream, quint64 socketID);
     /**

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -191,6 +191,7 @@ protected:
     void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, QMap<QString, QByteArray> & hostModHashes, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed);
     void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, const QMap<QString, QByteArray> & hostModHashes, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed);
     void confirmModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
+    void startModSyncDownload(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
     void onModSyncProgress();
     void onModSyncSucceeded();
     void onModSyncFailed(const QString & reason);

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QDir>
+#include <QMap>
 #include <QSet>
 #include <QPair>
 
@@ -187,8 +188,8 @@ protected:
     spGameMap createMapFromStream(QString mapFile, QString scriptFile, QDataStream &stream);
     QString getNewFileName(QString filename);    
     void clientMapInfo(QDataStream & stream, quint64 socketID);
-    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed);
-    void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed);
+    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, QMap<QString, QByteArray> & hostModHashes, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed);
+    void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, const QMap<QString, QByteArray> & hostModHashes, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed);
     void confirmModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
     void onModSyncProgress();
     void onModSyncSucceeded();

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -4,6 +4,8 @@
 #include <QObject>
 #include <QTimer>
 #include <QDir>
+#include <QSet>
+#include <QPair>
 
 #include "3rd_party/oxygine-framework/oxygine/actor/Button.h"
 
@@ -188,6 +190,13 @@ protected:
     void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion);
     bool checkMods(const QStringList & mods, const QStringList & versions, QStringList & myMods, QStringList & myVersions, bool filter);
     void verifyGameData(QDataStream & stream, quint64 socketID);
+    void requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
+    void handleModSyncRequest(QDataStream & stream, quint64 socketID);
+    void handleModSyncData(QDataStream & stream, quint64 socketID);
+    void handleModSyncReject(QDataStream & stream, quint64 socketID);
+    void handleModSyncComplete(QDataStream & stream, quint64 socketID);
+    void sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message);
+    void cancelModSyncSession();
     /**
      * @brief requestRule
      * @param socketID
@@ -365,6 +374,14 @@ private:
     QTimer m_slaveDespawnTimer{this};
     bool m_despawning{false};
     bool m_sameVersionAsServer{false};
+
+    // Mod-sync client-session state; cleared on completion or abort.
+    QList<QPair<QString, QString>> m_modSyncStagings;
+    QSet<QString> m_modSyncRequestedSet;
+    QStringList m_modSyncPostSyncActiveMods;
+    qint64 m_modSyncReceivedBytes{0};
+    qint64 m_modSyncReceivedUncompressedBytes{0};
+    bool m_modSyncActive{false};
 };
 
 Q_DECLARE_INTERFACE(Multiplayermenu, "Multiplayermenu");

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -375,6 +375,8 @@ private:
     bool m_slaveGameReady{false};
     Password m_password;
     quint64 m_hostSocket{0};
+    QString m_serverAddress;
+    quint16 m_serverPort{0};
     spDialogConnecting m_pDialogConnecting;
     QElapsedTimer m_slaveDespawnElapseTimer;
     QTimer m_slaveDespawnTimer{this};

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -7,8 +7,11 @@
 #include <QMap>
 #include <QSet>
 #include <QPair>
+#include <QVector>
 
 #include "3rd_party/oxygine-framework/oxygine/actor/Button.h"
+
+#include "coreengine/filesupport.h"
 
 #include "menue/mapselectionmapsmenue.h"
 
@@ -201,10 +204,15 @@ protected:
     void handleModSyncRequest(QDataStream & stream, quint64 socketID);
     void handleModSyncManifest(QDataStream & stream, quint64 socketID);
     void handleModSyncData(QDataStream & stream, quint64 socketID);
+    void handleModSyncModBegin(QDataStream & stream, quint64 socketID);
+    void handleModSyncModChunk(QDataStream & stream, quint64 socketID);
+    void handleModSyncModEnd(QDataStream & stream, quint64 socketID);
     void handleModSyncReject(QDataStream & stream, quint64 socketID);
     void handleModSyncComplete(QDataStream & stream, quint64 socketID);
     void sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message);
     void cancelModSyncSession();
+    // Drives the host-side chunked send loop one chunk per event-loop iteration so a large mod cannot pin the GUI thread.
+    void pumpModSyncSend();
     /**
      * @brief requestRule
      * @param socketID
@@ -397,6 +405,32 @@ private:
     qint64 m_modSyncExpectedUncompressedTotal{0};
     bool m_modSyncActive{false};
     spDialogModSyncProgress m_modSyncProgressDialog;
+
+    // Client-side chunked-receive accumulator. modPath empty when no chunked mod is in flight (legacy single-frame path stays untouched).
+    struct ModSyncChunkAccumulator
+    {
+        QString modPath;
+        qint32 declaredUncompressedSize{0};
+        qint32 fileCount{0};
+        qint64 compressedTotal{0};
+        qint32 expectedChunkCount{0};
+        qint32 receivedChunkCount{0};
+        qint64 uncompressedAdvanced{0};
+        QByteArray blob;
+    };
+    ModSyncChunkAccumulator m_modSyncCurrentChunkMod;
+
+    // Host-side chunked-send pump state. socketID==0 means no send in flight.
+    struct ModSyncSendState
+    {
+        quint64 socketID{0};
+        QVector<QPair<QString, Filesupport::ModSyncPackage>> packages;
+        qint32 currentMod{0};
+        qint32 currentChunk{0};
+        bool useChunked{false};
+        bool beginEmitted{false};
+    };
+    ModSyncSendState m_modSyncSendState;
 };
 
 Q_DECLARE_INTERFACE(Multiplayermenu, "Multiplayermenu");

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -199,6 +199,7 @@ protected:
     void verifyGameData(QDataStream & stream, quint64 socketID);
     bool requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
     void handleModSyncRequest(QDataStream & stream, quint64 socketID);
+    void handleModSyncManifest(QDataStream & stream, quint64 socketID);
     void handleModSyncData(QDataStream & stream, quint64 socketID);
     void handleModSyncReject(QDataStream & stream, quint64 socketID);
     void handleModSyncComplete(QDataStream & stream, quint64 socketID);
@@ -379,6 +380,8 @@ private:
     QString m_serverAddress;
     quint16 m_serverPort{0};
     spDialogConnecting m_pDialogConnecting;
+    // Held as a member so the mod-sync flow can dismiss it before stacking a second Cancel button.
+    spDialogConnecting m_pJoinConnectingDialog;
     QElapsedTimer m_slaveDespawnElapseTimer;
     QTimer m_slaveDespawnTimer{this};
     bool m_despawning{false};
@@ -390,6 +393,8 @@ private:
     QStringList m_modSyncPostSyncActiveMods;
     qint64 m_modSyncReceivedBytes{0};
     qint64 m_modSyncReceivedUncompressedBytes{0};
+    // Sum of declaredUncompressedSize from MODSYNCMANIFEST; 0 when older hosts skip the frame.
+    qint64 m_modSyncExpectedUncompressedTotal{0};
     bool m_modSyncActive{false};
     spDialogModSyncProgress m_modSyncProgressDialog;
 };

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -184,7 +184,7 @@ protected:
     spGameMap createMapFromStream(QString mapFile, QString scriptFile, QDataStream &stream);
     QString getNewFileName(QString filename);    
     void clientMapInfo(QDataStream & stream, quint64 socketID);
-    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, bool & sameMods, bool & differentHash, bool & sameVersion);
+    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, bool & sameMods, bool & differentHash, bool & sameVersion);
     void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, bool sameMods, bool differentHash, bool sameVersion);
     bool checkMods(const QStringList & mods, const QStringList & versions, QStringList & myMods, QStringList & myVersions, bool filter);
     void verifyGameData(QDataStream & stream, quint64 socketID);

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -189,12 +189,6 @@ protected:
     bool checkMods(const QStringList & mods, const QStringList & versions, QStringList & myMods, QStringList & myVersions, bool filter);
     void verifyGameData(QDataStream & stream, quint64 socketID);
     /**
-     * @brief filterCosmeticMods
-     * @param mods
-     * @param versions
-     */
-    void filterCosmeticMods(QStringList & mods, QStringList & versions, bool filter);
-    /**
      * @brief requestRule
      * @param socketID
      */

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -18,6 +18,7 @@
 
 #include "objects/base/chat.h"
 #include "objects/dialogs/dialogconnecting.h"
+#include "objects/dialogs/dialogmodsyncprogress.h"
 
 class Multiplayermenu;
 using spMultiplayermenu = std::shared_ptr<Multiplayermenu>;
@@ -186,11 +187,15 @@ protected:
     spGameMap createMapFromStream(QString mapFile, QString scriptFile, QDataStream &stream);
     QString getNewFileName(QString filename);    
     void clientMapInfo(QDataStream & stream, quint64 socketID);
-    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion);
-    void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, bool sameMods, bool differentHash, bool sameVersion);
+    void readHashInfo(QDataStream & stream, quint64 socketID, QStringList & mods, QStringList & versions, QStringList & myMods, QStringList & myVersions, QStringList & mismatchedResourceFolders, QStringList & mismatchedMods, quint32 & hostCapabilities, bool & sameMods, bool & differentHash, bool & sameVersion, bool & cosmeticAllowed);
+    void handleVersionMissmatch(const QStringList & mods, const QStringList & versions, const QStringList & myMods, const QStringList & myVersions, const QStringList & mismatchedResourceFolders, const QStringList & mismatchedMods, quint32 hostCapabilities, bool sameMods, bool differentHash, bool sameVersion, bool cosmeticAllowed);
+    void confirmModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
+    void onModSyncProgress();
+    void onModSyncSucceeded();
+    void onModSyncFailed(const QString & reason);
     bool checkMods(const QStringList & mods, const QStringList & versions, QStringList & myMods, QStringList & myVersions, bool filter);
     void verifyGameData(QDataStream & stream, quint64 socketID);
-    void requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
+    bool requestModSync(const QStringList & modsToDownload, const QStringList & postSyncActiveMods);
     void handleModSyncRequest(QDataStream & stream, quint64 socketID);
     void handleModSyncData(QDataStream & stream, quint64 socketID);
     void handleModSyncReject(QDataStream & stream, quint64 socketID);
@@ -382,6 +387,7 @@ private:
     qint64 m_modSyncReceivedBytes{0};
     qint64 m_modSyncReceivedUncompressedBytes{0};
     bool m_modSyncActive{false};
+    spDialogModSyncProgress m_modSyncProgressDialog;
 };
 
 Q_DECLARE_INTERFACE(Multiplayermenu, "Multiplayermenu");

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -211,6 +211,8 @@ protected:
     void handleModSyncComplete(QDataStream & stream, quint64 socketID);
     void sendModSyncReject(quint64 socketID, NetworkCommands::ModSyncRejectReason reasonCode, const QString & modPath, const QString & message);
     void cancelModSyncSession();
+    // Shared failure path of the client-side receive handlers: tear down the session, then surface the reason.
+    void failModSync(const QString & uiReason);
     // Drives the host-side chunked send loop one chunk per event-loop iteration so a large mod cannot pin the GUI thread.
     void pumpModSyncSend();
     /**

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -209,7 +209,7 @@ protected:
     void handleModSyncModEnd(QDataStream & stream, quint64 socketID);
     void handleModSyncReject(QDataStream & stream, quint64 socketID);
     void handleModSyncComplete(QDataStream & stream, quint64 socketID);
-    void sendModSyncReject(quint64 socketID, qint32 reasonCode, const QString & modPath, const QString & message);
+    void sendModSyncReject(quint64 socketID, NetworkCommands::ModSyncRejectReason reasonCode, const QString & modPath, const QString & message);
     void cancelModSyncSession();
     // Drives the host-side chunked send loop one chunk per event-loop iteration so a large mod cannot pin the GUI thread.
     void pumpModSyncSend();

--- a/multiplayer/networkcommands.h
+++ b/multiplayer/networkcommands.h
@@ -163,8 +163,18 @@ namespace NetworkCommands
     // Optional, before MODSYNCDATA, lets the client budget a byte-based progress bar. Older hosts skip it; older clients ignore it.
     const char* const MODSYNCMANIFEST = "MODSYNCMANIFEST";
     const char* const MODSYNCDATA = "MODSYNCDATA";
+    // Chunked-transfer triple, used when the client signals ModSyncClientFlagChunked. BEGIN announces a mod, CHUNK*N delivers slices in order, END finalises.
+    const char* const MODSYNCMODBEGIN = "MODSYNCMODBEGIN";
+    const char* const MODSYNCMODCHUNK = "MODSYNCMODCHUNK";
+    const char* const MODSYNCMODEND = "MODSYNCMODEND";
     const char* const MODSYNCREJECT = "MODSYNCREJECT";
     const char* const MODSYNCCOMPLETE = "MODSYNCCOMPLETE";
+
+    // Bit flags appended (optional) to REQUESTMODSYNC; older hosts read past them via QDataStream EOF and treat absent flags as zero.
+    enum ModSyncClientFlag : qint32
+    {
+        ModSyncClientFlagChunked = 0x00000001,
+    };
 
     // Append-only; serialize as qint32, not the enum's underlying type. 0 reserved so callers can use truthy reads.
     enum ModSyncRejectReason
@@ -176,6 +186,7 @@ namespace NetworkCommands
         ModSyncFileCountCapExceeded = 4,
         ModSyncInvalidPath = 5,
         ModSyncInternalError = 6,
+        ModSyncBusy = 7,
     };
     /**
      * @brief JOINASPLAYER

--- a/multiplayer/networkcommands.h
+++ b/multiplayer/networkcommands.h
@@ -160,6 +160,8 @@ namespace NetworkCommands
     const char* const GAMEDATAVERIFIED = "GAMEDATAVERIFIED";
     // Mod-sync wire format v1. Gated by capability bit Filesupport::CapabilityModSync.
     const char* const REQUESTMODSYNC = "REQUESTMODSYNC";
+    // Optional, before MODSYNCDATA, lets the client budget a byte-based progress bar. Older hosts skip it; older clients ignore it.
+    const char* const MODSYNCMANIFEST = "MODSYNCMANIFEST";
     const char* const MODSYNCDATA = "MODSYNCDATA";
     const char* const MODSYNCREJECT = "MODSYNCREJECT";
     const char* const MODSYNCCOMPLETE = "MODSYNCCOMPLETE";

--- a/multiplayer/networkcommands.h
+++ b/multiplayer/networkcommands.h
@@ -158,6 +158,23 @@ namespace NetworkCommands
      * @brief GAMEDATAVERIFIED
      */
     const char* const GAMEDATAVERIFIED = "GAMEDATAVERIFIED";
+    // Mod-sync wire format v1. Gated by capability bit Filesupport::CapabilityModSync.
+    const char* const REQUESTMODSYNC = "REQUESTMODSYNC";
+    const char* const MODSYNCDATA = "MODSYNCDATA";
+    const char* const MODSYNCREJECT = "MODSYNCREJECT";
+    const char* const MODSYNCCOMPLETE = "MODSYNCCOMPLETE";
+
+    // Append-only; serialize as qint32, not the enum's underlying type. 0 reserved so callers can use truthy reads.
+    enum ModSyncRejectReason
+    {
+        ModSyncNoReason = 0,
+        ModSyncDisabled = 1,
+        ModSyncUnknownMod = 2,
+        ModSyncSizeCapExceeded = 3,
+        ModSyncFileCountCapExceeded = 4,
+        ModSyncInvalidPath = 5,
+        ModSyncInternalError = 6,
+    };
     /**
      * @brief JOINASPLAYER
      */

--- a/multiplayer/networkcommands.h
+++ b/multiplayer/networkcommands.h
@@ -171,13 +171,13 @@ namespace NetworkCommands
     const char* const MODSYNCCOMPLETE = "MODSYNCCOMPLETE";
 
     // Bit flags appended (optional) to REQUESTMODSYNC; older hosts read past them via QDataStream EOF and treat absent flags as zero.
-    enum ModSyncClientFlag : qint32
+    enum class ModSyncClientFlag : qint32
     {
         ModSyncClientFlagChunked = 0x00000001,
     };
 
     // Append-only; serialize as qint32, not the enum's underlying type. 0 reserved so callers can use truthy reads.
-    enum ModSyncRejectReason
+    enum class ModSyncRejectReason : qint32
     {
         ModSyncNoReason = 0,
         ModSyncDisabled = 1,

--- a/objects/dialogs/dialogconnecting.cpp
+++ b/objects/dialogs/dialogconnecting.cpp
@@ -63,12 +63,17 @@ DialogConnecting::DialogConnecting(QString text, qint32 timeoutMs, bool showCanc
 void DialogConnecting::cancel()
 {
     CONSOLE_PRINT("Canceling DialogConnecting", GameConsole::eDEBUG);
+    m_Timer.stop();
+    m_TimerConnectionTimeout.stop();
     detach();
 }
 
 void DialogConnecting::connected()
 {
     CONSOLE_PRINT("Connected in DialogConnecting", GameConsole::eDEBUG);
+    // Stop timers so a retained spDialogConnecting cannot fire a late connectionTimeout that re-emits sigCancel after the user is already in-game.
+    m_Timer.stop();
+    m_TimerConnectionTimeout.stop();
     emit sigConnected();
     detach();
 }

--- a/objects/dialogs/dialogmodsyncprogress.cpp
+++ b/objects/dialogs/dialogmodsyncprogress.cpp
@@ -32,9 +32,10 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
 
     m_Header = MemoryManagement::create<oxygine::TextField>();
     m_Header->setStyle(headerStyle);
+    // Same full-width-with-HALIGN_MIDDLE pattern as m_Detail, dodging oxygine's stale getTextRect after setHtmlText.
+    m_Header->setSize(oxygine::Stage::getStage()->getWidth(), 30);
     m_Header->setHtmlText(tr("Downloading host's mod set"));
-    m_Header->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Header->getTextRect().width() / 2,
-                          oxygine::Stage::getStage()->getHeight() / 2 - 80);
+    m_Header->setPosition(0, oxygine::Stage::getStage()->getHeight() / 2 - 80);
     pSpriteBox->addChild(m_Header);
 
     m_barWidth = 480;
@@ -60,9 +61,10 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
 
     m_Detail = MemoryManagement::create<oxygine::TextField>();
     m_Detail->setStyle(detailStyle);
+    // Full-width field with HALIGN_MIDDLE re-centers via layout on every setHtmlText, dodging oxygine's stale getTextRect on substantial text-length growth.
+    m_Detail->setSize(oxygine::Stage::getStage()->getWidth(), 30);
     m_Detail->setHtmlText(tr("0 / %1 mods").arg(m_totalMods));
-    m_Detail->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Detail->getTextRect().width() / 2,
-                          barY + barHeight + 10);
+    m_Detail->setPosition(0, barY + barHeight + 10);
     pSpriteBox->addChild(m_Detail);
 
     m_CancelButton = pObjectManager->createButton(tr("Cancel"), 150);
@@ -175,8 +177,6 @@ void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedCompre
                  .arg(formatRate(static_cast<qint64>(m_smoothedRateBytesPerSec)));
     }
     m_Detail->setHtmlText(detail);
-    m_Detail->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Detail->getTextRect().width() / 2,
-                          m_Detail->getY());
 }
 
 void DialogModSyncProgress::remove()

--- a/objects/dialogs/dialogmodsyncprogress.cpp
+++ b/objects/dialogs/dialogmodsyncprogress.cpp
@@ -74,26 +74,107 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
         emit sigCancel();
     });
     connect(this, &DialogModSyncProgress::sigCancel, this, &DialogModSyncProgress::remove, Qt::QueuedConnection);
+    m_timer.start();
 }
 
-void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedBytes)
+void DialogModSyncProgress::setExpectedTotalBytes(qint64 expectedUncompressed)
 {
-    if (m_totalMods <= 0)
+    if (expectedUncompressed < 0)
+    {
+        expectedUncompressed = 0;
+    }
+    // Manifest is canonical and one-shot in the wire-correct flow; refuse downward revisions so the bar stays monotonic against intentional or accidental shrinkage.
+    if (m_expectedTotalBytes > 0 && expectedUncompressed < m_expectedTotalBytes)
     {
         return;
     }
+    m_expectedTotalBytes = expectedUncompressed;
+}
+
+void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedCompressed, qint64 receivedUncompressed)
+{
     if (stagedMods < 0)
     {
         stagedMods = 0;
     }
-    if (stagedMods > m_totalMods)
+    if (m_totalMods > 0 && stagedMods > m_totalMods)
     {
         stagedMods = m_totalMods;
     }
-    const float fraction = static_cast<float>(stagedMods) / static_cast<float>(m_totalMods);
-    m_BarFill->setWidth(m_barWidth * fraction);
-    const qint64 receivedKb = receivedBytes / 1024;
-    m_Detail->setHtmlText(tr("%1 / %2 mods (%3 KB)").arg(stagedMods).arg(m_totalMods).arg(receivedKb));
+    if (receivedCompressed < 0)
+    {
+        receivedCompressed = 0;
+    }
+    if (receivedUncompressed < 0)
+    {
+        receivedUncompressed = 0;
+    }
+
+    // 50 ms minimum sample window so a hot LAN burst doesn't seed the EMA at multi-GB/s; lastSampleMs starts at 0 (constructor t0) so the first real sample is always rate-eligible.
+    constexpr qint64 RATE_MIN_DT_MS = 50;
+    constexpr double alpha = 0.3;
+    const qint64 nowMs = m_timer.isValid() ? m_timer.elapsed() : 0;
+    const qint64 dtMs = nowMs - m_lastSampleMs;
+    const qint64 dCompressed = receivedCompressed - m_lastReceivedCompressed;
+    const qint64 dUncompressed = receivedUncompressed - m_lastReceivedUncompressed;
+    if (dtMs >= RATE_MIN_DT_MS && dCompressed >= 0 && dUncompressed >= 0)
+    {
+        const double dtSec = static_cast<double>(dtMs) / 1000.0;
+        const double instantCompressed = static_cast<double>(dCompressed) / dtSec;
+        const double instantUncompressed = static_cast<double>(dUncompressed) / dtSec;
+        m_smoothedRateBytesPerSec = alpha * instantCompressed + (1.0 - alpha) * m_smoothedRateBytesPerSec;
+        m_smoothedUncompressedRateBytesPerSec = alpha * instantUncompressed + (1.0 - alpha) * m_smoothedUncompressedRateBytesPerSec;
+        m_lastSampleMs = nowMs;
+        m_lastReceivedCompressed = receivedCompressed;
+        m_lastReceivedUncompressed = receivedUncompressed;
+    }
+
+    float targetFraction = 0.0f;
+    if (m_expectedTotalBytes > 0)
+    {
+        targetFraction = static_cast<float>(static_cast<double>(receivedUncompressed) / static_cast<double>(m_expectedTotalBytes));
+    }
+    else if (m_totalMods > 0)
+    {
+        targetFraction = static_cast<float>(stagedMods) / static_cast<float>(m_totalMods);
+    }
+    if (targetFraction < 0.0f)
+    {
+        targetFraction = 0.0f;
+    }
+    if (targetFraction > 1.0f)
+    {
+        targetFraction = 1.0f;
+    }
+    if (targetFraction < m_lastDisplayedFraction)
+    {
+        targetFraction = m_lastDisplayedFraction;
+    }
+    m_lastDisplayedFraction = targetFraction;
+    m_BarFill->setWidth(static_cast<qint32>(m_barWidth * targetFraction));
+
+    QString detail;
+    if (m_expectedTotalBytes > 0)
+    {
+        detail = tr("%1 / %2 mods, %3 / %4, %5, ETA %6")
+                 .arg(stagedMods)
+                 .arg(m_totalMods)
+                 .arg(formatBytes(receivedUncompressed))
+                 .arg(formatBytes(m_expectedTotalBytes))
+                 .arg(formatRate(static_cast<qint64>(m_smoothedRateBytesPerSec)))
+                 .arg(formatEta(m_smoothedUncompressedRateBytesPerSec > 0.0
+                                ? static_cast<qint64>(static_cast<double>(m_expectedTotalBytes - receivedUncompressed) / m_smoothedUncompressedRateBytesPerSec)
+                                : -1));
+    }
+    else
+    {
+        detail = tr("%1 / %2 mods, %3, %4")
+                 .arg(stagedMods)
+                 .arg(m_totalMods)
+                 .arg(formatBytes(receivedUncompressed))
+                 .arg(formatRate(static_cast<qint64>(m_smoothedRateBytesPerSec)));
+    }
+    m_Detail->setHtmlText(detail);
     m_Detail->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Detail->getTextRect().width() / 2,
                           m_Detail->getY());
 }
@@ -101,4 +182,54 @@ void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedBytes)
 void DialogModSyncProgress::remove()
 {
     detach();
+}
+
+QString DialogModSyncProgress::formatBytes(qint64 bytes)
+{
+    if (bytes < 1024)
+    {
+        return tr("%1 B").arg(bytes);
+    }
+    const double kb = static_cast<double>(bytes) / 1024.0;
+    if (kb < 1024.0)
+    {
+        return tr("%1 KB").arg(QString::number(kb, 'f', 1));
+    }
+    const double mb = kb / 1024.0;
+    if (mb < 1024.0)
+    {
+        return tr("%1 MB").arg(QString::number(mb, 'f', 1));
+    }
+    const double gb = mb / 1024.0;
+    return tr("%1 GB").arg(QString::number(gb, 'f', 2));
+}
+
+QString DialogModSyncProgress::formatRate(qint64 bytesPerSecond)
+{
+    if (bytesPerSecond <= 0)
+    {
+        return tr("--");
+    }
+    return tr("%1/s").arg(formatBytes(bytesPerSecond));
+}
+
+QString DialogModSyncProgress::formatEta(qint64 seconds)
+{
+    if (seconds < 0)
+    {
+        return tr("--");
+    }
+    if (seconds < 60)
+    {
+        return tr("%1s").arg(seconds);
+    }
+    const qint64 minutes = seconds / 60;
+    const qint64 remSec = seconds % 60;
+    if (minutes < 60)
+    {
+        return tr("%1m %2s").arg(minutes).arg(remSec);
+    }
+    const qint64 hours = minutes / 60;
+    const qint64 remMin = minutes % 60;
+    return tr("%1h %2m").arg(hours).arg(remMin);
 }

--- a/objects/dialogs/dialogmodsyncprogress.cpp
+++ b/objects/dialogs/dialogmodsyncprogress.cpp
@@ -1,0 +1,104 @@
+#include "3rd_party/oxygine-framework/oxygine/actor/Stage.h"
+
+#include "objects/dialogs/dialogmodsyncprogress.h"
+
+#include "coreengine/interpreter.h"
+#include "coreengine/mainapp.h"
+
+#include "resource_management/objectmanager.h"
+#include "resource_management/fontmanager.h"
+
+DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
+    : QObject(),
+      m_totalMods(totalMods)
+{
+#ifdef GRAPHICSUPPORT
+    setObjectName("DialogModSyncProgress");
+#endif
+    Interpreter::setCppOwnerShip(this);
+    ObjectManager* pObjectManager = ObjectManager::getInstance();
+    oxygine::spBox9Sprite pSpriteBox = MemoryManagement::create<oxygine::Box9Sprite>();
+    oxygine::ResAnim* pAnim = pObjectManager->getResAnim("codialog");
+    pSpriteBox->setResAnim(pAnim);
+    pSpriteBox->setSize(oxygine::Stage::getStage()->getWidth(), oxygine::Stage::getStage()->getHeight());
+    addChild(pSpriteBox);
+    pSpriteBox->setPosition(0, 0);
+    pSpriteBox->setPriority(static_cast<qint32>(Mainapp::ZOrder::Objects));
+    setPriority(static_cast<qint32>(Mainapp::ZOrder::Dialogs));
+
+    oxygine::TextStyle headerStyle = oxygine::TextStyle(FontManager::getMainFont24());
+    headerStyle.hAlign = oxygine::TextStyle::HALIGN_MIDDLE;
+    headerStyle.multiline = false;
+
+    m_Header = MemoryManagement::create<oxygine::TextField>();
+    m_Header->setStyle(headerStyle);
+    m_Header->setHtmlText(tr("Downloading host's mod set"));
+    m_Header->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Header->getTextRect().width() / 2,
+                          oxygine::Stage::getStage()->getHeight() / 2 - 80);
+    pSpriteBox->addChild(m_Header);
+
+    m_barWidth = 480;
+    const qint32 barHeight = 24;
+    const qint32 barX = oxygine::Stage::getStage()->getWidth() / 2 - m_barWidth / 2;
+    const qint32 barY = oxygine::Stage::getStage()->getHeight() / 2 - barHeight / 2;
+
+    m_BarBackground = MemoryManagement::create<oxygine::ColorRectSprite>();
+    m_BarBackground->setSize(m_barWidth, barHeight);
+    m_BarBackground->setColor(QColor(100, 100, 100, 200));
+    m_BarBackground->setPosition(barX, barY);
+    pSpriteBox->addChild(m_BarBackground);
+
+    m_BarFill = MemoryManagement::create<oxygine::ColorRectSprite>();
+    m_BarFill->setSize(0, barHeight);
+    m_BarFill->setColor(QColor(35, 180, 80, 255));
+    m_BarFill->setPosition(barX, barY);
+    pSpriteBox->addChild(m_BarFill);
+
+    oxygine::TextStyle detailStyle = oxygine::TextStyle(FontManager::getMainFont24());
+    detailStyle.hAlign = oxygine::TextStyle::HALIGN_MIDDLE;
+    detailStyle.multiline = false;
+
+    m_Detail = MemoryManagement::create<oxygine::TextField>();
+    m_Detail->setStyle(detailStyle);
+    m_Detail->setHtmlText(tr("0 / %1 mods").arg(m_totalMods));
+    m_Detail->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Detail->getTextRect().width() / 2,
+                          barY + barHeight + 10);
+    pSpriteBox->addChild(m_Detail);
+
+    m_CancelButton = pObjectManager->createButton(tr("Cancel"), 150);
+    m_CancelButton->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_CancelButton->getScaledWidth() / 2,
+                                barY + barHeight + 60);
+    pSpriteBox->addChild(m_CancelButton);
+    m_CancelButton->addEventListener(oxygine::TouchEvent::CLICK, [this](oxygine::Event*)
+    {
+        emit sigCancel();
+    });
+    connect(this, &DialogModSyncProgress::sigCancel, this, &DialogModSyncProgress::remove, Qt::QueuedConnection);
+}
+
+void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedBytes)
+{
+    if (m_totalMods <= 0)
+    {
+        return;
+    }
+    if (stagedMods < 0)
+    {
+        stagedMods = 0;
+    }
+    if (stagedMods > m_totalMods)
+    {
+        stagedMods = m_totalMods;
+    }
+    const float fraction = static_cast<float>(stagedMods) / static_cast<float>(m_totalMods);
+    m_BarFill->setWidth(m_barWidth * fraction);
+    const qint64 receivedKb = receivedBytes / 1024;
+    m_Detail->setHtmlText(tr("%1 / %2 mods (%3 KB)").arg(stagedMods).arg(m_totalMods).arg(receivedKb));
+    m_Detail->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_Detail->getTextRect().width() / 2,
+                          m_Detail->getY());
+}
+
+void DialogModSyncProgress::remove()
+{
+    detach();
+}

--- a/objects/dialogs/dialogmodsyncprogress.cpp
+++ b/objects/dialogs/dialogmodsyncprogress.cpp
@@ -29,6 +29,12 @@ namespace
     // 50 ms minimum sample window so a hot LAN burst doesn't seed the EMA at multi-GB/s.
     constexpr qint64 kRateMinDtMs = 50;
     constexpr double kRateEmaAlpha = 0.3;
+
+    constexpr qint32 kSizeDecimalPlaces = 1;
+    // GB steps are coarse enough that a second decimal carries real information.
+    constexpr qint32 kGbDecimalPlaces = 2;
+    // Shown while a rate or ETA is not yet computable.
+    constexpr const char* const kUnknownPlaceholder = QT_TRANSLATE_NOOP("DialogModSyncProgress", "--");
 }
 
 DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
@@ -213,22 +219,22 @@ QString DialogModSyncProgress::formatBytes(qint64 bytes)
     const double kb = static_cast<double>(bytes) / kBytesPerKib;
     if (kb < kBytesPerKib)
     {
-        return tr("%1 KB").arg(QString::number(kb, 'f', 1));
+        return tr("%1 KB").arg(QString::number(kb, 'f', kSizeDecimalPlaces));
     }
     const double mb = kb / kBytesPerKib;
     if (mb < kBytesPerKib)
     {
-        return tr("%1 MB").arg(QString::number(mb, 'f', 1));
+        return tr("%1 MB").arg(QString::number(mb, 'f', kSizeDecimalPlaces));
     }
     const double gb = mb / kBytesPerKib;
-    return tr("%1 GB").arg(QString::number(gb, 'f', 2));
+    return tr("%1 GB").arg(QString::number(gb, 'f', kGbDecimalPlaces));
 }
 
 QString DialogModSyncProgress::formatRate(qint64 bytesPerSecond)
 {
     if (bytesPerSecond <= 0)
     {
-        return tr("--");
+        return tr(kUnknownPlaceholder);
     }
     return tr("%1/s").arg(formatBytes(bytesPerSecond));
 }
@@ -237,7 +243,7 @@ QString DialogModSyncProgress::formatEta(qint64 seconds)
 {
     if (seconds < 0)
     {
-        return tr("--");
+        return tr(kUnknownPlaceholder);
     }
     if (seconds < kSecondsPerMinute)
     {

--- a/objects/dialogs/dialogmodsyncprogress.cpp
+++ b/objects/dialogs/dialogmodsyncprogress.cpp
@@ -1,3 +1,4 @@
+#include "3rd_party/oxygine-framework/oxygine/actor/Box9Sprite.h"
 #include "3rd_party/oxygine-framework/oxygine/actor/Stage.h"
 
 #include "objects/dialogs/dialogmodsyncprogress.h"
@@ -5,18 +6,16 @@
 #include "coreengine/interpreter.h"
 #include "coreengine/mainapp.h"
 
+#include "objects/base/label.h"
+
 #include "resource_management/objectmanager.h"
-#include "resource_management/fontmanager.h"
+
+#include "ui_reader/uifactory.h"
 
 namespace
 {
-    constexpr qint32 kTextFieldHeight = 30;
-    constexpr qint32 kHeaderYOffsetAboveCenter = 80;
     constexpr qint32 kBarWidth = 480;
     constexpr qint32 kBarHeight = 24;
-    constexpr qint32 kDetailYGapBelowBar = 10;
-    constexpr qint32 kCancelButtonWidth = 150;
-    constexpr qint32 kCancelButtonYOffsetBelowBar = 60;
 
     const QColor kBarBackgroundColor{100, 100, 100, 200};
     const QColor kBarFillColor{35, 180, 80, 255};
@@ -35,11 +34,15 @@ namespace
     constexpr qint32 kGbDecimalPlaces = 2;
     // Shown while a rate or ETA is not yet computable.
     constexpr const char* const kUnknownPlaceholder = QT_TRANSLATE_NOOP("DialogModSyncProgress", "--");
+
+    // JS global the XML cancel button calls into.
+    constexpr const char* const kModSyncProgressItem = "modSyncProgress";
+    // Label Id in dialogModSyncProgress.xml.
+    const auto kDetailLabelId = QStringLiteral("modSyncDetail");
 }
 
 DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
-    : QObject(),
-      m_totalMods(totalMods)
+    : m_totalMods(totalMods)
 {
 #ifdef GRAPHICSUPPORT
     setObjectName("DialogModSyncProgress");
@@ -55,18 +58,7 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
     pSpriteBox->setPriority(static_cast<qint32>(Mainapp::ZOrder::Objects));
     setPriority(static_cast<qint32>(Mainapp::ZOrder::Dialogs));
 
-    oxygine::TextStyle headerStyle = oxygine::TextStyle(FontManager::getMainFont24());
-    headerStyle.hAlign = oxygine::TextStyle::HALIGN_MIDDLE;
-    headerStyle.multiline = false;
-
-    m_Header = MemoryManagement::create<oxygine::TextField>();
-    m_Header->setStyle(headerStyle);
-    // Same full-width-with-HALIGN_MIDDLE pattern as m_Detail, dodging oxygine's stale getTextRect after setHtmlText.
-    m_Header->setSize(oxygine::Stage::getStage()->getWidth(), kTextFieldHeight);
-    m_Header->setHtmlText(tr("Downloading host's mod set"));
-    m_Header->setPosition(0, oxygine::Stage::getStage()->getHeight() / 2 - kHeaderYOffsetAboveCenter);
-    pSpriteBox->addChild(m_Header);
-
+    // The fill bar mutates every progress tick; the XML system cannot hand back a mutable ColoredRect, so both bar rects stay code-built.
     m_barWidth = kBarWidth;
     const qint32 barX = oxygine::Stage::getStage()->getWidth() / 2 - m_barWidth / 2;
     const qint32 barY = oxygine::Stage::getStage()->getHeight() / 2 - kBarHeight / 2;
@@ -83,28 +75,37 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
     m_BarFill->setPosition(barX, barY);
     pSpriteBox->addChild(m_BarFill);
 
-    oxygine::TextStyle detailStyle = oxygine::TextStyle(FontManager::getMainFont24());
-    detailStyle.hAlign = oxygine::TextStyle::HALIGN_MIDDLE;
-    detailStyle.multiline = false;
+    Interpreter* pInterpreter = Interpreter::getInstance();
+    pInterpreter->setGlobal(kModSyncProgressItem, pInterpreter->newQObject(this));
+    UiFactory::getInstance().createUi("ui/dialogModSyncProgress.xml", this);
+    setDetailText(tr("0 / %1 mods").arg(m_totalMods));
 
-    m_Detail = MemoryManagement::create<oxygine::TextField>();
-    m_Detail->setStyle(detailStyle);
-    // Full-width field with HALIGN_MIDDLE re-centers via layout on every setHtmlText, dodging oxygine's stale getTextRect on substantial text-length growth.
-    m_Detail->setSize(oxygine::Stage::getStage()->getWidth(), kTextFieldHeight);
-    m_Detail->setHtmlText(tr("0 / %1 mods").arg(m_totalMods));
-    m_Detail->setPosition(0, barY + kBarHeight + kDetailYGapBelowBar);
-    pSpriteBox->addChild(m_Detail);
-
-    m_CancelButton = pObjectManager->createButton(tr("Cancel"), kCancelButtonWidth);
-    m_CancelButton->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_CancelButton->getScaledWidth() / 2,
-                                barY + kBarHeight + kCancelButtonYOffsetBelowBar);
-    pSpriteBox->addChild(m_CancelButton);
-    m_CancelButton->addEventListener(oxygine::TouchEvent::CLICK, [this](oxygine::Event*)
-    {
-        emit sigCancel();
-    });
     connect(this, &DialogModSyncProgress::sigCancel, this, &DialogModSyncProgress::remove, Qt::QueuedConnection);
     m_timer.start();
+}
+
+DialogModSyncProgress::~DialogModSyncProgress()
+{
+    Interpreter* pInterpreter = Interpreter::getInstance();
+    if (pInterpreter != nullptr)
+    {
+        pInterpreter->deleteObject(kModSyncProgressItem);
+    }
+}
+
+void DialogModSyncProgress::cancel()
+{
+    emit sigCancel();
+}
+
+void DialogModSyncProgress::setDetailText(const QString & text)
+{
+    Label* pDetail = getCastedObject<Label>(kDetailLabelId);
+    // createUi failure is non-fatal; progress math keeps running without the label.
+    if (pDetail != nullptr)
+    {
+        pDetail->setHtmlText(text);
+    }
 }
 
 void DialogModSyncProgress::setExpectedTotalBytes(qint64 expectedUncompressed)
@@ -202,7 +203,7 @@ void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedCompre
                  .arg(formatBytes(receivedUncompressed))
                  .arg(formatRate(static_cast<qint64>(m_smoothedRateBytesPerSec)));
     }
-    m_Detail->setHtmlText(detail);
+    setDetailText(detail);
 }
 
 void DialogModSyncProgress::remove()

--- a/objects/dialogs/dialogmodsyncprogress.cpp
+++ b/objects/dialogs/dialogmodsyncprogress.cpp
@@ -8,6 +8,29 @@
 #include "resource_management/objectmanager.h"
 #include "resource_management/fontmanager.h"
 
+namespace
+{
+    constexpr qint32 kTextFieldHeight = 30;
+    constexpr qint32 kHeaderYOffsetAboveCenter = 80;
+    constexpr qint32 kBarWidth = 480;
+    constexpr qint32 kBarHeight = 24;
+    constexpr qint32 kDetailYGapBelowBar = 10;
+    constexpr qint32 kCancelButtonWidth = 150;
+    constexpr qint32 kCancelButtonYOffsetBelowBar = 60;
+
+    const QColor kBarBackgroundColor{100, 100, 100, 200};
+    const QColor kBarFillColor{35, 180, 80, 255};
+
+    constexpr double kBytesPerKib = 1024.0;
+    constexpr double kMsPerSecond = 1000.0;
+    constexpr qint64 kSecondsPerMinute = 60;
+    constexpr qint64 kMinutesPerHour = 60;
+
+    // 50 ms minimum sample window so a hot LAN burst doesn't seed the EMA at multi-GB/s.
+    constexpr qint64 kRateMinDtMs = 50;
+    constexpr double kRateEmaAlpha = 0.3;
+}
+
 DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
     : QObject(),
       m_totalMods(totalMods)
@@ -33,25 +56,24 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
     m_Header = MemoryManagement::create<oxygine::TextField>();
     m_Header->setStyle(headerStyle);
     // Same full-width-with-HALIGN_MIDDLE pattern as m_Detail, dodging oxygine's stale getTextRect after setHtmlText.
-    m_Header->setSize(oxygine::Stage::getStage()->getWidth(), 30);
+    m_Header->setSize(oxygine::Stage::getStage()->getWidth(), kTextFieldHeight);
     m_Header->setHtmlText(tr("Downloading host's mod set"));
-    m_Header->setPosition(0, oxygine::Stage::getStage()->getHeight() / 2 - 80);
+    m_Header->setPosition(0, oxygine::Stage::getStage()->getHeight() / 2 - kHeaderYOffsetAboveCenter);
     pSpriteBox->addChild(m_Header);
 
-    m_barWidth = 480;
-    const qint32 barHeight = 24;
+    m_barWidth = kBarWidth;
     const qint32 barX = oxygine::Stage::getStage()->getWidth() / 2 - m_barWidth / 2;
-    const qint32 barY = oxygine::Stage::getStage()->getHeight() / 2 - barHeight / 2;
+    const qint32 barY = oxygine::Stage::getStage()->getHeight() / 2 - kBarHeight / 2;
 
     m_BarBackground = MemoryManagement::create<oxygine::ColorRectSprite>();
-    m_BarBackground->setSize(m_barWidth, barHeight);
-    m_BarBackground->setColor(QColor(100, 100, 100, 200));
+    m_BarBackground->setSize(m_barWidth, kBarHeight);
+    m_BarBackground->setColor(kBarBackgroundColor);
     m_BarBackground->setPosition(barX, barY);
     pSpriteBox->addChild(m_BarBackground);
 
     m_BarFill = MemoryManagement::create<oxygine::ColorRectSprite>();
-    m_BarFill->setSize(0, barHeight);
-    m_BarFill->setColor(QColor(35, 180, 80, 255));
+    m_BarFill->setSize(0, kBarHeight);
+    m_BarFill->setColor(kBarFillColor);
     m_BarFill->setPosition(barX, barY);
     pSpriteBox->addChild(m_BarFill);
 
@@ -62,14 +84,14 @@ DialogModSyncProgress::DialogModSyncProgress(qint32 totalMods)
     m_Detail = MemoryManagement::create<oxygine::TextField>();
     m_Detail->setStyle(detailStyle);
     // Full-width field with HALIGN_MIDDLE re-centers via layout on every setHtmlText, dodging oxygine's stale getTextRect on substantial text-length growth.
-    m_Detail->setSize(oxygine::Stage::getStage()->getWidth(), 30);
+    m_Detail->setSize(oxygine::Stage::getStage()->getWidth(), kTextFieldHeight);
     m_Detail->setHtmlText(tr("0 / %1 mods").arg(m_totalMods));
-    m_Detail->setPosition(0, barY + barHeight + 10);
+    m_Detail->setPosition(0, barY + kBarHeight + kDetailYGapBelowBar);
     pSpriteBox->addChild(m_Detail);
 
-    m_CancelButton = pObjectManager->createButton(tr("Cancel"), 150);
+    m_CancelButton = pObjectManager->createButton(tr("Cancel"), kCancelButtonWidth);
     m_CancelButton->setPosition(oxygine::Stage::getStage()->getWidth() / 2 - m_CancelButton->getScaledWidth() / 2,
-                                barY + barHeight + 60);
+                                barY + kBarHeight + kCancelButtonYOffsetBelowBar);
     pSpriteBox->addChild(m_CancelButton);
     m_CancelButton->addEventListener(oxygine::TouchEvent::CLICK, [this](oxygine::Event*)
     {
@@ -112,20 +134,18 @@ void DialogModSyncProgress::setProgress(qint32 stagedMods, qint64 receivedCompre
         receivedUncompressed = 0;
     }
 
-    // 50 ms minimum sample window so a hot LAN burst doesn't seed the EMA at multi-GB/s; lastSampleMs starts at 0 (constructor t0) so the first real sample is always rate-eligible.
-    constexpr qint64 RATE_MIN_DT_MS = 50;
-    constexpr double alpha = 0.3;
+    // lastSampleMs starts at 0 (constructor t0) so the first real sample is always rate-eligible.
     const qint64 nowMs = m_timer.isValid() ? m_timer.elapsed() : 0;
     const qint64 dtMs = nowMs - m_lastSampleMs;
     const qint64 dCompressed = receivedCompressed - m_lastReceivedCompressed;
     const qint64 dUncompressed = receivedUncompressed - m_lastReceivedUncompressed;
-    if (dtMs >= RATE_MIN_DT_MS && dCompressed >= 0 && dUncompressed >= 0)
+    if (dtMs >= kRateMinDtMs && dCompressed >= 0 && dUncompressed >= 0)
     {
-        const double dtSec = static_cast<double>(dtMs) / 1000.0;
+        const double dtSec = static_cast<double>(dtMs) / kMsPerSecond;
         const double instantCompressed = static_cast<double>(dCompressed) / dtSec;
         const double instantUncompressed = static_cast<double>(dUncompressed) / dtSec;
-        m_smoothedRateBytesPerSec = alpha * instantCompressed + (1.0 - alpha) * m_smoothedRateBytesPerSec;
-        m_smoothedUncompressedRateBytesPerSec = alpha * instantUncompressed + (1.0 - alpha) * m_smoothedUncompressedRateBytesPerSec;
+        m_smoothedRateBytesPerSec = kRateEmaAlpha * instantCompressed + (1.0 - kRateEmaAlpha) * m_smoothedRateBytesPerSec;
+        m_smoothedUncompressedRateBytesPerSec = kRateEmaAlpha * instantUncompressed + (1.0 - kRateEmaAlpha) * m_smoothedUncompressedRateBytesPerSec;
         m_lastSampleMs = nowMs;
         m_lastReceivedCompressed = receivedCompressed;
         m_lastReceivedUncompressed = receivedUncompressed;
@@ -186,21 +206,21 @@ void DialogModSyncProgress::remove()
 
 QString DialogModSyncProgress::formatBytes(qint64 bytes)
 {
-    if (bytes < 1024)
+    if (bytes < kBytesPerKib)
     {
         return tr("%1 B").arg(bytes);
     }
-    const double kb = static_cast<double>(bytes) / 1024.0;
-    if (kb < 1024.0)
+    const double kb = static_cast<double>(bytes) / kBytesPerKib;
+    if (kb < kBytesPerKib)
     {
         return tr("%1 KB").arg(QString::number(kb, 'f', 1));
     }
-    const double mb = kb / 1024.0;
-    if (mb < 1024.0)
+    const double mb = kb / kBytesPerKib;
+    if (mb < kBytesPerKib)
     {
         return tr("%1 MB").arg(QString::number(mb, 'f', 1));
     }
-    const double gb = mb / 1024.0;
+    const double gb = mb / kBytesPerKib;
     return tr("%1 GB").arg(QString::number(gb, 'f', 2));
 }
 
@@ -219,17 +239,17 @@ QString DialogModSyncProgress::formatEta(qint64 seconds)
     {
         return tr("--");
     }
-    if (seconds < 60)
+    if (seconds < kSecondsPerMinute)
     {
         return tr("%1s").arg(seconds);
     }
-    const qint64 minutes = seconds / 60;
-    const qint64 remSec = seconds % 60;
-    if (minutes < 60)
+    const qint64 minutes = seconds / kSecondsPerMinute;
+    const qint64 remSec = seconds % kSecondsPerMinute;
+    if (minutes < kMinutesPerHour)
     {
         return tr("%1m %2s").arg(minutes).arg(remSec);
     }
-    const qint64 hours = minutes / 60;
-    const qint64 remMin = minutes % 60;
+    const qint64 hours = minutes / kMinutesPerHour;
+    const qint64 remMin = minutes % kMinutesPerHour;
     return tr("%1h %2m").arg(hours).arg(remMin);
 }

--- a/objects/dialogs/dialogmodsyncprogress.h
+++ b/objects/dialogs/dialogmodsyncprogress.h
@@ -1,6 +1,7 @@
 #ifndef DIALOGMODSYNCPROGRESS_H
 #define DIALOGMODSYNCPROGRESS_H
 
+#include <QElapsedTimer>
 #include <QObject>
 
 #include "3rd_party/oxygine-framework/oxygine/actor/Actor.h"
@@ -18,14 +19,29 @@ public:
     explicit DialogModSyncProgress(qint32 totalMods);
     virtual ~DialogModSyncProgress() = default;
 
-    void setProgress(qint32 stagedMods, qint64 receivedBytes);
+    // 0 means unknown; once set the field refuses downward revision so a late or hostile follow-up can't shrink the bar.
+    void setExpectedTotalBytes(qint64 expectedUncompressed);
+    void setProgress(qint32 stagedMods, qint64 receivedCompressed, qint64 receivedUncompressed);
 signals:
     void sigCancel();
 public slots:
     void remove();
 private:
+    static QString formatBytes(qint64 bytes);
+    static QString formatRate(qint64 bytesPerSecond);
+    static QString formatEta(qint64 seconds);
+
     qint32 m_totalMods{0};
     qint32 m_barWidth{0};
+    qint64 m_expectedTotalBytes{0};
+    qint64 m_lastReceivedCompressed{0};
+    qint64 m_lastReceivedUncompressed{0};
+    qint64 m_lastSampleMs{0};
+    // Compressed rate drives the displayed network throughput; uncompressed rate drives ETA so units match remaining-uncompressed.
+    double m_smoothedRateBytesPerSec{0.0};
+    double m_smoothedUncompressedRateBytesPerSec{0.0};
+    float m_lastDisplayedFraction{0.0f};
+    QElapsedTimer m_timer;
     oxygine::spColorRectSprite m_BarBackground;
     oxygine::spColorRectSprite m_BarFill;
     oxygine::spTextField m_Header;

--- a/objects/dialogs/dialogmodsyncprogress.h
+++ b/objects/dialogs/dialogmodsyncprogress.h
@@ -1,0 +1,36 @@
+#ifndef DIALOGMODSYNCPROGRESS_H
+#define DIALOGMODSYNCPROGRESS_H
+
+#include <QObject>
+
+#include "3rd_party/oxygine-framework/oxygine/actor/Actor.h"
+#include "3rd_party/oxygine-framework/oxygine/actor/Button.h"
+#include "3rd_party/oxygine-framework/oxygine/actor/ColorRectSprite.h"
+#include "3rd_party/oxygine-framework/oxygine/actor/TextField.h"
+
+class DialogModSyncProgress;
+using spDialogModSyncProgress = std::shared_ptr<DialogModSyncProgress>;
+
+class DialogModSyncProgress final : public QObject, public oxygine::Actor
+{
+    Q_OBJECT
+public:
+    explicit DialogModSyncProgress(qint32 totalMods);
+    virtual ~DialogModSyncProgress() = default;
+
+    void setProgress(qint32 stagedMods, qint64 receivedBytes);
+signals:
+    void sigCancel();
+public slots:
+    void remove();
+private:
+    qint32 m_totalMods{0};
+    qint32 m_barWidth{0};
+    oxygine::spColorRectSprite m_BarBackground;
+    oxygine::spColorRectSprite m_BarFill;
+    oxygine::spTextField m_Header;
+    oxygine::spTextField m_Detail;
+    oxygine::spButton m_CancelButton;
+};
+
+#endif

--- a/objects/dialogs/dialogmodsyncprogress.h
+++ b/objects/dialogs/dialogmodsyncprogress.h
@@ -2,31 +2,32 @@
 #define DIALOGMODSYNCPROGRESS_H
 
 #include <QElapsedTimer>
-#include <QObject>
 
-#include "3rd_party/oxygine-framework/oxygine/actor/Actor.h"
-#include "3rd_party/oxygine-framework/oxygine/actor/Button.h"
 #include "3rd_party/oxygine-framework/oxygine/actor/ColorRectSprite.h"
-#include "3rd_party/oxygine-framework/oxygine/actor/TextField.h"
+
+#include "ui_reader/createdgui.h"
 
 class DialogModSyncProgress;
 using spDialogModSyncProgress = std::shared_ptr<DialogModSyncProgress>;
 
-class DialogModSyncProgress final : public QObject, public oxygine::Actor
+class DialogModSyncProgress final : public CreatedGui
 {
     Q_OBJECT
 public:
     explicit DialogModSyncProgress(qint32 totalMods);
-    virtual ~DialogModSyncProgress() = default;
+    virtual ~DialogModSyncProgress();
 
     // 0 means unknown; once set the field refuses downward revision so a late or hostile follow-up can't shrink the bar.
     void setExpectedTotalBytes(qint64 expectedUncompressed);
     void setProgress(qint32 stagedMods, qint64 receivedCompressed, qint64 receivedUncompressed);
+    // Entry point for the XML cancel button.
+    Q_INVOKABLE void cancel();
 signals:
     void sigCancel();
 public slots:
     void remove();
 private:
+    void setDetailText(const QString & text);
     static QString formatBytes(qint64 bytes);
     static QString formatRate(qint64 bytesPerSecond);
     static QString formatEta(qint64 seconds);
@@ -44,9 +45,8 @@ private:
     QElapsedTimer m_timer;
     oxygine::spColorRectSprite m_BarBackground;
     oxygine::spColorRectSprite m_BarFill;
-    oxygine::spTextField m_Header;
-    oxygine::spTextField m_Detail;
-    oxygine::spButton m_CancelButton;
 };
+
+Q_DECLARE_INTERFACE(DialogModSyncProgress, "DialogModSyncProgress");
 
 #endif

--- a/resources/ui/dialogModSyncProgress.xml
+++ b/resources/ui/dialogModSyncProgress.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ui>
+    <Label>
+        <x>0</x>
+        <y>settings.getStageHeight() / 2 - 80</y>
+        <width>settings.getStageWidth()</width>
+        <text>QT_TRANSLATE_NOOP("GAME","Downloading host's mod set")</text>
+        <font>"main"</font>
+        <fontSize>24</fontSize>
+        <hAlign>"Middle"</hAlign>
+    </Label>
+    <Label>
+        <Id>"modSyncDetail"</Id>
+        <x>0</x>
+        <y>settings.getStageHeight() / 2 + 22</y>
+        <width>settings.getStageWidth()</width>
+        <text>""</text>
+        <font>"main"</font>
+        <fontSize>24</fontSize>
+        <hAlign>"Middle"</hAlign>
+    </Label>
+    <Button>
+        <x>settings.getStageWidth() / 2 - 75</x>
+        <y>settings.getStageHeight() / 2 + 72</y>
+        <width>150</width>
+        <text>QT_TRANSLATE_NOOP("GAME","Cancel")</text>
+        <tooltip>QT_TRANSLATE_NOOP("GAME","Cancels the mod download")</tooltip>
+        <onEvent>modSyncProgress.cancel();</onEvent>
+    </Button>
+</ui>

--- a/resources/ui/options/optionnetworkmenu.xml
+++ b/resources/ui/options/optionnetworkmenu.xml
@@ -99,6 +99,36 @@
                 <max>65535</max>
                 <onEvent>settings.setGamePort(input)</onEvent>
             </Spinbox>
+            <Label>
+                <x>10</x>
+                <y>lastY + lastHeight + 10</y>
+                <width>400</width>
+                <text>QT_TRANSLATE_NOOP("GAME","Allow clients to sync mods from this host:")</text>
+                <font>"main"</font>
+                <fontSize>24</fontSize>
+            </Label>
+            <Checkbox>
+                <x>lastX + lastWidth + 10</x>
+                <y>lastY</y>
+                <tooltip>QT_TRANSLATE_NOOP("GAME","When hosting, advertise the mod-sync capability so connecting clients can opt to download your mod set if theirs differs.")</tooltip>
+                <startValue>settings.getModSyncEnabled()</startValue>
+                <onEvent>settings.setModSyncEnabled(input)</onEvent>
+            </Checkbox>
+            <Label>
+                <x>10</x>
+                <y>lastY + lastHeight + 10</y>
+                <width>400</width>
+                <text>QT_TRANSLATE_NOOP("GAME","Keep backup of replaced mods after sync:")</text>
+                <font>"main"</font>
+                <fontSize>24</fontSize>
+            </Label>
+            <Checkbox>
+                <x>lastX + lastWidth + 10</x>
+                <y>lastY</y>
+                <tooltip>QT_TRANSLATE_NOOP("GAME","When syncing mods from a host, retain the previous mod folder as mods/&lt;name&gt;.bak-&lt;timestamp&gt;. Disable to save disk space if you have large mod files.")</tooltip>
+                <startValue>settings.getModSyncKeepBackups()</startValue>
+                <onEvent>settings.setModSyncKeepBackups(input)</onEvent>
+            </Checkbox>
         </childs>
     </Panel>
 </ui>

--- a/sprites.qrc
+++ b/sprites.qrc
@@ -3007,6 +3007,7 @@
         <file>resources/images/game/weather/weather_symbol_thunderstorm.png</file>
         <file>resources/objects/gamepad.png</file>
         <file>resources/ui/gamepadInfoDialog.xml</file>
+        <file>resources/ui/dialogModSyncProgress.xml</file>
         <file>resources/images/game/battlesprites/background/back_creeper.png</file>
         <file>resources/images/game/battlesprites/background/back_wastetempharbour.png</file>
         <file>resources/images/colortables/purple.png</file>


### PR DESCRIPTION

<img width="1022" height="376" alt="image" src="https://github.com/user-attachments/assets/e05f2a42-4a54-432c-b9c6-66a181f24219" />
<img width="847" height="317" alt="image" src="https://github.com/user-attachments/assets/fe0af22b-3f46-4040-a409-082f3ae5a03a" />
<img width="1085" height="296" alt="image" src="https://github.com/user-attachments/assets/ac6a2eab-cfd5-4bf5-a660-69dae6090dfb" />
<img width="902" height="326" alt="image" src="https://github.com/user-attachments/assets/866d9ca0-00e2-4e72-933b-860e8a2bff92" />


Adds an optional flow that lets a connecting client whose mod set differs from the host download the host's mods, stage them to disk, restart, and auto-rejoin the lobby.

The feature is off by default. The host enables it under Network options ("Allow clients to sync mods from this host:"); the client signs off on each individual sync via an explicit trust dialog before any host content is downloaded. There is no per-host trust memory, every sync requires a fresh user click.

Wire format is a small additive set of QDataStream-over-TCP frames gated by capability and flag bits, with full back-compat to older clients and hosts. Old hosts ignore unknown frames; old clients see no-op fallback behavior. Per-mod and per-total size caps, per-mod file-count caps, and relpath length caps are all configurable from Settings with conservative defaults.

Protocol surface in `multiplayer/networkcommands.h` and `multiplayer/multiplayermenu.{h,cpp}`. New frames: `REQUESTMODSYNC`, `MODSYNCMANIFEST`, `MODSYNCDATA`, `MODSYNCMODBEGIN`, `MODSYNCMODCHUNK`, `MODSYNCMODEND`, `MODSYNCREJECT`, `MODSYNCCOMPLETE`. Per-frame protocol-version field, append-only reject-reason enum, `Filesupport::CapabilityModSync` bit on the existing handshake, optional `ModSyncClientFlagChunked` bit on `REQUESTMODSYNC`.

Filesystem helpers in `coreengine/filesupport.{h,cpp}` build a `qCompress`'d package per mod (level 1 to limit host CPU stall on text-heavy mods), validate relpaths and caps defense-in-depth on both endpoints, stage each received mod into `mods/<name>.sync-staging-<pid>/`, and write a pending-manifest JSON that a boot-time executor renames into place atomically. A reaper trims orphaned `.bak-<iso>` directories on subsequent launches.

Settings additions in `coreengine/settings.{h,cpp}` and `resources/ui/options/optionnetworkmenu.xml`: `ModSyncEnabled` (host opt-in), `ModSyncMaxPerModBytes`, `ModSyncMaxTotalBytes`, `ModSyncMaxFiles`, `ModSyncMaxRelativePathLength`, `ModSyncKeepBackups`. Two of these surface as checkboxes in the Network options panel; the rest are admin-tunable via the INI.

UI in `objects/dialogs/dialogmodsyncprogress.{h,cpp}` and a refactor of `objects/dialogs/dialogconnecting.cpp`. Mismatch dialog gains an "Apply" button; trust acknowledgment dialog ("You are about to install unverified mods from this host...") gates downloads. Progress dialog shows a smoothed download rate, ETA, and a byte-based bar that advances during a single in-flight mod via the chunked-transfer path. Fixes a regression where the initial join "Connecting" dialog stacked a duplicate Cancel button alongside the progress dialog.

After staging, `Mainapp::setRestartArgv` queues a `--rejoin-password=` argv plus a `.rejoin.json` manifest, the game restarts via `QCoreApplication::exit(1)`, and the next launch rejoins the original lobby host without the user having to retype the password or browse back.

## Tested

Verified end-to-end across two machines (LAN and over the open internet at ~500 to 900 KB/s) with a real 800 MB mod set:

1. Happy path: client with empty mod set joins host with custom mods, mismatch dialog appears, click Apply, click Install on the trust dialog, progress dialog shows real rate and ETA, game auto-restarts, lobby rejoins without re-entering credentials.
2. Settings-only branch: client has the mods on disk but inactive, mismatch dialog appears, click Apply, no trust prompt (no untrusted code is being downloaded), restart, mods activate, lobby rejoins.
3. Cancel mid-sync: progress dialog Cancel button cleanly tears down `mods/<name>.sync-staging-<pid>/` directories, no orphaned state.
4. Old-host-to-new-client and new-host-to-old-client compat: both fall through to the legacy whole-frame `MODSYNCDATA` path.
5. Concurrent peers: second `REQUESTMODSYNC` arriving while a transfer is in flight gets a `ModSyncBusy` reject with a clear failure dialog rather than clobbering the in-flight pump.
6. Backup retention: with `ModSyncKeepBackups=true` the previous mod folders persist as `.bak-<iso>`; with the default `false` they are removed after the swap succeeds, with the reaper handling anything left behind.

## Notes

The feature is opt-in per host. No existing flow is altered when `ModSyncEnabled=false`; the capability bit is simply not advertised and clients see the existing leave-the-game behavior on mismatch. Mod-sync downloads are bounded by both per-mod and per-total caps; a hostile or buggy host cannot cause the client to allocate or stage past the configured limits, and mid-stream cap violations abort the session.

Future hardening deferred from this PR: per-mod SHA-256 integrity check in the manifest, per-socket pump state instead of busy-reject for concurrent peers, host-side cancel hook on client disconnect, and resource-folder sync (currently a `resourceDrift` mismatch still blocks Apply).