### PR TITLE
Stop a fast second click from skipping the rules screen

### DIFF
--- a/menue/mapselectionmapsmenue.cpp
+++ b/menue/mapselectionmapsmenue.cpp
@@ -307,12 +307,17 @@ void MapSelectionMapsMenue::exitMenu()
 
 void MapSelectionMapsMenue::mapSelectionItemClicked(QString item)
 {    
+    if (!m_pMapSelectionView->getVisible())
+    {
+        CONSOLE_PRINT("Ignoring map selection click", GameConsole::eDEBUG);
+        return;
+    }
     QFileInfo info = QFileInfo(item);
     if (info.isFile())
     {
         m_pMapSelectionView->setCurrentFile(info.filePath());
         emit sigButtonNext();
-    }    
+    }
 }
 
 void MapSelectionMapsMenue::mapSelectionItemChanged(QString item)

--- a/objects/mapselection.cpp
+++ b/objects/mapselection.cpp
@@ -93,12 +93,13 @@ void MapSelection::refresh()
 
 void MapSelection::changeFolder(QString folder)
 {
+    // before the early return, else a clicked map latches the flag for the pending timer
+    m_itemClicked = false;
     if (folder.endsWith(".map"))
     {
         return;
     }
     CONSOLE_PRINT("MapSelection::changeFolder " + folder, GameConsole::eDEBUG);
-    m_itemClicked = false;
     QString newFolder =  folder;
     if (newFolder == "")
     {


### PR DESCRIPTION
Clicking a map twice within the 350ms selection window latched m_itemClicked past changeFolder's ".map" early return, so the pending timer emitted a second itemClicked and buttonNext advanced two steps instead of one.

Reset the flag before the early return, and ignore a click once the map list is hidden, matching the guard mapSelectionItemChanged already has.