### PR TITLE
Start the ai pipe game even when a seed already exists

### DIFF
--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -184,8 +184,9 @@ void GameMenue::loadingAiPipe()
         CONSOLE_PRINT("Creating seed " + QString::number(seed) + " and starting the ai pipe", GameConsole::eDEBUG);
         GlobalUtils::seed(seed);
         GlobalUtils::setUseSeed(true);
-        startAiPipeGame();
     }
+    // network games already have a seed, the ai pipe still needs to start
+    startAiPipeGame();
 }
 
 GameMenue::GameMenue(spGameMap pMap, bool clearPlayerlist)


### PR DESCRIPTION
Network multiplayer assigns a seed before GameMenue::startGame runs, so getUseSeed() was already true and startAiPipeGame() was skipped. The ai slave process then hung forever after sending PIPEREADY.