### PR TITLE
Resolve campaign and map script paths relative to their own files

### DIFF
--- a/game/campaign.cpp
+++ b/game/campaign.cpp
@@ -1,4 +1,5 @@
 #include <QFile>
+#include <QFileInfo>
 #include <QTextStream>
 #include <QDir>
 #include <QDirIterator>
@@ -70,9 +71,14 @@ Campaign::CampaignMapInfo Campaign::getCampaignMaps()
     {
         folder = files[0];
         files.removeAt(0);
+        QString scriptDir = getScriptDir();
         for (qint32 i = 0; i < files.size(); ++i)
         {
             QString path = VirtualPaths::find(folder + files[i]);
+            if (!QFileInfo(path).isFile() && !scriptDir.isEmpty())
+            {
+                path = findMapNextToScript(scriptDir, folder, files[i]);
+            }
             if (QFile::exists(path))
             {
                 files[i] = path;
@@ -81,12 +87,44 @@ Campaign::CampaignMapInfo Campaign::getCampaignMaps()
         }
 
         QStringList searchPath = VirtualPaths::createSearchPath(folder, false);
+        if (!scriptDir.isEmpty())
+        {
+            searchPath.append(scriptDir);
+        }
         for (qint32 i = 0; i < searchPath.size(); i++)
         {
             addDeveloperMaps(searchPath[i], files);
         }
     }
     return CampaignMapInfo(folder, files);
+}
+
+QString Campaign::getScriptDir() const
+{
+    if (m_scriptFile.isEmpty())
+    {
+        return QString();
+    }
+    QString scriptDir = QFileInfo(m_scriptFile).path();
+    if (scriptDir == "." || scriptDir.isEmpty())
+    {
+        return QString();
+    }
+    return scriptDir + "/";
+}
+
+QString Campaign::findMapNextToScript(const QString & scriptDir, const QString & folder, const QString & file) const
+{
+    QString candidate = scriptDir + folder + file;
+    if (!QFileInfo(candidate).isFile())
+    {
+        candidate = scriptDir + file;
+    }
+    if (!QFileInfo(candidate).isFile())
+    {
+        return QString();
+    }
+    return candidate;
 }
 
 void Campaign::addDeveloperMaps(const QString & prefix, QStringList & files)

--- a/game/campaign.h
+++ b/game/campaign.h
@@ -132,6 +132,20 @@ public:
     Q_INVOKABLE void onCampaignMapSelected(GameMap* pMap, const QString & filePath);
 
 private:
+    /**
+     * @brief getScriptDir the directory containing the campaign script or an empty string if unknown
+     * @return
+     */
+    QString getScriptDir() const;
+    /**
+     * @brief findMapNextToScript locates a campaign map relative to the campaign script when the declared folder is stale
+     * @param scriptDir
+     * @param folder
+     * @param file
+     * @return
+     */
+    QString findMapNextToScript(const QString & scriptDir, const QString & folder, const QString & file) const;
+
     QString m_script;
     QString m_scriptFile;
     ScriptVariables m_Variables;

--- a/game/gamescript.cpp
+++ b/game/gamescript.cpp
@@ -1,4 +1,5 @@
 #include <QFile>
+#include <QFileInfo>
 #include <QTextStream>
 
 #include "game/gamescript.h"
@@ -57,12 +58,38 @@ void GameScript::deserializeObject(QDataStream& pStream)
     }
 }
 
+QString GameScript::findScriptNextToMap() const
+{
+    QString mapPath = (m_pMap != nullptr) ? m_pMap->getMapPath() : QString();
+    if (mapPath.isEmpty() || m_scriptFile.isEmpty())
+    {
+        return QString();
+    }
+    QString candidate = QFileInfo(mapPath).path() + "/" + QFileInfo(m_scriptFile).fileName();
+    QString found = candidate;
+    if (!QFileInfo(found).isFile())
+    {
+        found = VirtualPaths::find(candidate);
+    }
+    if (!QFileInfo(found).isFile())
+    {
+        return QString();
+    }
+    CONSOLE_PRINT("Map script " + m_scriptFile + " not found. Using " + found + " instead.", GameConsole::eDEBUG);
+    return found;
+}
+
 void GameScript::init()
 {
     Interpreter* pInterpreter = Interpreter::getInstance();
     if (!m_scriptFile.isEmpty())
     {
-        QFile file = QFile(VirtualPaths::find(m_scriptFile));
+        QString scriptPath = VirtualPaths::find(m_scriptFile);
+        if (!QFileInfo(scriptPath).isFile())
+        {
+            scriptPath = findScriptNextToMap();
+        }
+        QFile file = QFile(scriptPath);
         if (file.exists())
         {
             CONSOLE_PRINT("Loading map script " + file.fileName(), GameConsole::eDEBUG);
@@ -75,7 +102,7 @@ void GameScript::init()
         }
         else
         {
-            CONSOLE_PRINT("Unable to load map script " + file.fileName(), GameConsole::eWARNING);
+            CONSOLE_PRINT("Unable to load map script " + m_scriptFile, GameConsole::eWARNING);
             m_scriptFile = "";
             m_script = "";
             m_loaded = false;

--- a/game/gamescript.h
+++ b/game/gamescript.h
@@ -99,6 +99,12 @@ public:
     Q_INVOKABLE void setScriptFile(const QString & value);
 
 private:
+    /**
+     * @brief findScriptNextToMap locates the script in the map's own folder when the stored path is stale
+     * @return
+     */
+    QString findScriptNextToMap() const;
+
     bool m_victoryCalled{false};
     QString m_script;
     QString m_scriptFile;


### PR DESCRIPTION
Map files store their script path and campaign scripts their maps folder relative to the install root, so moving a campaign into a subdirectory required editing the campaign script and re-saving every map in the editor. Fall back to looking next to the containing file when the stored path no longer resolves. Existing paths that resolve keep the exact previous behavior.