### PR TITLE
Stack/script api

### DIFF
--- a/ai/coreai.cpp
+++ b/ai/coreai.cpp
@@ -2099,6 +2099,13 @@ void CoreAI::sortUnitsFarFromEnemyFirst(std::vector<MoveUnitData> & pUnits, spQm
     }
     std::sort(pUnits.begin(), pUnits.end(), [](const MoveUnitData& lhs, const MoveUnitData& rhs)
     {
+        // script-set ai priority overrides the heuristic, zero means no opinion
+        qint32 lhsPriority = lhs.pUnit->getAiPriority();
+        qint32 rhsPriority = rhs.pUnit->getAiPriority();
+        if (lhsPriority != rhsPriority)
+        {
+            return lhsPriority > rhsPriority;
+        }
         if (lhs.canCapture == rhs.canCapture)
         {
             if (lhs.distanceToEnemy == rhs.distanceToEnemy)

--- a/ai/coreai_predefinedai.cpp
+++ b/ai/coreai_predefinedai.cpp
@@ -284,7 +284,8 @@ bool CoreAI::processPredefinedAi()
     {
         CONSOLE_PRINT("processPredefinedAi()", GameConsole::eDEBUG);
         spQmlVectorUnit pUnits = m_pPlayer->getSpUnits();
-        pUnits->randomize();
+        // deterministic order so map scripts can sequence their units via setAiPriority
+        pUnits->sortAiPriority();
         spQmlVectorUnit pEnemyUnits = m_pPlayer->getSpEnemyUnits();
         pEnemyUnits->randomize();
         spQmlVectorBuilding pEnemyBuildings = m_pPlayer->getSpEnemyBuildings();

--- a/ai/productionSystem/simpleproductionsystem.cpp
+++ b/ai/productionSystem/simpleproductionsystem.cpp
@@ -1052,7 +1052,8 @@ void SimpleProductionSystem::deserializeObject(QDataStream& pStream)
         InitialProduction item;
         qint32 size2 = 0;
         pStream >> size2;
-        for (qint32 i2 = 0; i2 < size; ++i2)
+        // size2 is this entry's id count; size is the entry count, and reading by it misaligns.
+        for (qint32 i2 = 0; i2 < size2; ++i2)
         {
             QString id;
             pStream >> id;

--- a/ai/productionSystem/simpleproductionsystem.cpp
+++ b/ai/productionSystem/simpleproductionsystem.cpp
@@ -1033,6 +1033,15 @@ bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QStri
         setBuildFailure(failureReason, "DANGER");
         return false;
     }
+    // Ask about this unit before the action does, because ACTION_BUILD_UNITS
+    // refuses outright when the player cannot afford anything the factory
+    // offers. That reads as NOT_ALLOWED, which callers treat as permanent, when
+    // it is only poverty and will fix itself once funds accumulate.
+    if (m_owner->getPlayer()->getCosts(unitId, pBuilding->getPosition()) > m_owner->getPlayer()->getFunds())
+    {
+        setBuildFailure(failureReason, "NO_FUNDS");
+        return false;
+    }
     spGameAction pAction = MemoryManagement::create<GameAction>(CoreAI::ACTION_BUILD_UNITS, m_owner->getMap());
     pAction->setTarget(pBuilding->getPosition());
     if (!pAction->canBePerformed())

--- a/ai/productionSystem/simpleproductionsystem.cpp
+++ b/ai/productionSystem/simpleproductionsystem.cpp
@@ -563,7 +563,7 @@ bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildin
     for (qint32 i = 0; i < m_priorityProduction.size(); ++i)
     {
         auto & item = m_priorityProduction[i];
-        QString reason = "NO_FACTORY";
+        BuildFailure reason = BuildFailure::NoFactory;
         QString lastUnitId = item.unitIds[0];
         if (pMap->onMap(item.x, item.y))
         {
@@ -583,7 +583,7 @@ bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildin
             }
             else
             {
-                reason = "INVALID_POSITION";
+                reason = BuildFailure::InvalidPosition;
             }
         }
         else
@@ -599,7 +599,7 @@ bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildin
                 }
             }
         }
-        m_lastPriorityBuildResult = (success ? QString("BUILT") : reason) + "|" + lastUnitId + "|" +
+        m_lastPriorityBuildResult = (success ? QString("BUILT") : QString(buildFailureName(reason))) + "|" + lastUnitId + "|" +
                                     QString::number(item.x) + "," + QString::number(item.y);
         CONSOLE_PRINT("SimpleProductionSystem priority production " + m_lastPriorityBuildResult, GameConsole::eDEBUG);
         if (success)
@@ -607,8 +607,8 @@ bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildin
             m_priorityProduction.erase(m_priorityProduction.cbegin() + i);
             break;
         }
