### PR TITLE
Fix walk animations finishing before start when the unit sprite is missing.

### DIFF
--- a/game/gameanimation/gameanimation.h
+++ b/game/gameanimation/gameanimation.h
@@ -387,6 +387,7 @@ protected:
     bool m_started{false};
     bool m_startEmitted{false};
     bool m_skipping{false};
+    bool m_missingResource{false};
     spGameAnimation m_previousAnimation{nullptr};
     struct SoundData
     {
@@ -409,7 +410,6 @@ private:
     bool m_stopSoundAtAnimationEnd{false};
     bool m_global{false};
     bool m_finished{false};
-    bool m_missingResource{false};
 
     QVector<oxygine::spSingleResAnim> m_resAnims;
     /**

--- a/game/gameanimation/gameanimationwalk.cpp
+++ b/game/gameanimation/gameanimationwalk.cpp
@@ -247,6 +247,6 @@ void GameAnimationWalk::loadSpriteV2(const QString spriteID, GameEnums::Recolori
     else
     {
         CONSOLE_PRINT_MODULE("Unable to load unit walk sprite: " + spriteID, GameConsole::eDEBUG, GameConsole::eResources);
-        emitFinished();
+        m_missingResource = true;
     }
 }


### PR DESCRIPTION
I checked the other emitFinished() call sites in the animation classes and they run fine during testing headless runs