### PR TITLE
Fixed the observer join crash, connectToSlave was reading the gateway setting off a map that isn't loaded yet

### DIFF
--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -856,7 +856,8 @@ void Multiplayermenu::connectToSlave(const QJsonObject & objData, quint64 socket
     quint16 port = objData.value(JsonKeys::JSONKEY_PORT).toInteger();
     spGameMap pMap = m_pMapSelectionView->getCurrentMap();
     bool isServer = m_pNetworkInterface->getIsServer();
-    bool isGateway = pMap->getGameRules()->getGatewayHosting();
+    // observers joining a running game have no map loaded yet
+    bool isGateway = pMap.get() != nullptr && pMap->getGameRules()->getGatewayHosting();
     disconnectNetworkSlots();
     m_pNetworkInterface = MemoryManagement::create<TCPClient>(nullptr);
     m_pNetworkInterface->setIsObserver(m_networkMode == NetworkMode::Observer);


### PR DESCRIPTION
This is the observer crash from our discord convo today (the 09:33 report plus the 18:19 one on my hotfix build).