-        else if (reason != "NO_FUNDS" &&
-                 reason != "FACTORY_BLOCKED")
+        else if (reason != BuildFailure::NoFunds &&
+                 reason != BuildFailure::FactoryBlocked)
         {
             // permanent failure: drop the entry so a blocking one cannot starve the ai forever
             CONSOLE_PRINT("SimpleProductionSystem dropping priority production " + m_lastPriorityBuildResult, GameConsole::eWARNING);
@@ -947,24 +947,7 @@ bool SimpleProductionSystem::buildUnitCloseTo(QmlVectorBuilding* pBuildings, QSt
     return success;
 }
 
-static qint32 buildFailureRank(const QString & reason)
-{
-    if (reason == "NO_FUNDS")
-    {
-        return 2;
-    }
-    else if (reason == "FACTORY_BLOCKED")
-    {
-        return 1;
-    }
-    else if (reason == "NO_FACTORY" || reason.isEmpty())
-    {
-        return -1;
-    }
-    return 0;
-}
-
-bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild, QString * failureReason)
+bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild, BuildFailure * failureReason)
 {
     bool success = false;
     for (auto & pBuilding : pBuildings->getVector())
@@ -972,7 +955,7 @@ bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString un
         auto & item = m_averageMoverange[pBuilding.get()];
         if (item.averageValue * minAverageIslandSize <= item.islandSizes[unitId])
         {
-            QString reason;
+            BuildFailure reason = BuildFailure::NoFactory;
             success = buildUnit(pBuilding->getX(), pBuilding->getY(), unitId, alwaysBuild, failureReason != nullptr ? &reason : nullptr);
             if (success)
             {
@@ -980,7 +963,7 @@ bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString un
             }
             // keep the most retryable failure so one town cannot mask a blocked factory
             if (failureReason != nullptr &&
-                buildFailureRank(reason) > buildFailureRank(*failureReason))
+                reason > *failureReason)
             {
                 *failureReason = reason;
             }
@@ -993,7 +976,7 @@ bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString un
     return success;
 }
 
-void SimpleProductionSystem::setBuildFailure(QString * failureReason, const char * reason)
+void SimpleProductionSystem::setBuildFailure(BuildFailure * failureReason, BuildFailure reason)
 {
     if (failureReason != nullptr)
     {
@@ -1001,39 +984,57 @@ void SimpleProductionSystem::setBuildFailure(QString * failureReason, const char
     }
 }
 
-bool SimpleProductionSystem::buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, QString * failureReason)
+// the only place the reason names exist, converted at the script and console boundary
+const char* SimpleProductionSystem::buildFailureName(BuildFailure reason)
+{
+    switch (reason)
+    {
+        case BuildFailure::NoFactory: return "NO_FACTORY";
+        case BuildFailure::Danger: return "DANGER";
+        case BuildFailure::InvalidPosition: return "INVALID_POSITION";
+        case BuildFailure::NotAFactory: return "NOT_A_FACTORY";
+        case BuildFailure::NotAllowed: return "NOT_ALLOWED";
+        case BuildFailure::NotInBuildList: return "NOT_IN_BUILD_LIST";
+        case BuildFailure::Disabled: return "DISABLED";
+        case BuildFailure::FactoryBlocked: return "FACTORY_BLOCKED";
+        case BuildFailure::NoFunds: return "NO_FUNDS";
+    }
+    return "UNKNOWN";
+}
+
+bool SimpleProductionSystem::buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, BuildFailure * failureReason)
 {
     if (unitId.isEmpty())
     {
-        setBuildFailure(failureReason, "NOT_IN_BUILD_LIST");
+        setBuildFailure(failureReason, BuildFailure::NotInBuildList);
         return false;
     }
     Building* pBuilding = ownedBuildingAt(x, y);
     if (pBuilding == nullptr)
     {
-        setBuildFailure(failureReason, "INVALID_POSITION");
+        setBuildFailure(failureReason, BuildFailure::InvalidPosition);
         return false;
     }
     return executeBuildAction(pBuilding, unitId, DEFAULT_ACTION_ORDINAL, NO_EXPECTED_COST, alwaysBuild, failureReason);
 }
 
-bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild, QString * failureReason)
+bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild, BuildFailure * failureReason)
 {
     if (pBuilding == nullptr || pBuilding->getOwner() != m_owner->getPlayer() ||
         !pBuilding->getActionList().contains(CoreAI::ACTION_BUILD_UNITS))
     {
-        setBuildFailure(failureReason, "NOT_A_FACTORY");
+        setBuildFailure(failureReason, BuildFailure::NotAFactory);
         return false;
     }
     if (pBuilding->getTerrain()->getUnit() != nullptr)
     {
-        setBuildFailure(failureReason, "FACTORY_BLOCKED");
+        setBuildFailure(failureReason, BuildFailure::FactoryBlocked);
         return false;
     }
     if (!alwaysBuild &&
         !reasonableBuildField(pBuilding->getX(), pBuilding->getY(), unitId, m_maxDamageCheckRange, m_maxSingleDamage))
     {
-        setBuildFailure(failureReason, "DANGER");
+        setBuildFailure(failureReason, BuildFailure::Danger);
         return false;
     }
     // Ask about this unit before the action does, because ACTION_BUILD_UNITS
@@ -1042,20 +1043,20 @@ bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QStri
     // it is only poverty and will fix itself once funds accumulate.
     if (m_owner->getPlayer()->getCosts(unitId, pBuilding->getPosition()) > m_owner->getPlayer()->getFunds())
     {
-        setBuildFailure(failureReason, "NO_FUNDS");
+        setBuildFailure(failureReason, BuildFailure::NoFunds);
         return false;
     }
     spGameAction pAction = MemoryManagement::create<GameAction>(CoreAI::ACTION_BUILD_UNITS, m_owner->getMap());
     pAction->setTarget(pBuilding->getPosition());
     if (!pAction->canBePerformed())
     {
-        setBuildFailure(failureReason, "NOT_ALLOWED");
+        setBuildFailure(failureReason, BuildFailure::NotAllowed);
         return false;
     }
     spMenuData pData = pAction->getMenuStepData();
     if (!pData->validData())
     {
-        setBuildFailure(failureReason, "NOT_ALLOWED");
+        setBuildFailure(failureReason, BuildFailure::NotAllowed);
         return false;
     }
     const QStringList actionIds = pData->getActionIDs();
@@ -1075,18 +1076,18 @@ bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QStri
     }
     if (selectedIndex < 0)
     {
-        setBuildFailure(failureReason, "NOT_IN_BUILD_LIST");
+        setBuildFailure(failureReason, BuildFailure::NotInBuildList);
         return false;
     }
     if (!pData->getEnabledList()[selectedIndex])
     {
         if (pData->getCostList()[selectedIndex] > m_owner->getPlayer()->getFunds())
         {
-            setBuildFailure(failureReason, "NO_FUNDS");
+            setBuildFailure(failureReason, BuildFailure::NoFunds);
         }
         else
         {
-            setBuildFailure(failureReason, "DISABLED");
+            setBuildFailure(failureReason, BuildFailure::Disabled);
         }
         return false;
     }
