### PR TITLE
Issue #2041: Add Launch action to Aircraft Carriers

### DIFF
--- a/mods/awdc_unit/scripts/actions/ACTION_UNLOAD_LAUNCH.js
+++ b/mods/awdc_unit/scripts/actions/ACTION_UNLOAD_LAUNCH.js
@@ -1,0 +1,307 @@
+var Constructor = function()
+{
+    this.canBePerformed = function(action, map)
+    {
+        var unit = action.getTargetUnit();
+        var actionTargetField = action.getActionTarget();
+        var targetField = action.getTarget();
+        var transportTerrain = map.getTerrain(actionTargetField.x, actionTargetField.y);
+        if (ACTION_UNLOAD.isUnloadTerrain(unit, transportTerrain, map) &&
+            ACTION.isEmptyFieldAndHasNotMoved(action, unit, actionTargetField, targetField, map) &&
+            (actionTargetField.x == targetField.x && actionTargetField.y == targetField.y))
+        {
+            var size = unit.getLoadedUnitCount();
+            for (var i = 0; i < size; i++)
+            {
+                if (ACTION_UNLOAD_LAUNCH.getUnloadFields(action, i, map).length > 0)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    this.getUnloadFields = function(action, transportUnitIdx, map)
+    {
+        var targetField = action.getActionTarget();
+        var targetFields = [Qt.point(targetField.x + 1, targetField.y),
+                            Qt.point(targetField.x - 1, targetField.y),
+                            Qt.point(targetField.x,     targetField.y - 1),
+                            Qt.point(targetField.x,     targetField.y + 1)];
+        var unit = action.getTargetUnit();
+        var targetTerrain = map.getTerrain(targetField.x, targetField.y);
+        var transportUnit = unit.getLoadedUnit(transportUnitIdx);
+        var ret = [];
+        if (!transportUnit.getHasMoved()){
+            // can both units move over the current terrain?
+            var moveType = Global[transportUnit.getMovementType()];
+            if (ACTION_UNLOAD.isUnloadTerrain(unit, targetTerrain) &&
+                (moveType.getMovementpoints(targetTerrain, transportUnit, targetTerrain, false, map) > 0))
+            {
+                // check all neighbour terrains
+                for (var i = 0; i < targetFields.length; i++)
+                {
+                    if (map.onMap(targetFields[i].x, targetFields[i].y))
+                    {
+                        var terrain = map.getTerrain(targetFields[i].x, targetFields[i].y);
+                        var defUnit = terrain.getUnit();
+                        // can the transported unit move over the terrain?
+                        if ((Global[transportUnit.getMovementType()].getMovementpoints(terrain, transportUnit, targetTerrain, false, map) > 0) &&
+                            (defUnit === null ||
+                            defUnit.isStealthed(unit.getOwner()) ||
+                            (((defUnit !== null) && (defUnit === unit)))))
+                        {
+                            ret.push(targetFields[i]);
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    };
+
+    this.getActionText = function(map)
+    {
+        return qsTr("Launch");
+    };
+    this.getIcon = function(map)
+    {
+        return "load";
+    };
+    this.isFinalStep = function(action, map)
+    {
+        // check if the final step was a wait command
+        var step = action.getInputStep();
+        if (!globals.isEven(step))
+        {
+            action.startReading();
+            for (var i = 0; i < step; i += 2)
+            {
+                var dataString = action.readDataString();
+                if (i === step - 1)
+                {
+                    if (dataString === "ACTION_WAIT")
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    action.readDataInt32();
+                    action.readDataInt32();
+                }
+            }
+        }
+        else
+        {
+            var unloadableUnits = ACTION_UNLOAD_LAUNCH.getUnloadableUnits(action, map);
+            if (unloadableUnits.length === 0)
+            {
+                action.writeDataString("ACTION_WAIT");
+                action.setInputStep(action.getInputStep() + 1);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    this.getStepInputType = function(action, map)
+    {
+        // supported types are MENU and FIELD
+        if (globals.isEven(action.getInputStep()))
+        {
+            // only one unit can be unloaded?
+            var unitIndexes = [];
+            var blockedFields = [];
+            ACTION_UNLOAD.getUsedUnitsAndFields(action, unitIndexes, blockedFields);
+            var unloadableUnits = ACTION_UNLOAD_LAUNCH.getUnloadableUnits(action, map);
+            if (unitIndexes.length === 0 && unloadableUnits.length === 1)
+            {
+                // skip selecting a unit when only one can be unloaded
+                action.writeDataString(unloadableUnits[0]);
+                action.setInputStep(action.getInputStep() + 1);
+                return "FIELD";
+            }
+            else
+            {
+                return "MENU";
+            }
+        }
+        else
+        {
+            return "FIELD";
+        }
+    };
+
+    this.getUnloadableUnits = function(action, map)
+    {
+        var ret = [];
+        var unitIndexes = [];
+        var blockedFields = [];
+        ACTION_UNLOAD.getUsedUnitsAndFields(action, unitIndexes, blockedFields);
+        var unit = action.getTargetUnit();
+        var fields = null;
+        var i3 = 0;
+        var i4 = 0;
+        var found = false;
+        var size = unit.getLoadedUnitCount();
+        for (var i = 0; i < size; i++)
+        {
+            if (unitIndexes.indexOf(i) < 0)
+            {
+                fields = ACTION_UNLOAD_LAUNCH.getUnloadFields(action, i, map);
+                for (i3 = 0; i3 < fields.length; i3++)
+                {
+                    found = false;
+                    for (i4 = 0; i4 < blockedFields.length; i4++)
+                    {
+                        if (blockedFields[i4] === fields[i3])
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (found === false)
+                    {
+                        var transportUnit = unit.getLoadedUnit(i);
+                        ret.push(i.toString());
+                        break;
+                    }
+                }
+            }
+        }
+        return ret;
+    };
+
+    this.getStepData = function(action, data, map)
+    {
+        var step = action.getInputStep();
+
+        var unitIndexes = [];
+        var blockedFields = [];
+        ACTION_UNLOAD.getUsedUnitsAndFields(action, unitIndexes, blockedFields);
+
+        var fields = null;
+        var i3 = 0;
+        var i4 = 0;
+        var found = false;
+        if (globals.isEven(action.getInputStep()))
+        {
+            var unit = action.getTargetUnit();
+            var size = unit.getLoadedUnitCount();
+            for (var i = 0; i < size; i++)
+            {
+                if (unitIndexes.indexOf(i) < 0)
+                {
+                    fields = ACTION_UNLOAD_LAUNCH.getUnloadFields(action, i, map);
+                    for (i3 = 0; i3 < fields.length; i3++)
+                    {
+                        found = false;
+                        for (i4 = 0; i4 < blockedFields.length; i4++)
+                        {
+                            if (blockedFields[i4] === fields[i3])
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (found === false)
+                        {
+                            var transportUnit = unit.getLoadedUnit(i);
+                            data.addUnitData(Global[transportUnit.getUnitID()].getName(), i.toString(), transportUnit);
+                            break;
+                        }
+                    }
+                }
+            }
+            data.addData(qsTr("Wait"), "ACTION_WAIT", "wait");
+        }
+        else
+        {
+            // find out which unit we want to unload
+            fields = ACTION_UNLOAD_LAUNCH.getUnloadFields(action, unitIndexes[unitIndexes.length - 1], map);
+            for (i3 = 0; i3 < fields.length; i3++)
+            {
+                found = false;
+                for (i4 = 0; i4 < blockedFields.length; i4++)
+                {
+                    if (blockedFields[i4] === fields[i3])
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (found === false)
+                {
+                    data.addPoint(fields[i3]);
+                }
+            }
+            data.setColor("#0000FF");
+        }
+    };
+
+    this.postAnimationUnit = null;
+    this.postAnimationTransportUnits = [];
+    this.postAnimationTransportUnitsPosX = [];
+    this.postAnimationTransportUnitsPosY = [];
+    this.perform = function(action, map)
+    {
+        // we need to move the unit to the target position
+        ACTION_UNLOAD_LAUNCH.postAnimationUnit = action.getTargetUnit();
+        var animation = Global[ACTION_UNLOAD_LAUNCH.postAnimationUnit.getUnitID()].doWalkingAnimation(action, map);
+        animation.setEndOfAnimationCall("ACTION_UNLOAD_LAUNCH", "performPostAnimation");
+        // move unit to target position
+        ACTION_UNLOAD_LAUNCH.postAnimationUnit.moveUnitAction(action);
+        action.startReading();
+        var step = action.getInputStep();
+        for (var i = 0; i < step; i += 2)
+        {
+            var dataString = action.readDataString();
+            if (i === step - 1)
+            {
+            }
+            else
+            {
+                var x = action.readDataInt32();
+                var y = action.readDataInt32();
+                ACTION_UNLOAD_LAUNCH.postAnimationTransportUnits.push(ACTION_UNLOAD_LAUNCH.postAnimationUnit.getLoadedUnit(parseInt(dataString)));
+                ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosX.push(x);
+                ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosY.push(y);
+            }
+        }
+    };
+    this.performPostAnimation = function(postAnimation, map)
+    {
+        // unloading the units here :)
+        for (var i = 0; i < ACTION_UNLOAD_LAUNCH.postAnimationTransportUnits.length; i++)
+        {
+            // check if the field is empty before unloading
+            if (map.getTerrain(ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosX[i],
+                           ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosY[i]).getUnit() === null)
+            {
+                var transportUnit = ACTION_UNLOAD_LAUNCH.postAnimationTransportUnits[i];
+                transportUnit.addMovementBonus(-1, 1);
+                ACTION_UNLOAD_LAUNCH.postAnimationUnit.unloadUnit(transportUnit,
+                                                           Qt.point(ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosX[i],
+                                                                    ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosY[i]));
+            }
+        }
+        audio.playSound("unload.wav");
+        ACTION_UNLOAD_LAUNCH.postAnimationUnit = null;
+        ACTION_UNLOAD_LAUNCH.postAnimationTransportUnits = [];
+        ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosX = [];
+        ACTION_UNLOAD_LAUNCH.postAnimationTransportUnitsPosY = [];
+    };
+    this.getName = function()
+    {
+        return qsTr("Launch");
+    };
+    this.getDescription = function()
+    {
+        return qsTr("Unloads any loaded units from previous turns, allowing the unloaded units to act but with -1 move. Launches must be performed in place. Launches do not use up the launching unit's turn.");
+    };
+}
+
+Constructor.prototype = ACTION;
+var ACTION_UNLOAD_LAUNCH = new Constructor();

--- a/mods/awdc_unit/scripts/units/aircraftcarrier.js
+++ b/mods/awdc_unit/scripts/units/aircraftcarrier.js
@@ -20,3 +20,16 @@ AIRCRAFTCARRIER.getBaseCost = function()
 {
     return 28000;
 };
+
+AIRCRAFTCARRIER.startOfTurnOldAWDCUnit = AIRCRAFTCARRIER.startOfTurn;
+AIRCRAFTCARRIER.startOfTurn = function (unit, map) {
+    AIRCRAFTCARRIER.startOfTurnOldAWDCUnit(unit, map);
+    var size = unit.getLoadedUnitCount();
+    for (var i = 0; i < size; i++)
+    {
+        var transportUnit = unit.getLoadedUnit(i);
+        transportUnit.setHasMoved(false);
+    }
+}
+
+AIRCRAFTCARRIER.actionList = ["ACTION_FIRE", "ACTION_JOIN", "ACTION_LOAD", "ACTION_UNLOAD_LAUNCH", "ACTION_BUILD_WATERPLANE", "ACTION_WAIT", "ACTION_CO_UNIT_0", "ACTION_CO_UNIT_1"];


### PR DESCRIPTION
An implementation of #2041.
I put the launch action into the AWDC unit mod.
The carrier can now launch units loaded from prior turns. The action can only be done without moving, but doesn't take up the carrier's turn. Newly launched units have -1 movement to mimic starting from the carrier's tile.