### PR TITLE
Fix/socket keepalive and disconnect message

### DIFF
--- a/menue/gamemenue.cpp
+++ b/menue/gamemenue.cpp
@@ -1306,7 +1306,7 @@ void GameMenue::disconnected(quint64 socketID)
                 {
                     CONSOLE_PRINT("Connection to host lost", GameConsole::eDEBUG);
                     m_gameStarted = false;
-                    spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("The host has disconnected from the game! The game will now be stopped. You can save the game and reload the game to continue playing this map."));
+                    spDialogMessageBox pDialogMessageBox = MemoryManagement::create<DialogMessageBox>(tr("The connection to the host was lost. The game will now be stopped. You can save the game and reload the game to continue playing this map."));
                     addChild(pDialogMessageBox);
                 }
             }


### PR DESCRIPTION
I added TCP keep alive. Enables SO_KEEPALIVE on the outgoing client socket and on each accepted server
socket. As far as the timings go, well, I just put what sounds reasonable but if you think the timing should be different, it can be easily adjusted.