@@ -1094,13 +1095,13 @@ bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QStri
     const bool hasExpectedCost = expectedCost > NO_EXPECTED_COST;
     if (hasExpectedCost && liveCost != expectedCost)
     {
-        setBuildFailure(failureReason, "DISABLED");
+        setBuildFailure(failureReason, BuildFailure::Disabled);
         return false;
     }
     m_owner->addMenuItemData(pAction, unitId, liveCost);
     if (!pAction->isFinalStep() || !pAction->canBePerformed())
     {
-        setBuildFailure(failureReason, "NOT_ALLOWED");
+        setBuildFailure(failureReason, BuildFailure::NotAllowed);
         return false;
     }
     CONSOLE_PRINT("Building unit " + unitId + " at x=" + QString::number(pBuilding->getX()) + " y=" + QString::number(pBuilding->getY()), GameConsole::eDEBUG);

--- a/ai/productionSystem/simpleproductionsystem.cpp
+++ b/ai/productionSystem/simpleproductionsystem.cpp
@@ -450,14 +450,15 @@ void SimpleProductionSystem::addPriorityProduction(const QStringList & unitIds, 
         CONSOLE_PRINT("SimpleProductionSystem::addPriorityProduction ignoring entry with empty unitIds", GameConsole::eWARNING);
         return;
     }
-    for (const auto & existing : m_priorityProduction)
+    for (auto & existing : m_priorityProduction)
     {
-        // makes re-queueing every turn idempotent
+        // makes re-queueing every turn idempotent; a changed blocking flag
+        // updates the entry instead of duplicating it
         if (existing.x == x &&
             existing.y == y &&
-            existing.blocking == blocking &&
             existing.unitIds == unitIds)
         {
+            existing.blocking = blocking;
             return;
         }
     }
@@ -553,9 +554,11 @@ void SimpleProductionSystem::addItemToBuildDistribution(const QString & group, c
     }
 }
 
-bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildings, qreal minAverageIslandSize, bool & blocked)
+bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildings, bool & blocked)
 {
     bool success = false;
+    // cleared up front so the token always describes this build pass, never a stale turn
+    m_lastPriorityBuildResult.clear();
     GameMap* pMap = m_owner->getMap();
     for (qint32 i = 0; i < m_priorityProduction.size(); ++i)
     {
@@ -630,7 +633,7 @@ bool SimpleProductionSystem::buildNextUnit(QmlVectorBuilding* pBuildings, QmlVec
     }
     GameMap* pMap = m_owner->getMap();
     bool blocked = false;
-    bool success = buildPriorityProduction(pBuildings, minAverageIslandSize, blocked);
+    bool success = buildPriorityProduction(pBuildings, blocked);
     if (blocked)
     {
         return false;

--- a/ai/productionSystem/simpleproductionsystem.cpp
+++ b/ai/productionSystem/simpleproductionsystem.cpp
@@ -438,6 +438,47 @@ void SimpleProductionSystem::resetForcedProduction()
     m_forcedProduction.clear();
 }
 
+void SimpleProductionSystem::resetPriorityProduction()
+{
+    m_priorityProduction.clear();
+}
+
+void SimpleProductionSystem::addPriorityProduction(const QStringList & unitIds, qint32 x, qint32 y, bool blocking)
+{
+    if (unitIds.isEmpty())
+    {
+        CONSOLE_PRINT("SimpleProductionSystem::addPriorityProduction ignoring entry with empty unitIds", GameConsole::eWARNING);
+        return;
+    }
+    for (const auto & existing : m_priorityProduction)
+    {
+        // makes re-queueing every turn idempotent
+        if (existing.x == x &&
+            existing.y == y &&
+            existing.blocking == blocking &&
+            existing.unitIds == unitIds)
+        {
+            return;
+        }
+    }
+    PriorityProduction item;
+    item.unitIds = unitIds;
+    item.x = x;
+    item.y = y;
+    item.blocking = blocking;
+    m_priorityProduction.push_back(item);
+}
+
+qint32 SimpleProductionSystem::getPriorityProductionCount() const
+{
+    return static_cast<qint32>(m_priorityProduction.size());
+}
+
+QString SimpleProductionSystem::getLastPriorityBuildResult() const
+{
+    return m_lastPriorityBuildResult;
+}
+
 void SimpleProductionSystem::addForcedProduction(const QStringList & unitIds, qint32 x, qint32 y)
 {
     ForcedProduction item;
@@ -512,6 +553,74 @@ void SimpleProductionSystem::addItemToBuildDistribution(const QString & group, c
     }
 }
 
+bool SimpleProductionSystem::buildPriorityProduction(QmlVectorBuilding* pBuildings, qreal minAverageIslandSize, bool & blocked)
+{
+    bool success = false;
+    GameMap* pMap = m_owner->getMap();
+    for (qint32 i = 0; i < m_priorityProduction.size(); ++i)
+    {
+        auto & item = m_priorityProduction[i];
+        QString reason = "NO_FACTORY";
+        QString lastUnitId = item.unitIds[0];
+        if (pMap->onMap(item.x, item.y))
+        {
+            Building* pBuilding = pMap->getTerrain(item.x, item.y)->getBuilding();
+            if (pBuilding != nullptr &&
+                pBuilding->getOwner() == m_owner->getPlayer())
+            {
+                for (auto & unitId : item.unitIds)
+                {
+                    lastUnitId = unitId;
+                    success = buildUnit(item.x, item.y, unitId, true, &reason);
+                    if (success)
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                reason = "INVALID_POSITION";
+            }
+        }
+        else
+        {
+            for (auto & unitId : item.unitIds)
+            {
+                lastUnitId = unitId;
+                // island filter bypassed on purpose, the build menu decides instead
+                success = buildUnit(pBuildings, unitId, 0.0, true, &reason);
+                if (success)
+                {
+                    break;
+                }
+            }
+        }
+        m_lastPriorityBuildResult = (success ? QString("BUILT") : reason) + "|" + lastUnitId + "|" +
+                                    QString::number(item.x) + "," + QString::number(item.y);
+        CONSOLE_PRINT("SimpleProductionSystem priority production " + m_lastPriorityBuildResult, GameConsole::eDEBUG);
+        if (success)
+        {
+            m_priorityProduction.erase(m_priorityProduction.cbegin() + i);
+            break;
+        }
+        else if (reason != "NO_FUNDS" &&
+                 reason != "FACTORY_BLOCKED")
+        {
+            // permanent failure: drop the entry so a blocking one cannot starve the ai forever
+            CONSOLE_PRINT("SimpleProductionSystem dropping priority production " + m_lastPriorityBuildResult, GameConsole::eWARNING);
+            m_priorityProduction.erase(m_priorityProduction.cbegin() + i);
+            --i;
+        }
+        else if (item.blocking)
+        {
+            blocked = true;
+            break;
+        }
+    }
+    return success;
+}
+
 bool SimpleProductionSystem::buildNextUnit(QmlVectorBuilding* pBuildings, QmlVectorUnit* pUnits, qint32 minBuildMode, qint32 maxBuildMode,
                                            qreal minAverageIslandSize, qint32 minBaseCost, qint32 maxBaseCost, bool alwaysBuild)
 {
@@ -519,9 +628,14 @@ bool SimpleProductionSystem::buildNextUnit(QmlVectorBuilding* pBuildings, QmlVec
     {
         maxBaseCost = m_owner->getPlayer()->getFunds();
     }
-    bool success = false;
     GameMap* pMap = m_owner->getMap();
-    for (qint32 i = 0; i < m_initialProduction.size(); ++i)
+    bool blocked = false;
+    bool success = buildPriorityProduction(pBuildings, minAverageIslandSize, blocked);
+    if (blocked)
+    {
+        return false;
+    }
+    for (qint32 i = 0; i < m_initialProduction.size() && !success; ++i)
     {
         auto & item = m_initialProduction[i];
         for (auto & unitId : item.unitIds)
@@ -830,7 +944,24 @@ bool SimpleProductionSystem::buildUnitCloseTo(QmlVectorBuilding* pBuildings, QSt
     return success;
 }
 
-bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild)
+static qint32 buildFailureRank(const QString & reason)
+{
+    if (reason == "NO_FUNDS")
+    {
+        return 2;
+    }
+    else if (reason == "FACTORY_BLOCKED")
+    {
+        return 1;
+    }
+    else if (reason == "NO_FACTORY" || reason.isEmpty())
+    {
+        return -1;
+    }
+    return 0;
+}
+
+bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild, QString * failureReason)
 {
     bool success = false;
     for (auto & pBuilding : pBuildings->getVector())
@@ -838,10 +969,17 @@ bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString un
         auto & item = m_averageMoverange[pBuilding.get()];
         if (item.averageValue * minAverageIslandSize <= item.islandSizes[unitId])
         {
-            success = buildUnit(pBuilding->getX(), pBuilding->getY(), unitId, alwaysBuild);
+            QString reason;
+            success = buildUnit(pBuilding->getX(), pBuilding->getY(), unitId, alwaysBuild, failureReason != nullptr ? &reason : nullptr);
             if (success)
             {
                 break;
+            }
+            // keep the most retryable failure so one town cannot mask a blocked factory
+            if (failureReason != nullptr &&
+                buildFailureRank(reason) > buildFailureRank(*failureReason))
+            {
+                *failureReason = reason;
             }
         }
     }
@@ -852,42 +990,60 @@ bool SimpleProductionSystem::buildUnit(QmlVectorBuilding* pBuildings, QString un
     return success;
 }
 
-bool SimpleProductionSystem::buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild)
+void SimpleProductionSystem::setBuildFailure(QString * failureReason, const char * reason)
+{
+    if (failureReason != nullptr)
+    {
+        *failureReason = reason;
+    }
+}
+
+bool SimpleProductionSystem::buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, QString * failureReason)
 {
     if (unitId.isEmpty())
     {
+        setBuildFailure(failureReason, "NOT_IN_BUILD_LIST");
         return false;
     }
     Building* pBuilding = ownedBuildingAt(x, y);
     if (pBuilding == nullptr)
     {
+        setBuildFailure(failureReason, "INVALID_POSITION");
         return false;
     }
-    return executeBuildAction(pBuilding, unitId, DEFAULT_ACTION_ORDINAL, NO_EXPECTED_COST, alwaysBuild);
+    return executeBuildAction(pBuilding, unitId, DEFAULT_ACTION_ORDINAL, NO_EXPECTED_COST, alwaysBuild, failureReason);
 }
 
-bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild)
+bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild, QString * failureReason)
 {
     if (pBuilding == nullptr || pBuilding->getOwner() != m_owner->getPlayer() ||
-        !pBuilding->getActionList().contains(CoreAI::ACTION_BUILD_UNITS) ||
-        pBuilding->getTerrain()->getUnit() != nullptr)
+        !pBuilding->getActionList().contains(CoreAI::ACTION_BUILD_UNITS))
     {
+        setBuildFailure(failureReason, "NOT_A_FACTORY");
+        return false;
+    }
+    if (pBuilding->getTerrain()->getUnit() != nullptr)
+    {
+        setBuildFailure(failureReason, "FACTORY_BLOCKED");
         return false;
     }
     if (!alwaysBuild &&
         !reasonableBuildField(pBuilding->getX(), pBuilding->getY(), unitId, m_maxDamageCheckRange, m_maxSingleDamage))
     {
+        setBuildFailure(failureReason, "DANGER");
         return false;
     }
     spGameAction pAction = MemoryManagement::create<GameAction>(CoreAI::ACTION_BUILD_UNITS, m_owner->getMap());
     pAction->setTarget(pBuilding->getPosition());
     if (!pAction->canBePerformed())
     {
+        setBuildFailure(failureReason, "NOT_ALLOWED");
         return false;
     }
     spMenuData pData = pAction->getMenuStepData();
     if (!pData->validData())
     {
+        setBuildFailure(failureReason, "NOT_ALLOWED");
         return false;
     }
     const QStringList actionIds = pData->getActionIDs();
