### PR TITLE
Fixed the unknown CO group adding the entire CO list once per unknown CO instead of just that CO

### DIFF
--- a/resource_management/cospritemanager.cpp
+++ b/resource_management/cospritemanager.cpp
@@ -293,7 +293,7 @@ QVector<COSpriteManager::CoGroup> COSpriteManager::getCoGroups(QStringList & coi
             coID != CO::CO_RANDOM)
         {
             coids.append(coID);
-            unknownGroup.cos.append(coids);
+            unknownGroup.cos.append(coID);
         }
     }
     if (unknownGroup.cos.length() > 0)


### PR DESCRIPTION
When a CO was added to the unknown group, it added the entire unknown list per CO in the list