### PR TITLE
Fix/ai slot ready hang

### DIFF
--- a/multiplayer/multiplayermenu.cpp
+++ b/multiplayer/multiplayermenu.cpp
@@ -177,6 +177,7 @@ void Multiplayermenu::init()
 
     connect(&m_GameStartTimer, &QTimer::timeout, this, &Multiplayermenu::countdown, Qt::QueuedConnection);
     connect(&m_slaveDespawnTimer, &QTimer::timeout, this, &Multiplayermenu::despawnSlave, Qt::QueuedConnection);
+    connect(m_pPlayerSelection.get(), &PlayerSelection::sigPlayerStateChanged, this, &Multiplayermenu::onPlayerStateChanged, Qt::QueuedConnection);
     startDespawnTimer();
 }
 
@@ -2540,14 +2541,29 @@ void Multiplayermenu::changeButtonText()
     Mainapp::getInstance()->continueRendering();
 }
 
+void Multiplayermenu::onPlayerStateChanged()
+{
+    // only the slave may recheck, the hosting client also reports getIsServer but must never run the countdown
+    if (Mainapp::getSlave() &&
+        !m_local &&
+        m_pNetworkInterface.get() != nullptr &&
+        m_pNetworkInterface->getIsServer())
+    {
+        // ready flags may have been backfilled on a rebound slot, recheck if the game can start
+        CONSOLE_PRINT("Checking if server game should start after player state change", GameConsole::eDEBUG);
+        startCountdown();
+    }
+}
+
 void Multiplayermenu::startCountdown()
 {
-    m_counter = 5;
     // can we start the game?
     if (getGameReady())
     {
         if (!m_GameStartTimer.isActive())
         {
+            // resetting the counter only here keeps repeated ready checks from extending a running countdown
+            m_counter = 5;
             CONSOLE_PRINT("Starting countdown", GameConsole::eDEBUG);
             sendServerReady(true);
             m_GameStartTimer.setInterval(std::chrono::seconds(1));
@@ -2560,10 +2576,8 @@ void Multiplayermenu::startCountdown()
     {
         CONSOLE_PRINT("Stopping countdown", GameConsole::eDEBUG);
         m_GameStartTimer.stop();
-        if (m_local)
-        {
-            sendServerReady(false);
-        }
+        // must also run on remote lobbies or an aborted countdown never resumes listening and the slave stays unjoinable
+        sendServerReady(false);
     }
 }
 

--- a/multiplayer/multiplayermenu.h
+++ b/multiplayer/multiplayermenu.h
@@ -145,6 +145,10 @@ protected slots:
      */
     void countdown();
     /**
+     * @brief onPlayerStateChanged
+     */
+    void onPlayerStateChanged();
+    /**
      * @brief closeSlave
      */
     void closeSlave();

--- a/objects/playerselection.cpp
+++ b/objects/playerselection.cpp
@@ -347,6 +347,7 @@ void PlayerSelection::initializeMap(bool relaunchedLobby)
     m_lockedInCaseOfDisconnect.clear();
     m_lockedAiControl.clear();
     m_playerSockets.clear();
+    m_socketReadyStates.clear();
     for (qint32 i = 0; i < m_pMap->getPlayerCount(); i++)
     {
         m_playerReadyFlags.append(false);
@@ -1241,6 +1242,8 @@ void PlayerSelection::selectAI(qint32 player, bool forced)
                 ai = type;
                 createAi(player, GameEnums::AiTypes_ProxyAi, name);
                 m_pMap->getPlayer(player)->setControlType(type);
+                // no client owns this slot yet, requestPlayer transfers it to the first joiner
+                m_playerSockets[player] = 0;
             }
             else if (Mainapp::getSlave())
             {
@@ -1561,6 +1564,7 @@ void PlayerSelection::recievePlayerReady(quint64 socketID, QDataStream &stream)
         stream >> fixed;
         stream >> value;
         CONSOLE_PRINT("PlayerSelection::recievePlayerReady for socket " + QString::number(socketID) + " is " + (value ? "ready" : "not ready"), GameConsole::eDEBUG);
+        m_socketReadyStates[socketID] = value;
         for (qint32 i = 0; i < m_playerSockets.size(); i++)
         {
             if (m_playerSockets[i] == socketID)
@@ -1607,6 +1611,18 @@ void PlayerSelection::sendPlayerReady(quint64 socketID)
             sendStream << m_playerReadyFlags[i];
         }
         emit m_pNetworkInterface.get()->sigForwardData(socketID, sendData, NetworkInterface::NetworkSerives::Multiplayer);
+    }
+}
+
+void PlayerSelection::applySocketReadyState(qint32 player, quint64 socketID)
+{
+    bool ready = m_socketReadyStates.value(socketID, false);
+    m_playerReadyFlags[player] = ready;
+    m_lockedInCaseOfDisconnect[player] = ready;
+    Checkbox *pCheckbox = getCastedObject<Checkbox>(OBJECT_READY_PREFIX + QString::number(player));
+    if (pCheckbox != nullptr)
+    {
+        pCheckbox->setChecked(ready);
     }
 }
 
@@ -1714,8 +1730,14 @@ void PlayerSelection::requestPlayer(quint64 socketID, QDataStream &stream)
                         if (pPlayer != nullptr)
                         {
                             CONSOLE_PRINT("Player is " + QString::number(i) + " is currently owned by username " + pPlayer->getPlayerNameId() + " and socket " + QString::number(pPlayer->getSocketId()), GameConsole::eDEBUG);
-                            if (pPlayer->getSocketId() == socketID ||
-                                pPlayer->getPlayerNameId() == username)
+                            // an ai slot transferred to this socket must not block its own seat request
+                            bool ownAiSlot = pPlayer->getSocketId() == socketID &&
+                                             pPlayer->getControlType() > GameEnums::AiTypes::AiTypes_Human &&
+                                             pPlayer->getControlType() != GameEnums::AiTypes::AiTypes_Open &&
+                                             pPlayer->getControlType() != GameEnums::AiTypes::AiTypes_Closed;
+                            if (!ownAiSlot &&
+                                (pPlayer->getSocketId() == socketID ||
+                                 pPlayer->getPlayerNameId() == username))
                             {
                                 alreadyInGame = true;
                                 break;
@@ -1799,6 +1821,8 @@ void PlayerSelection::remoteChangePlayerOwner(quint64 socketID, const QString &u
         {
             pPlayer->setPlayerNameId(username);
             m_playerSockets[player] = socketID;
+            // the owning client may have pressed ready before this slot was bound to its socket
+            applySocketReadyState(player, socketID);
         }
         pPlayer->setSocketId(socketID);
         if (pDropDownmenu != nullptr)
@@ -1839,6 +1863,7 @@ void PlayerSelection::remoteChangePlayerOwner(quint64 socketID, const QString &u
     emit m_pNetworkInterface->sig_sendData(socketID, sendDataRequester, NetworkInterface::NetworkSerives::Multiplayer, false);
     emit m_pNetworkInterface.get()->sigForwardData(socketID, sendDataOtherClients, NetworkInterface::NetworkSerives::Multiplayer);
     sendPlayerReady(0);
+    emit sigPlayerStateChanged();
 }
 
 bool PlayerSelection::joinAllowed(quint64 socketId, QString username, GameEnums::AiTypes eAiType)
@@ -1971,6 +1996,13 @@ void PlayerSelection::changePlayer(quint64 socketId, QDataStream &stream)
                 m_pMap->getPlayer(player)->setPlayerNameId(name);
                 m_pMap->getPlayer(player)->setControlType(originalAiType);
                 m_pMap->getPlayer(player)->setSocketId(socketId);
+                if (Mainapp::getSlave() &&
+                    m_playerSockets[player] != 0)
+                {
+                    // the owning client may have pressed ready before this slot was bound to its socket
+                    applySocketReadyState(player, m_playerSockets[player]);
+                    sendPlayerReady(0);
+                }
 
                 bool humanFound = false;
                 for (qint32 i = 0; i < m_pMap->getPlayerCount(); i++)
@@ -2011,6 +2043,7 @@ void PlayerSelection::changePlayer(quint64 socketId, QDataStream &stream)
             CONSOLE_PRINT("Update ignored", GameConsole::eDEBUG);
         }
         sendOpenPlayerCount();
+        emit sigPlayerStateChanged();
     }
     else
     {
@@ -2205,6 +2238,7 @@ void PlayerSelection::disconnected(quint64 socketID)
             auto *gameRules = m_pMap->getGameRules();
             auto &observer = gameRules->getObserverList();
             observer.removeAll(socketID);
+            m_socketReadyStates.remove(socketID);
         }
         sendOpenPlayerCount();
     }

--- a/objects/playerselection.h
+++ b/objects/playerselection.h
@@ -83,6 +83,11 @@ signals :
          * don't own a player
          */
     void sigDisconnect();
+    /**
+         * @brief sigPlayerStateChanged emitted when a player slot got bound to
+         * another owner so the server can recheck if the game can start
+         */
+    void sigPlayerStateChanged();
 public:
     /**
      * @brief getOpenPlayerCount
@@ -349,6 +354,11 @@ protected:
     void createInitialAi(DropDownmenu* pPlayerAi, qint32 ai, qint32 player);
 private:
     /**
+     * @brief applySocketReadyState applies the last ready state received from
+     * the given socket to the given player slot
+     */
+    void applySocketReadyState(qint32 player, quint64 socketID);
+    /**
      * @brief m_PlayerSockets holds which socket owns which player
      * For clients and local games this always contains 0
      * For the host this contains 0 for owned by the server or the socket id for client owned
@@ -356,6 +366,7 @@ private:
     QVector<quint64> m_playerSockets;
     QVector<bool> m_playerReadyFlags;
     QVector<bool> m_lockedInCaseOfDisconnect;
+    QMap<quint64, bool> m_socketReadyStates;
     QVector<bool> m_lockedAiControl;
 
     spNetworkInterface m_pNetworkInterface{nullptr};


### PR DESCRIPTION
The tester found a human-vs-AI dedicated lobby bug where pressing Ready does nothing and the AI stays unchecked. Basically, if you ready up before selecting the AI, the server never applies that Ready state to the AI slot or checks the countdown again.
The fix remembers each connection’s Ready state, applies it when slots change, and makes the slave recheck whether the match can start. It also fixes seat claims being dropped, aborted countdowns leaving lobbies unjoinable, and repeated checks extending an active countdown.
This was already present in 38.7. Build 39’s longer connection process just made the timing issue easier to trigger.