@@ -905,19 +1061,34 @@ bool SimpleProductionSystem::executeBuildAction(Building* pBuilding, const QStri
             ++currentOrdinal;
         }
     }
-    if (selectedIndex < 0 || !pData->getEnabledList()[selectedIndex])
+    if (selectedIndex < 0)
     {
+        setBuildFailure(failureReason, "NOT_IN_BUILD_LIST");
+        return false;
+    }
+    if (!pData->getEnabledList()[selectedIndex])
+    {
+        if (pData->getCostList()[selectedIndex] > m_owner->getPlayer()->getFunds())
+        {
+            setBuildFailure(failureReason, "NO_FUNDS");
+        }
+        else
+        {
+            setBuildFailure(failureReason, "DISABLED");
+        }
         return false;
     }
     const qint32 liveCost = pData->getCostList()[selectedIndex];
     const bool hasExpectedCost = expectedCost > NO_EXPECTED_COST;
     if (hasExpectedCost && liveCost != expectedCost)
     {
+        setBuildFailure(failureReason, "DISABLED");
         return false;
     }
     m_owner->addMenuItemData(pAction, unitId, liveCost);
     if (!pAction->isFinalStep() || !pAction->canBePerformed())
     {
+        setBuildFailure(failureReason, "NOT_ALLOWED");
         return false;
     }
     CONSOLE_PRINT("Building unit " + unitId + " at x=" + QString::number(pBuilding->getX()) + " y=" + QString::number(pBuilding->getY()), GameConsole::eDEBUG);
@@ -1014,6 +1185,30 @@ void SimpleProductionSystem::serializeObject(QDataStream& pStream) const
     }
     m_Variables.serializeObject(pStream);
     pStream << m_currentTurnProducedUnitsCounter;
+    // version 2: forced production loses close-to-target references, those entries degrade to any factory
+    pStream << static_cast<qint32>(m_forcedProduction.size());
+    for (const auto& item : m_forcedProduction)
+    {
+        pStream << item.x;
+        pStream << item.y;
+        pStream << static_cast<qint32>(item.unitIds.size());
+        for (const auto& unitId : item.unitIds)
+        {
+            pStream << unitId;
+        }
+    }
+    pStream << static_cast<qint32>(m_priorityProduction.size());
+    for (const auto& item : m_priorityProduction)
+    {
+        pStream << item.x;
+        pStream << item.y;
+        pStream << item.blocking;
+        pStream << static_cast<qint32>(item.unitIds.size());
+        for (const auto& unitId : item.unitIds)
+        {
+            pStream << unitId;
+        }
+    }
 }
 
 void SimpleProductionSystem::deserializeObject(QDataStream& pStream)
@@ -1066,6 +1261,45 @@ void SimpleProductionSystem::deserializeObject(QDataStream& pStream)
     if (version > 0)
     {
         pStream >> m_currentTurnProducedUnitsCounter;
+    }
+    if (version > 1)
+    {
+        pStream >> size;
+        for (qint32 i = 0; i < size; ++i)
+        {
+            ForcedProduction item;
+            pStream >> item.x;
+            pStream >> item.y;
+            qint32 size2 = 0;
+            pStream >> size2;
+            for (qint32 i2 = 0; i2 < size2; ++i2)
+            {
+                QString id;
+                pStream >> id;
+                item.unitIds.append(id);
+            }
+            m_forcedProduction.push_back(item);
+        }
+        pStream >> size;
+        for (qint32 i = 0; i < size; ++i)
+        {
+            PriorityProduction item;
+            pStream >> item.x;
+            pStream >> item.y;
+            pStream >> item.blocking;
+            qint32 size2 = 0;
+            pStream >> size2;
+            for (qint32 i2 = 0; i2 < size2; ++i2)
+            {
+                QString id;
+                pStream >> id;
+                item.unitIds.append(id);
+            }
+            if (!item.unitIds.isEmpty())
+            {
+                m_priorityProduction.push_back(item);
+            }
+        }
     }
 }
 

