### PR TITLE
fix animations never finishing when a sprite resource is missing

### DIFF
--- a/game/gameanimation/gameanimation.cpp
+++ b/game/gameanimation/gameanimation.cpp
@@ -69,6 +69,10 @@ void GameAnimation::start()
         setVisible(true);
         m_previousAnimation.reset();
         doPreAnimationCall();
+        if (m_missingResource && !m_finishQueued)
+        {
+            addTweenWait(MISSING_RESOURCE_FINISH_DELAY_MS);
+        }
         AudioManager* pAudioThread = Mainapp::getInstance()->getAudioManager();
         for (auto & data : m_SoundData)
         {
@@ -237,6 +241,7 @@ void GameAnimation::addSpriteAnimTable(QString spriteID, float offsetX, float of
     else
     {
         CONSOLE_PRINT_MODULE("Unable to load animation sprite: " + spriteID, GameConsole::eDEBUG, GameConsole::eResources);
+        m_missingResource = true;
     }
 }
 
@@ -259,6 +264,7 @@ void GameAnimation::addSprite3(QString spriteID, float offsetX, float offsetY, Q
         else
         {
             CONSOLE_PRINT_MODULE("Unable to load animation sprite: " + spriteID, GameConsole::eDEBUG, GameConsole::eResources);
+            m_missingResource = true;
             return;
         }
         oxygine::spSingleResAnim pAnim = MemoryManagement::create<oxygine::SingleResAnim>();

--- a/game/gameanimation/gameanimation.h
+++ b/game/gameanimation/gameanimation.h
@@ -379,6 +379,8 @@ protected:
     virtual void update(const oxygine::UpdateState& us) override;
     void doPreAnimationCall();
 protected:
+    // an animation that lost its only sprite has no tween to finish it, so it needs a token one
+    static constexpr qint32 MISSING_RESOURCE_FINISH_DELAY_MS = 1;
     quint32 m_frameTime{1};
     bool m_stopped{false};
     bool m_finishQueued{false};
@@ -407,6 +409,7 @@ private:
     bool m_stopSoundAtAnimationEnd{false};
     bool m_global{false};
     bool m_finished{false};
+    bool m_missingResource{false};
 
     QVector<oxygine::spSingleResAnim> m_resAnims;
     /**


### PR DESCRIPTION
This fix follows from my #2010 investigation