### PR TITLE
skip gui crash report in headless builds and terminate with the orignal signal

### DIFF
--- a/coreengine/linux/crashreporter_os.cpp
+++ b/coreengine/linux/crashreporter_os.cpp
@@ -14,6 +14,9 @@ void crashhandler(int sig)
         frameList.append(messages[i]);
     }
     CrashReporter::_writeLog(QString("Error: signal ") + QString::number(sig) + " received", frameList);
+    // returning from a SIGSEGV handler restarts the faulting instruction, terminate with the original signal instead
+    signal(sig, SIG_DFL);
+    raise(sig);
 }
 
 void CrashReporter::setOsSignalHandler()

--- a/coreengine/mainapp.cpp
+++ b/coreengine/mainapp.cpp
@@ -773,6 +773,16 @@ void Mainapp::setRejoinPassword(const QString & password)
 
 void Mainapp::showCrashReport(const QString & log)
 {
+#ifndef GRAPHICSUPPORT
+    // headless: the report is already on disk and creating a QWidget under QCoreApplication aborts
+    Q_UNUSED(log);
+    return;
+#else
+    if (m_pMainapp->m_noUi)
+    {
+        // report is already on disk and no dialog is wanted without ui
+        return;
+    }
     static qint32 counter = 0;
     if (QCoreApplication::instance()->thread() == QThread::currentThread())
     {
@@ -804,6 +814,7 @@ void Mainapp::showCrashReport(const QString & log)
         m_pMainapp->m_crashMutex.lock();
         m_pMainapp->m_crashMutex.unlock();
     }
+#endif
 }
 
 void Mainapp::setRendering(bool render)


### PR DESCRIPTION
Note: the three-line Linux change is compile-verified only by inspection on my end (Windows toolchain), it's plain signal.h usage