--- a/ai/productionSystem/simpleproductionsystem.h
+++ b/ai/productionSystem/simpleproductionsystem.h
@@ -162,7 +162,7 @@ private:
     bool buildUnitCloseTo(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, const spQmlVectorUnit & pUnits, bool alwaysBuild);
     bool buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, QString * failureReason = nullptr);
     static void setBuildFailure(QString * failureReason, const char * reason);
-    bool buildPriorityProduction(QmlVectorBuilding* pBuildings, qreal minAverageIslandSize, bool & blocked);
+    bool buildPriorityProduction(QmlVectorBuilding* pBuildings, bool & blocked);
     void getBuildDistribution(std::vector<CurrentBuildDistribution> & buildDistribution, QmlVectorUnit* pUnits,
                               qint32 minBuildMode, qint32 maxBuildMode, qint32 minBaseCost, qint32 maxBaseCost);
     void updateActiveProductionSystem(QmlVectorBuilding* pBuildings);

--- a/ai/productionSystem/simpleproductionsystem.h
+++ b/ai/productionSystem/simpleproductionsystem.h
@@ -40,6 +40,19 @@ public:
         bool blocking{true};
         QStringList unitIds;
     };
+    // ordered by how retryable the failure is, so keeping the best reason is a plain comparison
+    enum class BuildFailure
+    {
+        NoFactory,
+        Danger,
+        InvalidPosition,
+        NotAFactory,
+        NotAllowed,
+        NotInBuildList,
+        Disabled,
+        FactoryBlocked,
+        NoFunds,
+    };
     struct BuildDistribution
     {
         QStringList unitIds;
@@ -157,11 +170,12 @@ private:
     bool isBaseProductionAction(const QString & actionId) const;
     spUnit getCounterpointUnit(const QString & unitId);
     spProductionActionData queryProductionAction(Building* pBuilding, const QString & actionId) const;
-    bool executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild, QString * failureReason = nullptr);
-    bool buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild, QString * failureReason = nullptr);
+    bool executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild, BuildFailure * failureReason = nullptr);
+    bool buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild, BuildFailure * failureReason = nullptr);
     bool buildUnitCloseTo(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, const spQmlVectorUnit & pUnits, bool alwaysBuild);
-    bool buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, QString * failureReason = nullptr);
-    static void setBuildFailure(QString * failureReason, const char * reason);
+    bool buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, BuildFailure * failureReason = nullptr);
+    static void setBuildFailure(BuildFailure * failureReason, BuildFailure reason);
+    static const char* buildFailureName(BuildFailure reason);
     bool buildPriorityProduction(QmlVectorBuilding* pBuildings, bool & blocked);
     void getBuildDistribution(std::vector<CurrentBuildDistribution> & buildDistribution, QmlVectorUnit* pUnits,
                               qint32 minBuildMode, qint32 maxBuildMode, qint32 minBaseCost, qint32 maxBaseCost);

--- a/ai/productionSystem/simpleproductionsystem.h
+++ b/ai/productionSystem/simpleproductionsystem.h
@@ -33,6 +33,13 @@ public:
         QStringList unitIds;
         spQmlVectorUnit targets;
     };
