### PR TITLE
Fix deferred actor lifetime crashes from the beta 39 update queues

### DIFF
--- a/3rd_party/oxygine-framework/oxygine/EventDispatcher.cpp
+++ b/3rd_party/oxygine-framework/oxygine/EventDispatcher.cpp
@@ -101,7 +101,7 @@ namespace oxygine
         if (requiresThreadChange())
         {
             EventUpdateInfo info;
-            info.action = EventUpdateAction::RemoveEventListenerThis;
+            info.action = EventUpdateAction::RemoveEventListenerId;
             info.dispatcher = getSharedPtr<EventDispatcher>();
             info.id = id;
             QMutexLocker lock(&m_eventUpdateActionMutex);
@@ -127,7 +127,7 @@ namespace oxygine
         if (requiresThreadChange())
         {
             EventUpdateInfo info;
-            info.action = EventUpdateAction::RemoveEventListenerId;
+            info.action = EventUpdateAction::RemoveEventListenerThis;
             info.dispatcher = getSharedPtr<EventDispatcher>();
             info.callbackThis = callbackThis;
             QMutexLocker lock(&m_eventUpdateActionMutex);
@@ -188,9 +188,15 @@ namespace oxygine
 
     bool EventDispatcher::requiresThreadChange() const
     {
+#ifdef GRAPHICSUPPORT
+        // Headless mode has no render pass to drain deferred updates.
         return !notInSharedUse() &&
                !GameWindow::getWindow()->isMainThread() &&
                !detached() &&
-               !GameWindow::getWindow()->renderingPaused();
+               !GameWindow::getWindow()->renderingPaused() &&
+               !GameWindow::getWindow()->getNoUi();
+#else
+        return false;
+#endif
     }
 }

--- a/3rd_party/oxygine-framework/oxygine/EventDispatcher.cpp
+++ b/3rd_party/oxygine-framework/oxygine/EventDispatcher.cpp
@@ -45,7 +45,7 @@ namespace oxygine
         const Actor* pActor = dynamic_cast<const Actor*>(this);
         if (pActor != nullptr)
         {
-            return pActor->__getStage() == nullptr;
+            return pActor->isDetachedForThreading();
         }
         else
         {

--- a/3rd_party/oxygine-framework/oxygine/EventDispatcher.h
+++ b/3rd_party/oxygine-framework/oxygine/EventDispatcher.h
@@ -38,10 +38,10 @@ namespace oxygine
         {
             EventUpdateAction action;
             oxygine::spEventDispatcher dispatcher;
-            oxygine::eventType et;
+            oxygine::eventType et{0};
             oxygine::EventCallback cb;
-            qint32 id;
-            oxygine::IClosureOwner* callbackThis;
+            qint32 id{-1};
+            oxygine::IClosureOwner* callbackThis{nullptr};
         };
         static void doUpdateInfos();
 

--- a/3rd_party/oxygine-framework/oxygine/actor/Actor.cpp
+++ b/3rd_party/oxygine-framework/oxygine/actor/Actor.cpp
@@ -16,88 +16,154 @@ namespace oxygine
     std::vector<Actor::UpdateInfo> Actor::m_updateActions;
     QMutex Actor::m_updateActionMutex;
 
+    QRecursiveMutex& Actor::treeMutex()
+    {
+        static QRecursiveMutex* mutex = new QRecursiveMutex();
+        return *mutex;
+    }
+
+    void Actor::finishPendingTreeChanges(UpdateInfo& info)
+    {
+        for (auto & actor : info.pendingTreeChanges)
+        {
+            actor->finishPendingTreeChange();
+        }
+        info.pendingTreeChanges.clear();
+    }
+
+    void Actor::queueUpdate(UpdateInfo&& info, std::initializer_list<spActor> guardedActors)
+    {
+        try
+        {
+            for (const auto & actor : guardedActors)
+            {
+                if (actor.get() == nullptr)
+                {
+                    continue;
+                }
+                bool found = false;
+                for (const auto & guarded : info.pendingTreeChanges)
+                {
+                    if (guarded.get() == actor.get())
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    info.pendingTreeChanges.push_back(actor);
+                    actor->beginPendingTreeChange();
+                }
+            }
+            QMutexLocker locker(&m_updateActionMutex);
+            m_updateActions.push_back(std::move(info));
+        }
+        catch (...)
+        {
+            finishPendingTreeChanges(info);
+            throw;
+        }
+    }
+
     void Actor::doUpdateInfos()
     {
-        QMutexLocker locker(&m_updateActionMutex);
-        for (auto & item : m_updateActions)
+        QMutexLocker treeLocker(&treeMutex());
+        std::vector<UpdateInfo> updateActions;
         {
-            switch (item.action)
+            QMutexLocker updateLocker(&m_updateActionMutex);
+            updateActions.swap(m_updateActions);
+        }
+        try
+        {
+            for (auto & item : updateActions)
             {
-                case UpdateAction::RestartAllTweens:
+                switch (item.action)
                 {
-                    item.parent->restartAllTweens();
-                    break;
+                    case UpdateAction::RestartAllTweens:
+                    {
+                        item.parent->restartAllTweens();
+                        break;
+                    }
+                    case UpdateAction::SyncTweens:
+                    {
+                        item.parent->syncAllTweens(item.syncTime);
+                        break;
+                    }
+                    case UpdateAction::AddChild:
+                    {
+                        item.parent->addChild(item.actor);
+                        break;
+                    }
+                    case UpdateAction::RemoveChild:
+                    {
+                        item.parent->removeChild(item.actor);
+                        break;
+                    }
+                    case UpdateAction::Priority:
+                    {
+                        item.parent->setPriority(item.zOrder);
+                        break;
+                    }
+                    case UpdateAction::AddTween:
+                    {
+                        item.parent->addTween(item.tween);
+                        break;
+                    }
+                    case UpdateAction::RemoveTween:
+                    {
+                        item.parent->removeTween(item.tween);
+                        break;
+                    }
+                    case UpdateAction::RemoveChildren:
+                    {
+                        item.parent->removeChildren();
+                        break;
+                    }
+                    case UpdateAction::RemoveTweens:
+                    {
+                        item.parent->removeTweens();
+                        break;
+                    }
+                    case UpdateAction::RebuildText:
+                    {
+                        oxygine::safeSpCast<oxygine::TextField>(item.parent)->rebuildText();
+                        break;
+                    }
+                    case UpdateAction::SetAddColor:
+                    {
+                        oxygine::safeSpCast<oxygine::VStyleActor>(item.parent)->setAddColor(item.color);
+                        break;
+                    }
+                    case UpdateAction::ChangeAnimFrame:
+                    {
+                        oxygine::safeSpCast<oxygine::Sprite>(item.parent)->changeAnimFrame(item.frame);
+                        break;
+                    }
+                    case UpdateAction::SetColorTable:
+                    {
+                        oxygine::safeSpCast<oxygine::Sprite>(item.parent)->setColorTable(item.pAnim, item.matrix);
+                        break;
+                    }
+                    case UpdateAction::DetachAndRemove:
+                    {
+                        item.parent->detach();
+                        break;
+                    }
+                    default:
+                        Q_ASSERT(false);
                 }
-                case UpdateAction::SyncTweens:
-                {
-                    item.parent->syncAllTweens(item.syncTime);
-                    break;
-                }
-                case UpdateAction::AddChild:
-                {
-                    item.parent->addChild(item.actor);
-                    break;
-                }
-                case UpdateAction::RemoveChild:
-                {
-                    item.parent->removeChild(item.actor);
-                    break;
-                }
-                case UpdateAction::Priority:
-                {
-                    item.parent->setPriority(item.zOrder);
-                    break;
-                }
-                case UpdateAction::AddTween:
-                {
-                    item.parent->addTween(item.tween);
-                    break;
-                }
-                case UpdateAction::RemoveTween:
-                {
-                    item.parent->removeTween(item.tween);
-                    break;
-                }
-                case UpdateAction::RemoveChildren:
-                {
-                    item.parent->removeChildren();
-                    break;
-                }
-                case UpdateAction::RemoveTweens:
-                {
-                    item.parent->removeTweens();
-                    break;
-                }
-                case UpdateAction::RebuildText:
-                {
-                    oxygine::safeSpCast<oxygine::TextField>(item.parent)->rebuildText();
-                    break;
-                }
-                case UpdateAction::SetAddColor:
-                {
-                    oxygine::safeSpCast<oxygine::VStyleActor>(item.parent)->setAddColor(item.color);
-                    break;
-                }
-                case UpdateAction::ChangeAnimFrame:
-                {
-                    oxygine::safeSpCast<oxygine::Sprite>(item.parent)->changeAnimFrame(item.frame);
-                    break;
-                }
-                case UpdateAction::SetColorTable:
-                {
-                    oxygine::safeSpCast<oxygine::Sprite>(item.parent)->setColorTable(item.pAnim, item.matrix);
-                    break;
-                }
-                case UpdateAction::DetachAndRemove:
-                {
-                    item.parent->detach();
-                    break;
-                }
-                default:
-                    Q_ASSERT(false);
+                finishPendingTreeChanges(item);
             }
         }
-        m_updateActions.clear();
+        catch (...)
+        {
+            for (auto & item : updateActions)
+            {
+                finishPendingTreeChanges(item);
+            }
+            throw;
+        }
     }
 
 #ifndef GRAPHICSUPPORT
@@ -115,6 +181,7 @@ namespace oxygine
 
     Actor::~Actor()
     {
+        QMutexLocker locker(&treeMutex());
         removeTweens();
         removeChildren();
     }
@@ -124,8 +191,46 @@ namespace oxygine
         return m_stage;
     }
 
+    bool Actor::isPendingTreeChangeUnlocked() const
+    {
+        const Actor* actor = this;
+        while (actor != nullptr)
+        {
+            if (actor->m_pendingTreeChangeCount.load(std::memory_order_acquire) != 0)
+            {
+                return true;
+            }
+            actor = actor->getParent();
+        }
+        return false;
+    }
+
+    bool Actor::isPendingTreeChange() const
+    {
+        QMutexLocker locker(&treeMutex());
+        return isPendingTreeChangeUnlocked();
+    }
+
+    bool Actor::isDetachedForThreading() const
+    {
+        QMutexLocker locker(&treeMutex());
+        return !isPendingTreeChangeUnlocked() && m_stage == nullptr;
+    }
+
+    void Actor::beginPendingTreeChange()
+    {
+        m_pendingTreeChangeCount.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    void Actor::finishPendingTreeChange()
+    {
+        const quint32 previous = m_pendingTreeChangeCount.fetch_sub(1, std::memory_order_acq_rel);
+        Q_ASSERT(previous != 0);
+    }
+
     void Actor::added2stage(Stage* stage)
     {
+        QMutexLocker locker(&treeMutex());
         Q_ASSERT(!requiresThreadChange());
         if (m_stage == nullptr)
         {
@@ -142,6 +247,7 @@ namespace oxygine
 
     void Actor::removedFromStage()
     {
+        QMutexLocker locker(&treeMutex());
         Q_ASSERT(!requiresThreadChange());
         if (m_stage != nullptr)
         {
@@ -455,6 +561,7 @@ namespace oxygine
     void Actor::setPriority(qint32 zorder)
     {
 #ifdef GRAPHICSUPPORT
+        QMutexLocker treeLocker(&treeMutex());
         if (m_zOrder == zorder)
         {
             return;
@@ -467,8 +574,9 @@ namespace oxygine
                 info.parent = getSharedPtr<Actor>();
                 info.zOrder = zorder;
                 info.action = Actor::UpdateAction::Priority;
-                QMutexLocker lock(&m_updateActionMutex);
-                m_updateActions.push_back(std::move(info));
+                spActor actorGuard = info.parent;
+                spActor parentGuard = m_parent->getSharedPtr<Actor>();
+                queueUpdate(std::move(info), {actorGuard, parentGuard});
             }
             else
             {
@@ -758,6 +866,7 @@ namespace oxygine
 
     bool Actor::isDescendant(const Actor* actor) const
     {
+        QMutexLocker locker(&treeMutex());
         const Actor* act = actor;
         while (act)
         {
@@ -772,6 +881,7 @@ namespace oxygine
 
     void Actor::setParent(Actor* actor, Actor* parent)
     {
+        QMutexLocker locker(&treeMutex());
         if (actor != nullptr)
         {
             actor->m_parent = parent;
@@ -792,6 +902,7 @@ namespace oxygine
 
     void Actor::insertActor(spActor & actor)
     {
+        QMutexLocker locker(&treeMutex());
         if (!actor.get())
         {
             oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::insertActor trying to add empty actor");
@@ -817,16 +928,8 @@ namespace oxygine
 
     void Actor::addChild(spActor actor)
     {
-        if (requiresThreadChange())
-        {
-            UpdateInfo info;
-            info.parent = getSharedPtr<Actor>();
-            info.action = Actor::UpdateAction::AddChild;
-            info.actor = actor;
-            QMutexLocker lock(&m_updateActionMutex);
-            m_updateActions.push_back(std::move(info));
-        }
-        else if (actor.get() == nullptr)
+        QMutexLocker treeLocker(&treeMutex());
+        if (actor.get() == nullptr)
         {
             oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::addChild trying to add empty actor");
             return;
@@ -834,6 +937,22 @@ namespace oxygine
         else if (actor.get() == this)
         {
             oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::addChild trying to add self");
+            return;
+        }
+        else if (requiresThreadChange() || actor->requiresThreadChange())
+        {
+            UpdateInfo info;
+            info.parent = getSharedPtr<Actor>();
+            info.action = Actor::UpdateAction::AddChild;
+            info.actor = actor;
+            spActor parentGuard = info.parent;
+            spActor actorGuard = info.actor;
+            spActor sourceGuard;
+            if (actor->m_parent != nullptr)
+            {
+                sourceGuard = actor->m_parent->getSharedPtr<Actor>();
+            }
+            queueUpdate(std::move(info), {parentGuard, actorGuard, sourceGuard});
         }
         else
         {
@@ -845,59 +964,64 @@ namespace oxygine
 
     void Actor::removeChild(spActor actor)
     {
-        if (actor->m_parent == nullptr)
+        QMutexLocker treeLocker(&treeMutex());
+        if (actor.get() == nullptr)
         {
-            oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::removeChild trying to remove a child without a parent");
+            oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::removeChild trying to remove empty actor");
             return;
         }
-        else if (requiresThreadChange())
+        if (requiresThreadChange() || actor->requiresThreadChange())
         {
             UpdateInfo info;
             info.parent = getSharedPtr<Actor>();
             info.action = Actor::UpdateAction::RemoveChild;
             info.actor = actor;
-            QMutexLocker lock(&m_updateActionMutex);
-            m_updateActions.push_back(std::move(info));
+            spActor parentGuard = info.parent;
+            spActor actorGuard = info.actor;
+            spActor sourceGuard;
+            if (actor->m_parent != nullptr)
+            {
+                sourceGuard = actor->m_parent->getSharedPtr<Actor>();
+            }
+            queueUpdate(std::move(info), {parentGuard, actorGuard, sourceGuard});
         }
-        else if (actor)
+        else if (actor->m_parent == nullptr)
         {
-            if (actor->m_parent != this)
-            {
-                oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::removeChild wrong parent while removing a child");
-            }
-            else
-            {
-#ifdef GRAPHICSUPPORT
-                Q_ASSERT(!m_internalUpdateRunning);
-#endif
-                setParent(actor.get(), nullptr);
-                auto iter = m_children.cbegin();
-                while (iter != m_children.cend())
-                {
-                    if (iter->get() == actor.get())
-                    {
-                        m_children.erase(iter);
-                        break;
-                    }
-                    ++iter;
-                }
-            }
+            oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::removeChild trying to remove a child without a parent");
+        }
+        else if (actor->m_parent != this)
+        {
+            oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::removeChild wrong parent while removing a child");
         }
         else
         {
-            oxygine::handleErrorPolicy(oxygine::ep_show_error, "Actor::removeChild trying to remove empty actor");
+#ifdef GRAPHICSUPPORT
+            Q_ASSERT(!m_internalUpdateRunning);
+#endif
+            setParent(actor.get(), nullptr);
+            auto iter = m_children.cbegin();
+            while (iter != m_children.cend())
+            {
+                if (iter->get() == actor.get())
+                {
+                    m_children.erase(iter);
+                    break;
+                }
+                ++iter;
+            }
         }
     }
 
     void Actor::removeChildren()
     {
+        QMutexLocker treeLocker(&treeMutex());
         if (requiresThreadChange())
         {
             UpdateInfo info;
             info.parent = getSharedPtr<Actor>();
             info.action = Actor::UpdateAction::RemoveChildren;
-            QMutexLocker lock(&m_updateActionMutex);
-            m_updateActions.push_back(std::move(info));
+            spActor parentGuard = info.parent;
+            queueUpdate(std::move(info), {parentGuard});
         }
         else
         {
@@ -914,16 +1038,26 @@ namespace oxygine
 
     void Actor::detach()
     {
+        QMutexLocker treeLocker(&treeMutex());
         Actor* parent = getParent();
         if (parent)
         {
             spActor pActor = getSharedPtr<Actor>();
             parent->removeChild(pActor);
         }
+        else if (requiresThreadChange())
+        {
+            UpdateInfo info;
+            info.parent = getSharedPtr<Actor>();
+            info.action = Actor::UpdateAction::DetachAndRemove;
+            spActor actorGuard = info.parent;
+            queueUpdate(std::move(info), {actorGuard});
+        }
     }
 
     void Actor::detachAndRemove()
     {
+        QMutexLocker treeLocker(&treeMutex());
         Actor* parent = getParent();
         if (parent)
         {
@@ -935,8 +1069,8 @@ namespace oxygine
             UpdateInfo info;
             info.parent = getSharedPtr<Actor>();
             info.action = Actor::UpdateAction::DetachAndRemove;
-            QMutexLocker lock(&m_updateActionMutex);
-            m_updateActions.push_back(std::move(info));
+            spActor actorGuard = info.parent;
+            queueUpdate(std::move(info), {actorGuard});
         }
 
     }

--- a/3rd_party/oxygine-framework/oxygine/actor/Actor.cpp
+++ b/3rd_party/oxygine-framework/oxygine/actor/Actor.cpp
@@ -80,7 +80,7 @@ namespace oxygine
                 }
                 case UpdateAction::ChangeAnimFrame:
                 {
-                    oxygine::safeSpCast<oxygine::Sprite>(item.parent)->changeAnimFrame(*item.frame);
+                    oxygine::safeSpCast<oxygine::Sprite>(item.parent)->changeAnimFrame(item.frame);
                     break;
                 }
                 case UpdateAction::SetColorTable:

--- a/3rd_party/oxygine-framework/oxygine/actor/Actor.h
+++ b/3rd_party/oxygine-framework/oxygine/actor/Actor.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <QTransform>
 #include <QMutex>
+#include <QRecursiveMutex>
 
 #include "3rd_party/oxygine-framework/oxygine/oxygine-forwards.h"
 #include "3rd_party/oxygine-framework/oxygine/tween/Tween.h"
@@ -9,6 +10,8 @@
 #include "3rd_party/oxygine-framework/oxygine/Clock.h"
 #include "3rd_party/oxygine-framework/oxygine/Property.h"
 #include "3rd_party/oxygine-framework/oxygine/AnimationFrame.h"
+#include <atomic>
+#include <initializer_list>
 #include <vector>
 
 namespace oxygine
@@ -113,6 +116,7 @@ namespace oxygine
             // Deferred updates can outlive the caller and resource reloads.
             oxygine::AnimationFrame frame;
             oxygine::spResAnim pAnim;
+            std::vector<oxygine::spActor> pendingTreeChanges;
             bool matrix{false};
         };
         static void doUpdateInfos();
@@ -404,6 +408,7 @@ namespace oxygine
 
         /**Returns Stage where Actor attached to. Used for multi stage (window) mode*/
         Stage* __getStage() const;
+        bool isDetachedForThreading() const;
 
         void setNotPressed(MouseButton b);
 
@@ -443,6 +448,13 @@ namespace oxygine
         void markTranformDirty();
         void updateTransform() const;
         void internalUpdate(const UpdateState& us);
+        bool isPendingTreeChange() const;
+        bool isPendingTreeChangeUnlocked() const;
+        void beginPendingTreeChange();
+        void finishPendingTreeChange();
+        static void queueUpdate(UpdateInfo&& info, std::initializer_list<spActor> guardedActors);
+        static void finishPendingTreeChanges(UpdateInfo& info);
+        static QRecursiveMutex& treeMutex();
         /**doUpdate is virtual method for overloading in inherited classes. UpdateState struct has local time of Actor (relative to Clock) and delta time.*/
         virtual void doUpdate(const UpdateState& us);
         void dispatchToParent(Event* event);
@@ -488,6 +500,7 @@ namespace oxygine
         };
         static QMutex m_updateActionMutex;
         static std::vector<UpdateInfo> m_updateActions;
+        std::atomic<quint32> m_pendingTreeChangeCount{0};
     private:
 #ifdef GRAPHICSUPPORT
         unsigned char   m_alpha{255};

--- a/3rd_party/oxygine-framework/oxygine/actor/Actor.h
+++ b/3rd_party/oxygine-framework/oxygine/actor/Actor.h
@@ -8,6 +8,7 @@
 #include "3rd_party/oxygine-framework/oxygine/TouchEvent.h"
 #include "3rd_party/oxygine-framework/oxygine/Clock.h"
 #include "3rd_party/oxygine-framework/oxygine/Property.h"
+#include "3rd_party/oxygine-framework/oxygine/AnimationFrame.h"
 #include <vector>
 
 namespace oxygine
@@ -106,12 +107,13 @@ namespace oxygine
             oxygine::spActor parent;
             oxygine::spActor actor;
             oxygine::spTween tween;
-            oxygine::timeMS syncTime;
-            qint32 zOrder;
+            oxygine::timeMS syncTime{0};
+            qint32 zOrder{0};
             QColor color;
-            const oxygine::AnimationFrame* frame;
+            // Deferred updates can outlive the caller and resource reloads.
+            oxygine::AnimationFrame frame;
             oxygine::spResAnim pAnim;
-            bool matrix;
+            bool matrix{false};
         };
         static void doUpdateInfos();
 

--- a/3rd_party/oxygine-framework/oxygine/actor/Sprite.cpp
+++ b/3rd_party/oxygine-framework/oxygine/actor/Sprite.cpp
@@ -260,7 +260,7 @@ namespace oxygine
             UpdateInfo info;
             info.parent = getSharedPtr<Actor>();
             info.action = Actor::UpdateAction::ChangeAnimFrame;
-            info.frame = &frame;
+            info.frame = frame;
             QMutexLocker lock(&m_updateActionMutex);
             m_updateActions.push_back(std::move(info));
         }

--- a/3rd_party/oxygine-framework/oxygine/core/gamewindow.h
+++ b/3rd_party/oxygine-framework/oxygine/core/gamewindow.h
@@ -21,6 +21,10 @@ public:
 
     static GameWindow* getWindow();
     bool isReady2Render();
+    bool getNoUi() const
+    {
+        return m_noUi;
+    }
     /**
          * @brief quitGame quits this game
          */

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1233,6 +1233,22 @@ qt_add_executable(${PROJECT_NAME} MANUAL_FINALIZATION
     objects/base/tabbedbox.h objects/base/tabbedbox.cpp
 )
 
+if (BUILD_TESTING AND GRAPHICSUPPORT)
+    target_sources(${PROJECT_NAME} PRIVATE
+        tests/oxygine_lifetime/oxyginelifetimetests.cpp
+        tests/oxygine_lifetime/oxyginelifetimetests.h
+    )
+    target_compile_definitions(${PROJECT_NAME} PRIVATE COW_BUILD_TESTING)
+    enable_testing()
+    add_test(
+        NAME OxygineLifetimeSelftest
+        COMMAND ${CMAKE_COMMAND} -E env
+            "COW_OXYGINE_SELFTEST=1"
+            $<TARGET_FILE:${PROJECT_NAME}> -noAudio
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()
+
 if (PRECOMPILED_HEADERS)
     target_precompile_headers(${PROJECT_NAME}
         PRIVATE

--- a/coreengine/workerthread.cpp
+++ b/coreengine/workerthread.cpp
@@ -44,6 +44,10 @@
 
 #include "ui_reader/uifactory.h"
 
+#ifdef COW_BUILD_TESTING
+#include "tests/oxygine_lifetime/oxyginelifetimetests.h"
+#endif
+
 WorkerThread::WorkerThread()
 {
 #ifdef GRAPHICSUPPORT
@@ -224,6 +228,17 @@ void WorkerThread::start()
 
 void WorkerThread::showMainwindow()
 {
+#ifdef COW_BUILD_TESTING
+    if (qEnvironmentVariableIsSet("COW_OXYGINE_SELFTEST"))
+    {
+        qint32 failures = OxygineLifetimeTests::runAll();
+        QMetaObject::invokeMethod(QCoreApplication::instance(), [failures]()
+        {
+            QCoreApplication::exit(failures == 0 ? 0 : 1);
+        }, Qt::QueuedConnection);
+        return;
+    }
+#endif
     CONSOLE_PRINT("WorkerThread::showMainwindow", GameConsole::eDEBUG);
     Interpreter* pInterpreter = Interpreter::getInstance();
     pInterpreter->threadProcessEvents();

--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -2597,6 +2597,8 @@ void Multiplayermenu::countdown()
         }
         if (m_counter == 0 && m_pNetworkInterface.get() != nullptr)
         {
+            // A retired menu can remain alive until queued actor removal drains.
+            m_GameStartTimer.stop();
             CONSOLE_PRINT("Starting game on server", GameConsole::eDEBUG);
             defeatClosedPlayers();
 

--- a/tests/oxygine_lifetime/oxyginelifetimetests.cpp
+++ b/tests/oxygine_lifetime/oxyginelifetimetests.cpp
@@ -1,0 +1,215 @@
+#include <cstdio>
+
+#include <QMetaObject>
+
+#include "tests/oxygine_lifetime/oxyginelifetimetests.h"
+#include "3rd_party/oxygine-framework/oxygine/actor/Actor.h"
+#include "3rd_party/oxygine-framework/oxygine/actor/Sprite.h"
+#include "3rd_party/oxygine-framework/oxygine/actor/Stage.h"
+#include "3rd_party/oxygine-framework/oxygine/core/gamewindow.h"
+#include "3rd_party/oxygine-framework/oxygine/Event.h"
+#include "coreengine/memorymanagement.h"
+
+namespace OxygineLifetimeTests
+{
+    static qint32 s_failures = 0;
+
+    static void check(bool ok, const char* what)
+    {
+        std::printf("[oxygine-selftest] %s %s\n", ok ? "PASS" : "FAIL", what);
+        std::fflush(stdout);
+        if (!ok)
+        {
+            ++s_failures;
+        }
+    }
+
+    static void drainOnMain()
+    {
+        QMetaObject::invokeMethod(oxygine::GameWindow::getWindow(), []()
+        {
+            oxygine::Stage::getStage()->updateStage();
+        }, Qt::BlockingQueuedConnection);
+    }
+
+    static void dispatchOnMain(oxygine::spActor & target, qint32 type)
+    {
+        QMetaObject::invokeMethod(oxygine::GameWindow::getWindow(), [target, type]()
+        {
+            oxygine::Event event(type);
+            target->dispatchEvent(&event);
+        }, Qt::BlockingQueuedConnection);
+    }
+
+    static constexpr qint32 STACK_CLOBBER_BYTES = 4096;
+    static constexpr QSize TEST_FRAME_SIZE{31, 17};
+
+    static void clobberStack()
+    {
+        volatile char buffer[STACK_CLOBBER_BYTES];
+        for (qint32 i = 0; i < STACK_CLOBBER_BYTES; ++i)
+        {
+            buffer[i] = static_cast<char>(i);
+        }
+    }
+
+    class Owner final : public oxygine::IClosureOwner
+    {
+    public:
+        qint32 m_hits{0};
+        void onEvent(oxygine::Event*)
+        {
+            ++m_hits;
+        }
+    };
+
+    static constexpr qint32 TEST_EVENT = oxygine::eventID('T', 'S', 'T', 'E');
+
+    qint32 runAll()
+    {
+        s_failures = 0;
+        auto stage = oxygine::Stage::getStage();
+
+        oxygine::spActor detached = MemoryManagement::create<oxygine::Actor>();
+        check(!detached->requiresThreadChange(), "detached actor permits direct construction");
+
+        oxygine::spActor subtreeRoot = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor subtreeBranch = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor subtreeLeaf = MemoryManagement::create<oxygine::Actor>();
+        subtreeRoot->addChild(subtreeBranch);
+        check(subtreeBranch->getParent() == subtreeRoot.get(), "detached subtree construction remains direct");
+        stage->addChild(subtreeRoot);
+        check(subtreeBranch->requiresThreadChange(), "pending subtree descendants defer updates");
+        subtreeBranch->addChild(subtreeLeaf);
+        check(subtreeLeaf->getParent() == nullptr, "pending subtree relationship is queued");
+        drainOnMain();
+        check(subtreeRoot->getParent() == stage.get(), "pending subtree root attaches after drain");
+        check(subtreeBranch->getParent() == subtreeRoot.get(), "pending subtree branch remains attached");
+        check(subtreeLeaf->getParent() == subtreeBranch.get(), "queued subtree relationship attaches after drain");
+        subtreeRoot->detach();
+        drainOnMain();
+
+        oxygine::spActor pendingReparent = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor detachedParent = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor destinationBranch = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor destinationLeaf = MemoryManagement::create<oxygine::Actor>();
+        detachedParent->addChild(destinationBranch);
+        stage->addChild(pendingReparent);
+        detachedParent->addChild(pendingReparent);
+        check(pendingReparent->requiresThreadChange(), "detached reparent preserves pending attachment");
+        check(detachedParent->requiresThreadChange(), "queued relationship protects detached destination");
+        check(destinationBranch->requiresThreadChange(), "destination descendants inherit protection");
+        destinationBranch->addChild(destinationLeaf);
+        check(pendingReparent->getParent() == nullptr, "pending child relationship remains queued");
+        check(destinationLeaf->getParent() == nullptr, "destination subtree mutation remains queued");
+        drainOnMain();
+        check(pendingReparent->getParent() == detachedParent.get(), "queued reparent order is preserved");
+        check(destinationLeaf->getParent() == destinationBranch.get(), "queued destination mutation completes");
+        check(!pendingReparent->requiresThreadChange(), "detached child is direct after queued transitions finish");
+
+        oxygine::spActor sourceParent = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor sourceChild = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor sourceSibling = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor attachedDestination = MemoryManagement::create<oxygine::Actor>();
+        sourceParent->addChild(sourceChild);
+        stage->addChild(attachedDestination);
+        drainOnMain();
+        attachedDestination->addChild(sourceChild);
+        check(sourceParent->requiresThreadChange(), "queued reparent protects detached source");
+        sourceParent->addChild(sourceSibling);
+        check(sourceSibling->getParent() == nullptr, "source subtree mutation remains queued");
+        drainOnMain();
+        check(sourceChild->getParent() == attachedDestination.get(), "queued child leaves detached source");
+        check(sourceSibling->getParent() == sourceParent.get(), "queued source mutation completes");
+
+        oxygine::spActor removalRoot = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor removalBranch = MemoryManagement::create<oxygine::Actor>();
+        oxygine::spActor removalLeaf = MemoryManagement::create<oxygine::Actor>();
+        removalRoot->addChild(removalBranch);
+        stage->addChild(removalRoot);
+        drainOnMain();
+        stage->removeChild(removalRoot);
+        check(removalBranch->requiresThreadChange(), "queued removal protects descendants");
+        removalBranch->addChild(removalLeaf);
+        check(removalLeaf->getParent() == nullptr, "removal subtree mutation remains queued");
+        drainOnMain();
+        check(removalRoot->getParent() == nullptr, "queued root removal completes");
+        check(removalLeaf->getParent() == removalBranch.get(), "post-removal subtree mutation completes");
+
+        oxygine::spActor pendingDetach = MemoryManagement::create<oxygine::Actor>();
+        stage->addChild(pendingDetach);
+        pendingDetach->detach();
+        drainOnMain();
+        check(pendingDetach->getParent() == nullptr, "plain detach cancels pending attachment");
+
+        oxygine::spActor pending = MemoryManagement::create<oxygine::Actor>();
+        stage->addChild(pending);
+        check(pending->requiresThreadChange(), "pending attach defers off-main updates");
+        drainOnMain();
+        check(pending->getParent() == stage.get(), "pending actor attaches after drain");
+        pending->detach();
+        drainOnMain();
+
+        oxygine::spActor parent = MemoryManagement::create<oxygine::Actor>();
+        stage->addChild(parent);
+        drainOnMain();
+        check(parent->getParent() == stage.get(), "addChild attaches after drain");
+
+        oxygine::spActor child = MemoryManagement::create<oxygine::Actor>();
+        parent->addChild(child);
+        drainOnMain();
+        check(child->getParent() == parent.get(), "child attached to parent");
+        child->detach();
+        child->detach();
+        drainOnMain();
+        check(child->getParent() == nullptr, "double detach leaves child detached");
+        check(parent->getParent() == stage.get(), "parent survives duplicate remove");
+
+        oxygine::spActor ghost = MemoryManagement::create<oxygine::Actor>();
+        stage->addChild(ghost);
+        ghost->detachAndRemove();
+        drainOnMain();
+        check(ghost->getParent() == nullptr, "detachAndRemove cancels pending attach");
+        std::weak_ptr<oxygine::Actor> watch = ghost;
+        ghost.reset();
+        drainOnMain();
+        check(watch.expired(), "no owner retains the removed actor");
+
+#ifdef GRAPHICSUPPORT
+        oxygine::spSprite sprite = MemoryManagement::create<oxygine::Sprite>();
+        stage->addChild(sprite);
+        drainOnMain();
+        {
+            oxygine::AnimationFrame frame;
+            frame.setSize(TEST_FRAME_SIZE);
+            sprite->changeAnimFrame(frame);
+        }
+        clobberStack();
+        drainOnMain();
+        check(sprite->getSize() == TEST_FRAME_SIZE, "queued anim frame survives caller stack frame");
+        sprite->detach();
+#endif
+
+        Owner owner;
+        oxygine::spActor target = MemoryManagement::create<oxygine::Actor>();
+        stage->addChild(target);
+        drainOnMain();
+        target->addEventListener(TEST_EVENT, oxygine::EventCallback(&owner, &Owner::onEvent));
+        drainOnMain();
+        dispatchOnMain(target, TEST_EVENT);
+        check(owner.m_hits == 1, "queued addEventListener registered");
+        target->removeEventListeners(&owner);
+        drainOnMain();
+        dispatchOnMain(target, TEST_EVENT);
+        check(owner.m_hits == 1, "queued removeEventListeners removes the owner's listeners");
+
+        target->detach();
+        parent->detach();
+        attachedDestination->detach();
+        drainOnMain();
+
+        std::printf("[oxygine-selftest] finished with %d failure(s)\n", s_failures);
+        std::fflush(stdout);
+        return s_failures;
+    }
+}

--- a/tests/oxygine_lifetime/oxyginelifetimetests.h
+++ b/tests/oxygine_lifetime/oxyginelifetimetests.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <QtGlobal>
+
+namespace OxygineLifetimeTests
+{
+    qint32 runAll();
+}


### PR DESCRIPTION
This is the crash cluster from the B1 reports I sent you. I split it into three commits so each part can be reviewed separately.
Commit 1 fixes three defects I could prove: the animation queue storing a pointer to a dead stack parameter, the two listener-removal actions queuing each other’s enum and reading uninitialized data, and headless servers never draining actor queues. The first two can cause delayed heap corruption/use-after-free crashes. The headless issue explains the old lobby objects staying alive and the negative countdown spam.
Commit 2 fixes the crash that survived those changes. I symbolized it twice to queued AddChild entering added2stage while another thread mutates the same subtree. It now tracks pending transitions across the subtree, queues removals behind pending attachments, and serializes tree mutations against the drain. That also addresses the repeated “remove child without a parent” messages.
Commit 3 is regression coverage for those cases and only exists with BUILD_TESTING=ON, so none of it ships.