+    struct PriorityProduction
+    {
+        qint32 x{-1};
+        qint32 y{-1};
+        bool blocking{true};
+        QStringList unitIds;
+    };
     struct BuildDistribution
     {
         QStringList unitIds;
@@ -74,7 +81,7 @@ public:
      */
     virtual qint32 getVersion() const override
     {
-        return 1;
+        return 2;
     }
     void initialize();
     bool buildUnit(QmlVectorBuilding* pBuildings, QmlVectorUnit* pUnits, QmlVectorUnit * pEnemyUnits, QmlVectorBuilding * pEnemyBuildings, bool & executed);
@@ -95,11 +102,27 @@ public:
     Q_INVOKABLE void resetBuildDistribution();
     Q_INVOKABLE void resetForcedProduction();
     Q_INVOKABLE void resetInitialProduction();
+    Q_INVOKABLE void resetPriorityProduction();
     Q_INVOKABLE bool buildNextUnit(QmlVectorBuilding* pBuildings, QmlVectorUnit* pUnits, qint32 minBuildMode, qint32 maxBuildMode,
                                    qreal minAverageIslandSize = 0.025, qint32 minBaseCost = 0, qint32 maxBaseCost = -1, bool alwaysBuild = false);
     Q_INVOKABLE void addInitialProduction(const QStringList & unitIds, qint32 count);
     Q_INVOKABLE void addForcedProduction(const QStringList & unitId, qint32 x = -1, qint32 y = -1);
     Q_INVOKABLE void addForcedProductionCloseToTargets(const QStringList & unitIds, QmlVectorUnit* targets);
+    /**
+     * @brief addPriorityProduction tried before any other production, skips the danger check but
+     * never the funds or occupancy checks. A blocking entry that fails stops all other production
+     * so funds bank up. An explicit (x, y) is never relocated; x = -1 allows any factory. Entries
+     * persist through save/load, duplicates are ignored, and an entry is kept only while it fails
+     * with NO_FUNDS or FACTORY_BLOCKED; any other failure drops it with a console warning so a
+     * blocking entry cannot starve the ai forever.
+     */
+    Q_INVOKABLE void addPriorityProduction(const QStringList & unitIds, qint32 x = -1, qint32 y = -1, bool blocking = true);
+    Q_INVOKABLE qint32 getPriorityProductionCount() const;
+    /**
+     * @brief getLastPriorityBuildResult "RESULT|unitId|x,y" of the last priority attempt, e.g.
+     * BUILT, NO_FUNDS, FACTORY_BLOCKED, NOT_IN_BUILD_LIST, INVALID_POSITION, NOT_A_FACTORY, DISABLED, NOT_ALLOWED, NO_FACTORY
+     */
+    Q_INVOKABLE QString getLastPriorityBuildResult() const;
     Q_INVOKABLE void addItemToBuildDistribution(const QString & group, const QStringList & unitIds, const QVector<qint32> & chance, qreal distribution, qint32 buildMode, const QString & guardCondition = "", qreal maxUnitDistribution = 1.0);
     /**
      * @brief getDummyUnit creates a dummy unit to calculate values not only one dummy unit will be alive at all time.
@@ -134,10 +157,12 @@ private:
     bool isBaseProductionAction(const QString & actionId) const;
     spUnit getCounterpointUnit(const QString & unitId);
     spProductionActionData queryProductionAction(Building* pBuilding, const QString & actionId) const;
-    bool executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild);
-    bool buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild);
+    bool executeBuildAction(Building* pBuilding, const QString & unitId, qint32 ordinal, qint32 expectedCost, bool alwaysBuild, QString * failureReason = nullptr);
+    bool buildUnit(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, bool alwaysBuild, QString * failureReason = nullptr);
     bool buildUnitCloseTo(QmlVectorBuilding* pBuildings, QString unitId, qreal minAverageIslandSize, const spQmlVectorUnit & pUnits, bool alwaysBuild);
-    bool buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild);
+    bool buildUnit(qint32 x, qint32 y, QString unitId, bool alwaysBuild, QString * failureReason = nullptr);
+    static void setBuildFailure(QString * failureReason, const char * reason);
+    bool buildPriorityProduction(QmlVectorBuilding* pBuildings, qreal minAverageIslandSize, bool & blocked);
     void getBuildDistribution(std::vector<CurrentBuildDistribution> & buildDistribution, QmlVectorUnit* pUnits,
                               qint32 minBuildMode, qint32 maxBuildMode, qint32 minBaseCost, qint32 maxBaseCost);
     void updateActiveProductionSystem(QmlVectorBuilding* pBuildings);
@@ -150,6 +175,8 @@ private:
     qint32 m_maxSingleDamage{70};
     std::vector<InitialProduction> m_initialProduction;
     std::vector<ForcedProduction> m_forcedProduction;
+    std::vector<PriorityProduction> m_priorityProduction;
+    QString m_lastPriorityBuildResult;
     std::map<QString, BuildDistribution> m_buildDistribution;
     std::map<QString, BuildDistribution> m_activeBuildDistribution;
     std::map<Building*, AverageBuildData> m_averageMoverange;

--- a/ai/veryeasyai.cpp
+++ b/ai/veryeasyai.cpp
@@ -66,7 +66,8 @@ void VeryEasyAI::process()
     AI_CONSOLE_PRINT("VeryEasyAI::process()", GameConsole::eDEBUG);
     spQmlVectorBuilding pBuildings = m_pPlayer->getSpBuildings();
     spQmlVectorUnit pUnits = m_pPlayer->getSpUnits();
-    pUnits->randomize();
+    // falls back to randomize when no unit carries an ai priority
+    pUnits->sortAiPriority();
     spQmlVectorUnit pEnemyUnits = m_pPlayer->getSpEnemyUnits();
     spQmlVectorBuilding pEnemyBuildings = m_pPlayer->getSpEnemyBuildings();
     prepareEnemieData(pUnits, pBuildings, pEnemyUnits, pEnemyBuildings);

--- a/coreengine/qmlvector.cpp
+++ b/coreengine/qmlvector.cpp
@@ -52,24 +52,25 @@ void QmlVectorUnit::sortAiPriority()
             break;
         }
     }
+    randomize();
     if (!hasPriority)
     {
-        randomize();
         return;
     }
-    for (auto & unit : m_Vector)
+    // prioritized units are fully deterministic, the zero-priority rest keeps the shuffled order
+    std::stable_sort(m_Vector.begin(), m_Vector.end(), [](const spUnit& lhs, const spUnit& rhs)
     {
-        unit->setSortValues({unit->getAiPriority(), unit->getUniqueID()});
-    }
-    std::sort(m_Vector.begin(), m_Vector.end(), [](const spUnit& lhs, const spUnit& rhs)
-    {
-        auto & lhsVec = lhs->getSortValues();
-        auto & rhsVec = rhs->getSortValues();
-        if (lhsVec[0] == rhsVec[0])
+        qint32 lhsPriority = lhs->getAiPriority();
+        qint32 rhsPriority = rhs->getAiPriority();
+        if (lhsPriority != rhsPriority)
         {
-            return lhsVec[1] < rhsVec[1];
+            return lhsPriority > rhsPriority;
         }
-        return lhsVec[0] > rhsVec[0];
+        if (lhsPriority != 0)
+        {
+            return lhs->getUniqueID() < rhs->getUniqueID();
+        }
+        return false;
     });
 }
 

--- a/coreengine/qmlvector.cpp
+++ b/coreengine/qmlvector.cpp
@@ -40,6 +40,24 @@ void QmlVectorUnit::randomize()
     });
 }
 
+void QmlVectorUnit::sortAiPriority()
+{
+    for (auto & unit : m_Vector)
+    {
+        unit->setSortValues({unit->getAiPriority(), unit->getUniqueID()});
+    }
+    std::sort(m_Vector.begin(), m_Vector.end(), [](const spUnit& lhs, const spUnit& rhs)
+    {
+        auto & lhsVec = lhs->getSortValues();
+        auto & rhsVec = rhs->getSortValues();
+        if (lhsVec[0] == rhsVec[0])
+        {
+            return lhsVec[1] < rhsVec[1];
+        }
+        return lhsVec[0] > rhsVec[0];
+    });
+}
+
 void QmlVectorUnit::sortExpensive()
 {
     for (auto & unit : m_Vector)

--- a/coreengine/qmlvector.cpp
+++ b/coreengine/qmlvector.cpp
@@ -42,6 +42,21 @@ void QmlVectorUnit::randomize()
 
 void QmlVectorUnit::sortAiPriority()
 {
+    // maps that never set a priority keep the legacy randomized order
+    bool hasPriority = false;
+    for (auto & unit : m_Vector)
+    {
+        if (unit->getAiPriority() != 0)
+        {
+            hasPriority = true;
+            break;
+        }
+    }
+    if (!hasPriority)
+    {
+        randomize();
+        return;
+    }
     for (auto & unit : m_Vector)
     {
         unit->setSortValues({unit->getAiPriority(), unit->getUniqueID()});

--- a/coreengine/qmlvector.h
+++ b/coreengine/qmlvector.h
@@ -94,6 +94,10 @@ public:
     }
     Q_INVOKABLE void randomize();
     /**
+     * @brief sortAiPriority deterministic order: higher ai priority first, ties by lowest unique id
+     */
+    Q_INVOKABLE void sortAiPriority();
+    /**
      * @brief sortExpensive most expensive units are sorted in first
      */
     Q_INVOKABLE void sortExpensive();

--- a/coreengine/qmlvector.h
+++ b/coreengine/qmlvector.h
@@ -94,8 +94,8 @@ public:
     }
     Q_INVOKABLE void randomize();
     /**
-     * @brief sortAiPriority higher ai priority first, ties by lowest unique id. Falls back to
-     * randomize when no unit has a priority, so unscripted maps keep the legacy behavior.
+     * @brief sortAiPriority higher ai priority first, ties by lowest unique id. Units without a
+     * priority keep a randomized order behind them, so unscripted behavior stays unpredictable.
      */
     Q_INVOKABLE void sortAiPriority();
     /**

--- a/coreengine/qmlvector.h
+++ b/coreengine/qmlvector.h
@@ -94,7 +94,8 @@ public:
     }
     Q_INVOKABLE void randomize();
     /**
-     * @brief sortAiPriority deterministic order: higher ai priority first, ties by lowest unique id
+     * @brief sortAiPriority higher ai priority first, ties by lowest unique id. Falls back to
+     * randomize when no unit has a priority, so unscripted maps keep the legacy behavior.
      */
     Q_INVOKABLE void sortAiPriority();
     /**

--- a/game/unit.cpp
+++ b/game/unit.cpp
@@ -3787,6 +3787,7 @@ void Unit::serializeObject(QDataStream& pStream, bool forHash) const
         {
             pStream << m_aiCache[i];
         }
+        pStream << m_aiPriority;
     }
 }
 
@@ -4166,6 +4167,10 @@ void Unit::deserializer(QDataStream& pStream, bool fast)
             m_aiCache.push_back(info);
         }
 
+    }
+    if (version > 24)
+    {
+        pStream >> m_aiPriority;
     }
     m_unitIdx = UnitSpriteManager::getInstance()->getIndex(m_UnitID);
 }

--- a/game/unit.h
+++ b/game/unit.h
@@ -91,7 +91,7 @@ public:
      */
     inline virtual qint32 getVersion() const override
     {
-        return 24;
+        return 25;
     }
 
 
@@ -393,6 +393,23 @@ public:
      * @param AiMode
      */
     Q_INVOKABLE void setAiMode(const GameEnums::GameAi AiMode);
+    /**
+     * @brief getAiPriority
+     * @return
+     */
+    Q_INVOKABLE qint32 getAiPriority() const
+    {
+        return m_aiPriority;
+    }
+    /**
+     * @brief setAiPriority higher priorities are moved first by the ai. Zero is the default and
+     * keeps the randomized or heuristic order, so only prioritized units become deterministic.
+     * @param aiPriority
+     */
+    Q_INVOKABLE void setAiPriority(qint32 aiPriority)
+    {
+        m_aiPriority = aiPriority;
+    }
     /**
      * @brief getTransportHidden
      * @param pPlayer
@@ -1236,6 +1253,7 @@ private:
     qint32 m_vision{1};
     qint32 m_UniqueID{0};
     GameEnums::GameAi m_AiMode{GameEnums::GameAi::GameAi_Normal};
+    qint32 m_aiPriority{0};
     QVector<QPoint> m_AiMovePath;
     ScriptVariables m_Variables;
     ModdingFlags m_ModdingFlags{ModdingFlags::None};


### PR DESCRIPTION
Adds two APIs I needed while AI-scripting campaign missions, following up on our Discord discussion about deterministic ordering.

Unit move order. New unit.setAiPriority(int), serialized, excluded from the desync hash like aiMode. 
Units with a nonzero priority move first (descending, ties by lowest unique id), everything at 0 keeps a fresh randomized order behind them, so an all-zero map is exactly the current shuffle and the AI stays unpredictable for normal play.

Priority production. system.addPriorityProduction(unitIds, x, y, blocking) is tried before initial production, forced production, and the build distribution. 

Serializer bumps: Unit 24 to 25, SimpleProductionSystem 1 to 2. Old saves load fine, forced production is also serialized now